### PR TITLE
Add missing race data files

### DIFF
--- a/data/races/humanstandard.json
+++ b/data/races/humanstandard.json
@@ -1,0 +1,64 @@
+{
+	"name": "Human (Standard)",
+	"source": "PHB",
+	"page": 31,
+	"size": [
+		"M"
+	],
+	"speed": 30,
+	"ability": [
+		{
+			"str": 1,
+			"dex": 1,
+			"con": 1,
+			"int": 1,
+			"wis": 1,
+			"cha": 1
+		}
+	],
+	"heightAndWeight": {
+		"baseHeight": 56,
+		"heightMod": "2d10",
+		"baseWeight": 110,
+		"weightMod": "2d4"
+	},
+	"age": {
+		"mature": 18,
+		"max": 80
+	},
+	"languageProficiencies": [
+		{
+			"common": true,
+			"anyStandard": 1
+		}
+	],
+	"entries": [
+		{
+			"name": "Age",
+			"type": "entries",
+			"entries": [
+				"Humans reach adulthood in their late teens and rarely live longer than a century."
+			]
+		},
+		{
+			"type": "entries",
+			"name": "Size",
+			"entries": [
+				"Humans vary widely in height and build, standing between 5 and over 6 feet tall. Your size is Medium."
+			]
+		},
+		{
+			"name": "Languages",
+			"type": "entries",
+			"entries": [
+				"You can speak, read, and write Common and one extra language of your choice."
+			]
+		}
+	],
+	"raceName": "Human",
+	"raceSource": "PHB",
+	"srd": true,
+	"basicRules": true,
+	"hasFluff": true,
+	"hasFluffImages": true
+}

--- a/data/races/humanvariant.json
+++ b/data/races/humanvariant.json
@@ -1,0 +1,79 @@
+{
+	"name": "Human (Variant)",
+	"source": "PHB",
+	"page": 31,
+	"size": [
+		"M"
+	],
+	"speed": 30,
+	"ability": [
+		{
+			"choose": {
+				"from": [
+					"str",
+					"dex",
+					"con",
+					"int",
+					"wis",
+					"cha"
+				],
+				"count": 2
+			}
+		}
+	],
+	"heightAndWeight": {
+		"baseHeight": 56,
+		"heightMod": "2d10",
+		"baseWeight": 110,
+		"weightMod": "2d4"
+	},
+	"age": {
+		"mature": 18,
+		"max": 80
+	},
+	"skillProficiencies": [
+		{
+			"any": 1
+		}
+	],
+	"languageProficiencies": [
+		{
+			"common": true,
+			"anyStandard": 1
+		}
+	],
+	"entries": [
+		{
+			"name": "Age",
+			"type": "entries",
+			"entries": [
+				"Humans reach adulthood in their late teens and rarely live longer than a century."
+			]
+		},
+		{
+			"type": "entries",
+			"name": "Size",
+			"entries": [
+				"Humans vary widely in height and build. Your size is Medium."
+			]
+		},
+		{
+			"name": "Feat",
+			"type": "entries",
+			"entries": [
+				"You gain one feat of your choice."
+			]
+		},
+		{
+			"name": "Languages",
+			"type": "entries",
+			"entries": [
+				"You can speak, read, and write Common and one extra language of your choice."
+			]
+		}
+	],
+	"raceName": "Human",
+	"raceSource": "PHB",
+	"hasFluff": true,
+	"hasFluffImages": true
+}

--- a/data/races/kalashtar.json
+++ b/data/races/kalashtar.json
@@ -1,0 +1,73 @@
+{
+	"name": "Kalashtar",
+	"source": "ERLW",
+	"page": 29,
+	"size": [
+		"M"
+	],
+	"speed": 30,
+	"ability": [
+		{
+			"wis": 2,
+			"cha": 1
+		}
+	],
+	"heightAndWeight": {
+		"baseHeight": 56,
+		"heightMod": "2d10",
+		"baseWeight": 110,
+		"weightMod": "2d4"
+	},
+	"age": {
+		"mature": 20,
+		"max": 80
+	},
+	"languageProficiencies": [
+		{
+			"common": true,
+			"quori": true,
+			"anyStandard": 1
+		}
+	],
+	"entries": [
+		{
+			"name": "Dual Mind",
+			"type": "entries",
+			"entries": [
+				"You have advantage on all Wisdom saving throws."
+			]
+		},
+		{
+			"name": "Mental Discipline",
+			"type": "entries",
+			"entries": [
+				"You have resistance to psychic damage."
+			]
+		},
+		{
+			"name": "Mind Link",
+			"type": "entries",
+			"entries": [
+				"You can telepathically speak to any creature you can see within 60 feet."
+			]
+		},
+		{
+			"name": "Severed from Dreams",
+			"type": "entries",
+			"entries": [
+				"Kalashtar can't be put to sleep by magical means."
+			]
+		},
+		{
+			"name": "Languages",
+			"type": "entries",
+			"entries": [
+				"You can speak, read, and write Common, Quori, and one extra language of your choice."
+			]
+		}
+	],
+	"raceName": "Kalashtar",
+	"raceSource": "ERLW",
+	"hasFluff": true,
+	"hasFluffImages": true
+}

--- a/data/races/kender.json
+++ b/data/races/kender.json
@@ -1,0 +1,65 @@
+{
+	"name": "Kender",
+	"source": "DLSotDQ",
+	"page": 18,
+	"size": [
+		"S"
+	],
+	"speed": 30,
+	"ability": [
+		{
+			"cha": 2,
+			"dex": 1
+		}
+	],
+	"heightAndWeight": {
+		"baseHeight": 42,
+		"heightMod": "2d4",
+		"baseWeight": 55,
+		"weightMod": "1d4"
+	},
+	"age": {
+		"mature": 20,
+		"max": 100
+	},
+	"languageProficiencies": [
+		{
+			"common": true,
+			"kenderspeak": true
+		}
+	],
+	"entries": [
+		{
+			"name": "Fearless",
+			"type": "entries",
+			"entries": [
+				"You have advantage on saving throws against being frightened."
+			]
+		},
+		{
+			"name": "Kender Ace",
+			"type": "entries",
+			"entries": [
+				"As a bonus action, you can pull an item from your pouches. The object disappears after 1 hour."
+			]
+		},
+		{
+			"name": "Taunt",
+			"type": "entries",
+			"entries": [
+				"As a bonus action, you can unleash a barrage of insults at a creature within 60 feet, imposing disadvantage on attack rolls against others."
+			]
+		},
+		{
+			"name": "Languages",
+			"type": "entries",
+			"entries": [
+				"You can speak, read, and write Common and Kenderspeak."
+			]
+		}
+	],
+	"raceName": "Kender",
+	"raceSource": "DLSotDQ",
+	"hasFluff": true,
+	"hasFluffImages": true
+}

--- a/data/races/kenku.json
+++ b/data/races/kenku.json
@@ -1,0 +1,65 @@
+{
+	"name": "Kenku",
+	"source": "MPMM",
+	"page": 20,
+	"size": [
+		"M"
+	],
+	"speed": 30,
+	"ability": [
+		{
+			"dex": 2,
+			"wis": 1
+		}
+	],
+	"heightAndWeight": {
+		"baseHeight": 60,
+		"heightMod": "2d8",
+		"baseWeight": 90,
+		"weightMod": "2d4"
+	},
+	"age": {
+		"mature": 12,
+		"max": 60
+	},
+	"languageProficiencies": [
+		{
+			"common": true,
+			"auran": true
+		}
+	],
+	"entries": [
+		{
+			"name": "Expert Forgery",
+			"type": "entries",
+			"entries": [
+				"You can duplicate other creatures' handwriting and craftwork."
+			]
+		},
+		{
+			"name": "Kenku Training",
+			"type": "entries",
+			"entries": [
+				"You gain proficiency in two skills of your choice from Acrobatics, Deception, Stealth, or Sleight of Hand."
+			]
+		},
+		{
+			"name": "Mimicry",
+			"type": "entries",
+			"entries": [
+				"You can mimic any sounds you have heard."
+			]
+		},
+		{
+			"name": "Languages",
+			"type": "entries",
+			"entries": [
+				"You can read and write Common and Auran but speak only by mimicking sounds you have heard."
+			]
+		}
+	],
+	"raceName": "Kenku",
+	"raceSource": "MPMM",
+	"hasFluff": true,
+	"hasFluffImages": true
+}

--- a/data/races/kobold.json
+++ b/data/races/kobold.json
@@ -1,0 +1,73 @@
+{
+	"name": "Kobold",
+	"source": "MPMM",
+	"page": 21,
+	"size": [
+		"S"
+	],
+	"speed": 30,
+	"ability": [
+		{
+			"dex": 2,
+			"con": 1
+		}
+	],
+	"heightAndWeight": {
+		"baseHeight": 30,
+		"heightMod": "2d4",
+		"baseWeight": 25,
+		"weightMod": "1d4"
+	},
+	"age": {
+		"mature": 6,
+		"max": 120
+	},
+	"darkvision": 60,
+	"languageProficiencies": [
+		{
+			"common": true,
+			"draconic": true
+		}
+	],
+	"entries": [
+		{
+			"name": "Darkvision",
+			"type": "entries",
+			"entries": [
+				"You can see in dim light within 60 feet of you as if it were bright light."
+			]
+		},
+		{
+			"name": "Grovel, Cower, and Beg",
+			"type": "entries",
+			"entries": [
+				"As an action, you can distract foes, giving your allies advantage on attacks against enemies within 10 feet of you."
+			]
+		},
+		{
+			"name": "Pack Tactics",
+			"type": "entries",
+			"entries": [
+				"You have advantage on attack rolls against a creature if at least one of your allies is within 5 feet of the creature."
+			]
+		},
+		{
+			"name": "Sunlight Sensitivity",
+			"type": "entries",
+			"entries": [
+				"You have disadvantage on attack rolls and on Wisdom (Perception) checks that rely on sight when you, the target, or whatever you are trying to perceive is in direct sunlight."
+			]
+		},
+		{
+			"name": "Languages",
+			"type": "entries",
+			"entries": [
+				"You can speak, read, and write Common and Draconic."
+			]
+		}
+	],
+	"raceName": "Kobold",
+	"raceSource": "MPMM",
+	"hasFluff": true,
+	"hasFluffImages": true
+}

--- a/data/races/leonin.json
+++ b/data/races/leonin.json
@@ -1,0 +1,65 @@
+{
+	"name": "Leonin",
+	"source": "MOoT",
+	"page": 20,
+	"size": [
+		"M"
+	],
+	"speed": 35,
+	"ability": [
+		{
+			"con": 2,
+			"str": 1
+		}
+	],
+	"heightAndWeight": {
+		"baseHeight": 72,
+		"heightMod": "2d10",
+		"baseWeight": 200,
+		"weightMod": "2d6"
+	},
+	"age": {
+		"mature": 18,
+		"max": 100
+	},
+	"languageProficiencies": [
+		{
+			"common": true,
+			"leonin": true
+		}
+	],
+	"entries": [
+		{
+			"name": "Claws",
+			"type": "entries",
+			"entries": [
+				"Your claws are natural weapons, dealing 1d4 slashing damage."
+			]
+		},
+		{
+			"name": "Daunting Roar",
+			"type": "entries",
+			"entries": [
+				"As a bonus action, you let out a menacing roar. Creatures within 10 feet that can hear you must succeed on a Wisdom saving throw or become frightened until the end of your next turn."
+			]
+		},
+		{
+			"name": "Hunter's Instincts",
+			"type": "entries",
+			"entries": [
+				"You gain proficiency in one of the following skills of your choice: Athletics, Intimidation, Perception, Stealth, or Survival."
+			]
+		},
+		{
+			"name": "Languages",
+			"type": "entries",
+			"entries": [
+				"You can speak, read, and write Common and Leonin."
+			]
+		}
+	],
+	"raceName": "Leonin",
+	"raceSource": "MOoT",
+	"hasFluff": true,
+	"hasFluffImages": true
+}

--- a/data/races/lizardfolk.json
+++ b/data/races/lizardfolk.json
@@ -1,0 +1,89 @@
+{
+	"name": "Lizardfolk",
+	"source": "MPMM",
+	"page": 22,
+	"size": [
+		"M"
+	],
+	"speed": {
+		"walk": 30,
+		"swim": 30
+	},
+	"ability": [
+		{
+			"con": 2,
+			"wis": 1
+		}
+	],
+	"heightAndWeight": {
+		"baseHeight": 60,
+		"heightMod": "2d10",
+		"baseWeight": 120,
+		"weightMod": "2d6"
+	},
+	"age": {
+		"mature": 14,
+		"max": 60
+	},
+	"languageProficiencies": [
+		{
+			"common": true,
+			"draconic": true
+		}
+	],
+	"entries": [
+		{
+			"name": "Bite",
+			"type": "entries",
+			"entries": [
+				"Your fanged maw is a natural weapon that deals 1d6 piercing damage."
+			]
+		},
+		{
+			"name": "Cunning Artisan",
+			"type": "entries",
+			"entries": [
+				"As part of a short rest, you can harvest bone and hide from a slain creature to craft items."
+			]
+		},
+		{
+			"name": "Hold Breath",
+			"type": "entries",
+			"entries": [
+				"You can hold your breath for up to 15 minutes."
+			]
+		},
+		{
+			"name": "Hunter's Lore",
+			"type": "entries",
+			"entries": [
+				"You gain proficiency in two skills of your choice from Animal Handling, Nature, Perception, Stealth, and Survival."
+			]
+		},
+		{
+			"name": "Natural Armor",
+			"type": "entries",
+			"entries": [
+				"You have tough, scaly skin. When you aren't wearing armor, your AC is 13 plus your Dexterity modifier."
+			]
+		},
+		{
+			"name": "Hungry Jaws",
+			"type": "entries",
+			"entries": [
+				"As a bonus action, you can make a special attack with your bite. If it hits, you gain temporary hit points equal to your proficiency bonus."
+			]
+		},
+		{
+			"name": "Languages",
+			"type": "entries",
+			"entries": [
+				"You can speak, read, and write Common and Draconic."
+			]
+		}
+	],
+	"raceName": "Lizardfolk",
+	"raceSource": "MPMM",
+	"hasFluff": true,
+	"hasFluffImages": true
+}

--- a/data/races/locathah.json
+++ b/data/races/locathah.json
@@ -1,0 +1,75 @@
+{
+	"name": "Locathah",
+	"source": "LR",
+	"page": 5,
+	"size": [
+		"M"
+	],
+	"speed": {
+		"walk": 30,
+		"swim": 30
+	},
+	"ability": [
+		{
+			"con": 2,
+			"dex": 1
+		}
+	],
+	"heightAndWeight": {
+		"baseHeight": 55,
+		"heightMod": "2d8",
+		"baseWeight": 100,
+		"weightMod": "2d6"
+	},
+	"age": {
+		"mature": 10,
+		"max": 80
+	},
+	"languageProficiencies": [
+		{
+			"common": true,
+			"aquan": true
+		}
+	],
+	"entries": [
+		{
+			"name": "Limited Amphibiousness",
+			"type": "entries",
+			"entries": [
+				"You can breathe air for up to 1 hour, after which you begin to suffocate."
+			]
+		},
+		{
+			"name": "Natural Armor",
+			"type": "entries",
+			"entries": [
+				"When you aren't wearing armor, your AC is 12 plus your Dexterity modifier."
+			]
+		},
+		{
+			"name": "Leviathan Will",
+			"type": "entries",
+			"entries": [
+				"You have advantage on saving throws against being frightened, charmed, paralyzed, poisoned, stunned, or put to sleep."
+			]
+		},
+		{
+			"name": "Observant & Athletic",
+			"type": "entries",
+			"entries": [
+				"You have proficiency in the Athletics and Perception skills."
+			]
+		},
+		{
+			"name": "Languages",
+			"type": "entries",
+			"entries": [
+				"You can speak, read, and write Common and Aquan."
+			]
+		}
+	],
+	"raceName": "Locathah",
+	"raceSource": "LR",
+	"hasFluff": true,
+	"hasFluffImages": true
+}

--- a/data/races/loxodon.json
+++ b/data/races/loxodon.json
@@ -1,0 +1,79 @@
+{
+	"name": "Loxodon",
+	"source": "GGR",
+	"page": 18,
+	"size": [
+		"M"
+	],
+	"speed": 30,
+	"ability": [
+		{
+			"con": 2,
+			"wis": 1
+		}
+	],
+	"heightAndWeight": {
+		"baseHeight": 84,
+		"heightMod": "2d10",
+		"baseWeight": 300,
+		"weightMod": "2d6"
+	},
+	"age": {
+		"mature": 60,
+		"max": 450
+	},
+	"languageProficiencies": [
+		{
+			"common": true,
+			"loxodon": true
+		}
+	],
+	"entries": [
+		{
+			"name": "Powerful Build",
+			"type": "entries",
+			"entries": [
+				"You count as one size larger when determining your carrying capacity and the weight you can push, drag, or lift."
+			]
+		},
+		{
+			"name": "Loxodon Serenity",
+			"type": "entries",
+			"entries": [
+				"You have advantage on saving throws against being charmed or frightened."
+			]
+		},
+		{
+			"name": "Natural Armor",
+			"type": "entries",
+			"entries": [
+				"When you aren't wearing armor, your AC is 12 plus your Constitution modifier."
+			]
+		},
+		{
+			"name": "Trunk",
+			"type": "entries",
+			"entries": [
+				"You can grasp things with your trunk, and it has a reach of 5 feet."
+			]
+		},
+		{
+			"name": "Keen Smell",
+			"type": "entries",
+			"entries": [
+				"You have advantage on Wisdom (Perception), Wisdom (Survival), and Intelligence (Investigation) checks that rely on smell."
+			]
+		},
+		{
+			"name": "Languages",
+			"type": "entries",
+			"entries": [
+				"You can speak, read, and write Common and Loxodon."
+			]
+		}
+	],
+	"raceName": "Loxodon",
+	"raceSource": "GGR",
+	"hasFluff": true,
+	"hasFluffImages": true
+}


### PR DESCRIPTION
## Summary
- add JSON data for missing races such as Human, Kalashtar, Kenku, and more
- include ability modifiers, traits, and language info
- verify race selection loads entries for new files

## Testing
- `node - <<'NODE'
const fs = require('fs');
const races = JSON.parse(fs.readFileSync('data/races.json','utf8')).races;
const newRaces = ['Human (Standard)','Human (Variant)','Kalashtar','Kender','Kenku','Kobold','Leonin','Lizardfolk','Locathah','Loxodon'];
newRaces.forEach(name => {
  const path = races[name];
  const data = JSON.parse(fs.readFileSync(path,'utf8'));
  console.log(name, 'traits', data.entries.length);
});
NODE`


------
https://chatgpt.com/codex/tasks/task_e_68a362b8a268832eb80b688c14e660ec