### PR TITLE
Add Artificer class and subclasses

### DIFF
--- a/data/classes.json
+++ b/data/classes.json
@@ -1,5 +1,6 @@
 {
     "classes": {
+        "Artificer": "data/classes/artificer.json",
         "Barbarian": "data/classes/barbarian.json",
         "Bard": "data/classes/bard.json",
         "Cleric": "data/classes/cleric.json",

--- a/data/classes/artificer.json
+++ b/data/classes/artificer.json
@@ -1,0 +1,111 @@
+{
+  "name": "Artificer",
+  "description": "Masters of invention, artificers use ingenuity to channel arcane power into wondrous items.",
+  "features_by_level": {
+    "1": [
+      { "name": "Optional Rule: Firearm Proficiency", "description": "If your campaign uses firearms and you have been trained with them, you are proficient with firearms." },
+      { "name": "Magical Tinkering", "description": "Using thieves' or artisan's tools, you can invest a Tiny nonmagical object with a magical property such as light, a recorded message, an odor or sound, or a static visual effect. You can affect a number of objects up to your Intelligence modifier, replacing older effects when you exceed this limit." },
+      { "name": "Spellcasting", "description": "You know two artificer cantrips. You prepare a number of artificer spells equal to your Intelligence modifier plus half your artificer level (minimum one). You cast artificer spells using Intelligence and must have thieves' tools or artisan's tools in hand as a spellcasting focus. You can cast prepared artificer spells as rituals if they have the ritual tag." }
+    ],
+    "2": [
+      { "name": "Infuse Item", "description": "You learn how to imbue mundane items with infusions. You learn four artificer infusions and can infuse items at the end of a long rest, up to the number shown in the Infused Items column. An infusion can exist in only one object at a time and ends if you exceed your limit or replace it." }
+    ],
+    "3": [
+      { "name": "Artificer Specialist", "description": "You choose a specialization such as Alchemist, Armorer, Artillerist, or Battle Smith, gaining its features at 3rd, 5th, 9th, and 15th levels." },
+      { "name": "The Right Tool for the Job", "description": "With one hour of work using thieves' or artisan's tools, you can create one set of artisan's tools. The tools are nonmagical and disappear when you create another set." }
+    ],
+    "4": [
+      { "name": "Ability Score Improvement", "description": "Increase one ability score by 2 or two scores by 1. You may instead take a feat if your campaign uses them." }
+    ],
+    "5": [
+      { "name": "Artificer Specialist Feature", "description": "You gain a feature from your chosen Artificer Specialist." }
+    ],
+    "6": [
+      { "name": "Tool Expertise", "description": "Your proficiency bonus is doubled for any ability check that uses a tool with which you are proficient." }
+    ],
+    "7": [
+      { "name": "Flash of Genius", "description": "When you or a creature within 30 feet makes an ability check or saving throw, you can use your reaction to add your Intelligence modifier to the roll. Uses equal to your Intelligence modifier per long rest." }
+    ],
+    "8": [
+      { "name": "Ability Score Improvement", "description": "Increase one ability score by 2 or two scores by 1. You may instead take a feat if allowed." }
+    ],
+    "9": [
+      { "name": "Artificer Specialist Feature", "description": "You gain a feature from your chosen Artificer Specialist." }
+    ],
+    "10": [
+      { "name": "Magic Item Adept", "description": "You can attune up to four magic items at once. Crafting a common or uncommon magic item takes a quarter of the normal time and half the cost." }
+    ],
+    "11": [
+      { "name": "Spell-Storing Item", "description": "You can store a 1st- or 2nd-level artificer spell that takes one action to cast in a weapon or focus. A creature holding the item can use an action to produce the spell, up to twice your Intelligence modifier uses." }
+    ],
+    "12": [
+      { "name": "Ability Score Improvement", "description": "Increase one ability score by 2 or two scores by 1. You may instead take a feat if allowed." }
+    ],
+    "14": [
+      { "name": "Magic Item Savant", "description": "You can attune to up to five magic items and ignore class, race, spell, and level requirements on attuning to or using magic items." }
+    ],
+    "15": [
+      { "name": "Artificer Specialist Feature", "description": "You gain a feature from your chosen Artificer Specialist." }
+    ],
+    "16": [
+      { "name": "Ability Score Improvement", "description": "Increase one ability score by 2 or two scores by 1. You may instead take a feat if allowed." }
+    ],
+    "18": [
+      { "name": "Magic Item Master", "description": "You can attune to up to six magic items at once." }
+    ],
+    "19": [
+      { "name": "Ability Score Improvement", "description": "Increase one ability score by 2 or two scores by 1. You may instead take a feat if allowed." }
+    ],
+    "20": [
+      { "name": "Soul of Artifice", "description": "You gain a +1 bonus to all saving throws for each magic item you are attuned to. If you would be reduced to 0 hit points, you can use your reaction to end one of your infusions, dropping to 1 hit point instead." }
+    ]
+  },
+  "subclasses": [
+    {
+      "name": "Alchemist",
+      "features": [
+        "Tool Proficiency",
+        "Alchemist Spells",
+        "Experimental Elixir",
+        "Alchemical Savant",
+        "Restorative Reagents",
+        "Chemical Mastery"
+      ]
+    },
+    {
+      "name": "Armorer",
+      "features": [
+        "Tools of the Trade",
+        "Armorer Spells",
+        "Arcane Armor",
+        "Armor Model",
+        "Extra Attack",
+        "Armor Modifications",
+        "Perfected Armor"
+      ]
+    },
+    {
+      "name": "Artillerist",
+      "features": [
+        "Tool Proficiency",
+        "Artillerist Spells",
+        "Eldritch Cannon",
+        "Arcane Firearm",
+        "Explosive Cannon",
+        "Fortified Position"
+      ]
+    },
+    {
+      "name": "Battle Smith",
+      "features": [
+        "Tool Proficiency",
+        "Battle Smith Spells",
+        "Battle Ready",
+        "Steel Defender",
+        "Extra Attack",
+        "Arcane Jolt",
+        "Improved Defender"
+      ]
+    }
+  ]
+}

--- a/data/subclasses/alchemist.json
+++ b/data/subclasses/alchemist.json
@@ -1,0 +1,20 @@
+{
+  "name": "Alchemist",
+  "description": "An expert at combining reagents to produce mystical effects.",
+  "features_by_level": {
+    "3": [
+      { "name": "Tool Proficiency", "description": "You gain proficiency with alchemist's supplies. If you already have it, gain proficiency with another set of artisan's tools of your choice." },
+      { "name": "Alchemist Spells", "description": "You always have certain spells prepared: 3rd—healing word, ray of sickness; 5th—flaming sphere, Melf's acid arrow; 9th—gaseous form, mass healing word; 13th—blight, death ward; 17th—cloudkill, raise dead. These count as artificer spells for you and don't count against spells prepared." },
+      { "name": "Experimental Elixir", "description": "After a long rest, you create a random elixir in an empty flask. Roll on the Experimental Elixir table for its effect (healing, swiftness, resilience, boldness, flight, or transformation). The elixir lasts until drunk or your next long rest. You can create more by expending spell slots and can make additional elixirs at higher levels." }
+    ],
+    "5": [
+      { "name": "Alchemical Savant", "description": "When you cast a spell using alchemist's supplies as your focus, add your Intelligence modifier to one roll that restores hit points or deals acid, fire, necrotic, or poison damage." }
+    ],
+    "9": [
+      { "name": "Restorative Reagents", "description": "When a creature drinks your experimental elixir, it gains temporary hit points equal to 2d6 plus your Intelligence modifier. You can also cast lesser restoration without expending a spell slot a number of times equal to your Intelligence modifier per long rest using alchemist's supplies." }
+    ],
+    "15": [
+      { "name": "Chemical Mastery", "description": "You gain resistance to acid and poison damage and immunity to the poisoned condition. You can cast greater restoration and heal without expending spell slots or material components once per long rest each when using alchemist's supplies as the focus." }
+    ]
+  }
+}

--- a/data/subclasses/armorer.json
+++ b/data/subclasses/armorer.json
@@ -1,0 +1,21 @@
+{
+  "name": "Armorer",
+  "description": "You modify armor to function as a magical second skin.",
+  "features_by_level": {
+    "3": [
+      { "name": "Tools of the Trade", "description": "You gain proficiency with heavy armor and smith's tools. If you already have smith's tools proficiency, gain proficiency with another set of artisan's tools of your choice." },
+      { "name": "Armorer Spells", "description": "You always have certain spells prepared: 3rd—magic missile, thunderwave; 5th—mirror image, shatter; 9th—hypnotic pattern, lightning bolt; 13th—fire shield, greater invisibility; 17th—passwall, wall of force. These count as artificer spells for you and don't count against spells prepared." },
+      { "name": "Arcane Armor", "description": "As an action, turn a suit of armor you're wearing into Arcane Armor. It ignores Strength requirements, can serve as your spellcasting focus, attaches to you and can't be removed, covers your body, and can be donned or doffed as an action." },
+      { "name": "Armor Model", "description": "Choose Guardian or Infiltrator model for your arcane armor. Guardian grants thunder gauntlets (1d8 thunder damage, imposes disadvantage on attacks against others) and a Defensive Field that grants temporary hit points equal to your artificer level as a bonus action, proficiency bonus times per long rest. Infiltrator grants a lightning launcher (90/300 ft, 1d6 lightning plus an extra 1d6 once per turn), Powered Steps (+5 ft speed), and a Dampening Field (advantage on Stealth and negates armor Stealth disadvantage). You can change the model after a short or long rest with smith's tools." }
+    ],
+    "5": [
+      { "name": "Extra Attack", "description": "You can attack twice, instead of once, whenever you take the Attack action on your turn." }
+    ],
+    "9": [
+      { "name": "Armor Modifications", "description": "Your arcane armor counts as separate items—armor, boots, helmet, and special weapon—for infusions. You can infuse two additional items, but they must be part of the armor." }
+    ],
+    "15": [
+      { "name": "Perfected Armor", "description": "Guardian: as a reaction when a creature ends its turn within 30 ft, you can pull it up to 25 ft and make a melee attack if it's within 5 ft; uses equal to your proficiency bonus per long rest. Infiltrator: creatures hit by your lightning launcher shed light and have disadvantage on attack rolls against you until your next turn; the next attack roll against the target has advantage and deals an extra 1d6 lightning damage on a hit." }
+    ]
+  }
+}

--- a/data/subclasses/artillerist.json
+++ b/data/subclasses/artillerist.json
@@ -1,0 +1,20 @@
+{
+  "name": "Artillerist",
+  "description": "You specialize in using magic to hurl energy and explosions on the battlefield.",
+  "features_by_level": {
+    "3": [
+      { "name": "Tool Proficiency", "description": "You gain proficiency with woodcarver's tools. If you already have it, gain proficiency with another set of artisan's tools of your choice." },
+      { "name": "Artillerist Spells", "description": "You always have certain spells prepared: 3rd—shield, thunderwave; 5th—scorching ray, shatter; 9th—fireball, wind wall; 13th—ice storm, wall of fire; 17th—cone of cold, wall of force. These count as artificer spells for you and don't count against spells prepared." },
+      { "name": "Eldritch Cannon", "description": "As an action, use woodcarver's or smith's tools to create a Small or Tiny magical cannon. Once per long rest or by expending a spell slot, you can create a cannon that lasts for up to 1 hour and can be activated as a bonus action to produce a flamethrower, force ballista, or protector effect. It has AC 18, hit points equal to five times your artificer level, and can move 15 ft as part of the activation." }
+    ],
+    "5": [
+      { "name": "Arcane Firearm", "description": "At the end of a long rest, you can carve sigils into a wand, staff, or rod to use as an arcane firearm. When you cast an artificer spell through it, roll a d8 and add the number rolled to one damage roll of the spell." }
+    ],
+    "9": [
+      { "name": "Explosive Cannon", "description": "Your eldritch cannons deal an extra d8 damage. As an action, you can detonate a cannon to deal 3d8 force damage to creatures within 20 feet (Dexterity save for half), destroying the cannon." }
+    ],
+    "15": [
+      { "name": "Fortified Position", "description": "You and your allies have half cover while within 10 ft of any eldritch cannon you create. You can maintain two cannons at once and can activate both with the same bonus action." }
+    ]
+  }
+}

--- a/data/subclasses/battle_smith.json
+++ b/data/subclasses/battle_smith.json
@@ -1,0 +1,21 @@
+{
+  "name": "Battle Smith",
+  "description": "A combination of protector and medic who uses magic to bolster allies and constructs.",
+  "features_by_level": {
+    "3": [
+      { "name": "Tool Proficiency", "description": "You gain proficiency with smith's tools. If you already have it, gain proficiency with another set of artisan's tools of your choice." },
+      { "name": "Battle Smith Spells", "description": "You always have certain spells prepared: 3rd—heroism, shield; 5th—branding smite, warding bond; 9th—aura of vitality, conjure barrage; 13th—aura of purity, fire shield; 17th—banishing smite, mass cure wounds. These count as artificer spells for you and don't count against spells prepared." },
+      { "name": "Battle Ready", "description": "You gain proficiency with martial weapons, and you can use Intelligence instead of Strength or Dexterity for the attack and damage rolls of magic weapons." },
+      { "name": "Steel Defender", "description": "You create a steel defender companion that acts on your initiative. It can move and use its reaction on its own, but it takes the Dodge action unless you command it with a bonus action. It has its own stat block using your proficiency bonus, can be healed by mending, and can be revived with a spell slot. You can build a new one after a long rest." }
+    ],
+    "5": [
+      { "name": "Extra Attack", "description": "You can attack twice, instead of once, whenever you take the Attack action on your turn." }
+    ],
+    "9": [
+      { "name": "Arcane Jolt", "description": "When you or your steel defender hits with a magic weapon attack, you can deal an extra 2d6 force damage to the target or restore 2d6 hit points to a creature or object within 30 ft of the target. Uses equal to your Intelligence modifier per long rest, once per turn." }
+    ],
+    "15": [
+      { "name": "Improved Defender", "description": "Arcane Jolt's extra damage or healing becomes 4d6. Your steel defender's AC increases by 2, and its Deflect Attack reaction deals 1d4 + your Intelligence modifier force damage to the attacker." }
+    ]
+  }
+}


### PR DESCRIPTION
## Summary
- add Artificer class with full feature progression and descriptions
- define Alchemist, Armorer, Artillerist, and Battle Smith subclass data with detailed features and spell lists

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a380289bac832e826b51b63e8cf900