### PR TITLE
Expand druid class and add circle subclasses

### DIFF
--- a/data/classes/druid.json
+++ b/data/classes/druid.json
@@ -1,11 +1,157 @@
 {
   "name": "Druid",
+  "description": "A wielder of nature's magic who can cast spells and shapeshift into beasts.",
+  "features_by_level": {
+    "1": [
+      {
+        "name": "Druidic",
+        "description": "You know Druidic, a secret language used to leave hidden messages that require a DC 15 Perception check to spot."
+      },
+      {
+        "name": "Spellcasting",
+        "description": "Use Wisdom to cast druid spells. You know cantrips, prepare spells after a long rest, can cast rituals and use a druidic focus."
+      }
+    ],
+    "2": [
+      {
+        "name": "Wild Shape",
+        "description": "As an action, transform into a beast you've seen twice per rest, with CR limits based on level and restrictions on flying and swimming."
+      },
+      {
+        "name": "Wild Companion",
+        "description": "Expend a use of Wild Shape to cast find familiar, summoning a fey spirit that lasts for hours equal to half your druid level."
+      },
+      {
+        "name": "Druid Circle",
+        "description": "Choose a druid circle, gaining additional features at levels 2, 6, 10 and 14."
+      }
+    ],
+    "4": [
+      {
+        "name": "Wild Shape Improvement",
+        "description": "Your Wild Shape form options improve according to the Beast Shapes table."
+      },
+      {
+        "name": "Ability Score Improvement",
+        "description": "Increase one ability score by 2, two scores by 1, or take a feat if allowed."
+      },
+      {
+        "name": "Cantrip Versatility",
+        "description": "Whenever you gain an Ability Score Improvement, you can replace a druid cantrip you know."
+      }
+    ],
+    "6": [
+      {
+        "name": "Druid Circle feature",
+        "description": "You gain a feature from your chosen druid circle."
+      }
+    ],
+    "8": [
+      {
+        "name": "Wild Shape Improvement",
+        "description": "Your Wild Shape form options improve according to the Beast Shapes table."
+      },
+      {
+        "name": "Ability Score Improvement",
+        "description": "Increase one ability score by 2, two scores by 1, or take a feat if allowed."
+      }
+    ],
+    "10": [
+      {
+        "name": "Druid Circle feature",
+        "description": "You gain a feature from your chosen druid circle."
+      }
+    ],
+    "12": [
+      {
+        "name": "Ability Score Improvement",
+        "description": "Increase one ability score by 2, two scores by 1, or take a feat if allowed."
+      }
+    ],
+    "14": [
+      {
+        "name": "Druid Circle feature",
+        "description": "You gain a feature from your chosen druid circle."
+      }
+    ],
+    "16": [
+      {
+        "name": "Ability Score Improvement",
+        "description": "Increase one ability score by 2, two scores by 1, or take a feat if allowed."
+      }
+    ],
+    "18": [
+      {
+        "name": "Timeless Body",
+        "description": "For every 10 years that pass, your body ages only 1 year."
+      },
+      {
+        "name": "Beast Spells",
+        "description": "You can cast many druid spells while in beast form without providing somatic or verbal components."
+      }
+    ],
+    "19": [
+      {
+        "name": "Ability Score Improvement",
+        "description": "Increase one ability score by 2, two scores by 1, or take a feat if allowed."
+      }
+    ],
+    "20": [
+      {
+        "name": "Archdruid",
+        "description": "Use Wild Shape an unlimited number of times and ignore the verbal and somatic components of druid spells."
+      }
+    ]
+  },
   "subclasses": [
+    {
+      "name": "Circle of Dreams",
+      "features": [
+        "Balm of the Summer Court",
+        "Hearth of Moonlight and Shadow",
+        "Hidden Paths",
+        "Walker in Dreams"
+      ]
+    },
+    {
+      "name": "Circle of Spores",
+      "features": [
+        "Circle Spells",
+        "Halo of Spores",
+        "Symbiotic Entity",
+        "Fungal Infestation",
+        "Spreading Spores",
+        "Fungal Body"
+      ]
+    },
+    {
+      "name": "Circle of Stars",
+      "features": [
+        "Star Map",
+        "Starry Form",
+        "Cosmic Omen",
+        "Twinkling Constellations",
+        "Full of Stars"
+      ]
+    },
+    {
+      "name": "Circle of the Blighted",
+      "features": [
+        "Defile Ground",
+        "Blighted Shape",
+        "Call of the Shadowseeds",
+        "Defile Ground (10th Level)",
+        "Foul Conjuration",
+        "Defile Ground (14th Level)",
+        "Incarnation of Corruption"
+      ]
+    },
     {
       "name": "Circle of the Land",
       "features": [
-        "Circle Spells",
+        "Bonus Cantrip",
         "Natural Recovery",
+        "Circle Spells",
         "Land's Stride",
         "Nature's Ward",
         "Nature's Sanctuary"
@@ -20,21 +166,26 @@
         "Elemental Wild Shape",
         "Thousand Forms"
       ]
+    },
+    {
+      "name": "Circle of the Shepherd",
+      "features": [
+        "Speech of the Woods",
+        "Spirit Totem",
+        "Mighty Summoner",
+        "Guardian Spirit",
+        "Faithful Summons"
+      ]
+    },
+    {
+      "name": "Circle of Wildfire",
+      "features": [
+        "Circle Spells",
+        "Summon Wildfire Spirit",
+        "Enhanced Bond",
+        "Cauterizing Flames",
+        "Blazing Revival"
+      ]
     }
-  ],
-  "description": "Description for Druid class.",
-  "features_by_level": {
-    "1": [
-      {
-        "name": "Druid Feature 1",
-        "description": "Description for Druid feature at level 1."
-      }
-    ],
-    "2": [
-      {
-        "name": "Druid Feature 2",
-        "description": "Description for Druid feature at level 2."
-      }
-    ]
-  }
+  ]
 }

--- a/data/subclasses/circle_of_dreams.json
+++ b/data/subclasses/circle_of_dreams.json
@@ -1,0 +1,30 @@
+{
+  "name": "Circle of Dreams",
+  "description": "Druids with ties to the Feywild who use dreamlike magic to heal and protect.",
+  "features_by_level": {
+    "2": [
+      {
+        "name": "Balm of the Summer Court",
+        "description": "As a bonus action, heal a creature within 120 feet using a pool of d6s equal to your druid level, granting temporary hit points as well."
+      }
+    ],
+    "6": [
+      {
+        "name": "Hearth of Moonlight and Shadow",
+        "description": "During a rest, create a 30-foot sphere that grants +5 to Stealth and Perception and masks light within it." 
+      }
+    ],
+    "10": [
+      {
+        "name": "Hidden Paths",
+        "description": "Teleport 60 feet as a bonus action or teleport a willing creature 30 feet as an action a number of times equal to your Wisdom modifier per long rest." 
+      }
+    ],
+    "14": [
+      {
+        "name": "Walker in Dreams",
+        "description": "After a short rest, cast dream, scrying, or teleportation circle (to your last long-rest location) once per long rest without expending a slot." 
+      }
+    ]
+  }
+}

--- a/data/subclasses/circle_of_spores.json
+++ b/data/subclasses/circle_of_spores.json
@@ -1,0 +1,38 @@
+{
+  "name": "Circle of Spores",
+  "description": "Druids who see life and death as a cycle, wielding fungal spores to animate decay.",
+  "features_by_level": {
+    "2": [
+      {
+        "name": "Circle Spells",
+        "description": "Learn chill touch and gain additional spells at levels 3,5,7 and 9 that are always prepared." 
+      },
+      {
+        "name": "Halo of Spores",
+        "description": "Use a reaction to deal necrotic damage to creatures within 10 feet that fail a Constitution save." 
+      },
+      {
+        "name": "Symbiotic Entity",
+        "description": "Expend Wild Shape to awaken spores, gaining temporary hit points and bonus necrotic damage for 10 minutes." 
+      }
+    ],
+    "6": [
+      {
+        "name": "Fungal Infestation",
+        "description": "When a Small or Medium beast or humanoid dies near you, animate it as a 1 hp zombie for 1 hour." 
+      }
+    ],
+    "10": [
+      {
+        "name": "Spreading Spores",
+        "description": "While Symbiotic Entity is active, hurl spores to create a 10-foot cube that damages creatures moving through it." 
+      }
+    ],
+    "14": [
+      {
+        "name": "Fungal Body",
+        "description": "You can't be blinded, deafened, frightened or poisoned, and critical hits count as normal hits." 
+      }
+    ]
+  }
+}

--- a/data/subclasses/circle_of_stars.json
+++ b/data/subclasses/circle_of_stars.json
@@ -1,0 +1,34 @@
+{
+  "name": "Circle of Stars",
+  "description": "Druids who study constellations and draw power from starlight.",
+  "features_by_level": {
+    "2": [
+      {
+        "name": "Star Map",
+        "description": "Create a starry focus that grants the guidance cantrip and prepared guiding bolt, plus free uses equal to proficiency bonus." 
+      },
+      {
+        "name": "Starry Form",
+        "description": "Expend Wild Shape to take on a luminous form, choosing Archer, Chalice or Dragon benefits for 10 minutes." 
+      }
+    ],
+    "6": [
+      {
+        "name": "Cosmic Omen",
+        "description": "After a long rest, roll to gain Weal or Woe and use reactions a number of times equal to proficiency bonus to add or subtract a d6." 
+      }
+    ],
+    "10": [
+      {
+        "name": "Twinkling Constellations",
+        "description": "Starry Form benefits improve; Archer and Chalice deal 2d8 and Dragon grants 20-foot flying and hovering." 
+      }
+    ],
+    "14": [
+      {
+        "name": "Full of Stars",
+        "description": "While in Starry Form, you gain resistance to bludgeoning, piercing and slashing damage." 
+      }
+    ]
+  }
+}

--- a/data/subclasses/circle_of_the_blighted.json
+++ b/data/subclasses/circle_of_the_blighted.json
@@ -1,0 +1,42 @@
+{
+  "name": "Circle of the Blighted",
+  "description": "Druids corrupted by tainted lands who wield decay as a weapon.",
+  "features_by_level": {
+    "2": [
+      {
+        "name": "Defile Ground",
+        "description": "As a bonus action, corrupt a 10-foot radius area for 1 minute, creating difficult terrain that deals extra necrotic damage once per turn." 
+      },
+      {
+        "name": "Blighted Shape",
+        "description": "Gain Intimidation proficiency and while Wild Shaped your form gains +2 AC and 60-foot darkvision." 
+      }
+    ],
+    "6": [
+      {
+        "name": "Call of the Shadowseeds",
+        "description": "When a creature takes damage in your defiled ground, summon a blighted sapling that can immediately attack." 
+      }
+    ],
+    "10": [
+      {
+        "name": "Defile Ground (10th Level)",
+        "description": "Your defiled area expands to a 20-foot radius and the extra damage increases to 1d6." 
+      },
+      {
+        "name": "Foul Conjuration",
+        "description": "Creatures you summon are immune to necrotic and poison damage and explode with necrotic damage when they die." 
+      }
+    ],
+    "14": [
+      {
+        "name": "Defile Ground (14th Level)",
+        "description": "The extra damage from your defiled ground increases to 1d8." 
+      },
+      {
+        "name": "Incarnation of Corruption",
+        "description": "Gain resistance to necrotic damage, +2 AC, and can gain temporary hit points when starting your turn in your defiled ground." 
+      }
+    ]
+  }
+}

--- a/data/subclasses/circle_of_the_land.json
+++ b/data/subclasses/circle_of_the_land.json
@@ -1,33 +1,37 @@
 {
   "name": "Circle of the Land",
-  "description": "Druids of the Circle of the Land are mystics and sages who safeguard ancient knowledge.",
+  "description": "Mystics who draw power from the land where they were initiated.",
   "features_by_level": {
     "2": [
       {
         "name": "Circle Spells",
-        "description": "Description for Circle Spells."
+        "description": "Gain extra spells at levels 3,5,7 and 9 based on your chosen terrain; always prepared." 
       },
       {
         "name": "Natural Recovery",
-        "description": "Description for Natural Recovery."
+        "description": "During a short rest, recover spell slots with a combined level up to half your druid level (rounded up)."
+      },
+      {
+        "name": "Bonus Cantrip",
+        "description": "Learn one additional druid cantrip."
       }
     ],
     "6": [
       {
         "name": "Land's Stride",
-        "description": "Description for Land's Stride."
+        "description": "Move through nonmagical difficult terrain and plants without penalty and gain advantage against plants that impede movement." 
       }
     ],
     "10": [
       {
         "name": "Nature's Ward",
-        "description": "Description for Nature's Ward."
+        "description": "You can't be charmed or frightened by elementals or fey and are immune to poison and disease." 
       }
     ],
     "14": [
       {
         "name": "Nature's Sanctuary",
-        "description": "Description for Nature's Sanctuary."
+        "description": "Beasts and plants must succeed on a Wisdom save to attack you; on a failure they must choose another target." 
       }
     ]
   }

--- a/data/subclasses/circle_of_the_moon.json
+++ b/data/subclasses/circle_of_the_moon.json
@@ -1,33 +1,33 @@
 {
   "name": "Circle of the Moon",
-  "description": "Druids of the Circle of the Moon are fierce guardians of the wilds.",
+  "description": "Guardians of the wilds who master powerful beast shapes.",
   "features_by_level": {
     "2": [
       {
         "name": "Combat Wild Shape",
-        "description": "Description for Combat Wild Shape."
+        "description": "Use Wild Shape as a bonus action and spend spell slots to heal while transformed."
       },
       {
         "name": "Circle Forms",
-        "description": "Description for Circle Forms."
+        "description": "Transform into beasts with challenge rating up to 1, ignoring normal CR limits."
       }
     ],
     "6": [
       {
         "name": "Primal Strike",
-        "description": "Description for Primal Strike."
+        "description": "Your attacks in beast form count as magical for overcoming resistances."
       }
     ],
     "10": [
       {
         "name": "Elemental Wild Shape",
-        "description": "Description for Elemental Wild Shape."
+        "description": "Expend two uses of Wild Shape to transform into an air, earth, fire or water elemental."
       }
     ],
     "14": [
       {
         "name": "Thousand Forms",
-        "description": "Description for Thousand Forms."
+        "description": "Cast alter self at will."
       }
     ]
   }

--- a/data/subclasses/circle_of_the_shepherd.json
+++ b/data/subclasses/circle_of_the_shepherd.json
@@ -1,0 +1,34 @@
+{
+  "name": "Circle of the Shepherd",
+  "description": "Druids who call on animal and fey spirits to protect their charges.",
+  "features_by_level": {
+    "2": [
+      {
+        "name": "Speech of the Woods",
+        "description": "Learn Sylvan and communicate with beasts; they can understand you and you can interpret their noises." 
+      },
+      {
+        "name": "Spirit Totem",
+        "description": "As a bonus action, summon an aura-creating spirit (bear, hawk or unicorn) for 1 minute, usable once per short rest." 
+      }
+    ],
+    "6": [
+      {
+        "name": "Mighty Summoner",
+        "description": "Beasts and fey you summon have 2 extra hit points per Hit Die and their attacks count as magical." 
+      }
+    ],
+    "10": [
+      {
+        "name": "Guardian Spirit",
+        "description": "Creatures you summoned regain hit points equal to half your druid level when they end their turn in your Spirit Totem aura." 
+      }
+    ],
+    "14": [
+      {
+        "name": "Faithful Summons",
+        "description": "If reduced to 0 hit points or incapacitated, automatically cast conjure animals at 9th level to summon protective beasts." 
+      }
+    ]
+  }
+}

--- a/data/subclasses/circle_of_wildfire.json
+++ b/data/subclasses/circle_of_wildfire.json
@@ -1,0 +1,34 @@
+{
+  "name": "Circle of Wildfire",
+  "description": "Druids bonded to a primal wildfire spirit that balances destruction and renewal.",
+  "features_by_level": {
+    "2": [
+      {
+        "name": "Circle Spells",
+        "description": "Gain additional spells at levels 2,3,5,7 and 9, including burning hands and cure wounds, always prepared." 
+      },
+      {
+        "name": "Summon Wildfire Spirit",
+        "description": "Expend Wild Shape to summon a fiery spirit that deals fire damage when it appears and obeys your commands for 1 hour." 
+      }
+    ],
+    "6": [
+      {
+        "name": "Enhanced Bond",
+        "description": "While your wildfire spirit is summoned, add a d8 to one damage or healing roll of spells that deal fire or restore hit points, and spells can originate from the spirit." 
+      }
+    ],
+    "10": [
+      {
+        "name": "Cauterizing Flames",
+        "description": "When a creature dies near you or the spirit, create a spectral flame you can use to heal or deal fire damage (2d10 + Wisdom modifier)." 
+      }
+    ],
+    "14": [
+      {
+        "name": "Blazing Revival",
+        "description": "If you drop to 0 hit points while the spirit is within 120 feet, it can drop to 0 to restore you to half hit points and stand you up." 
+      }
+    ]
+  }
+}


### PR DESCRIPTION
## Summary
- Flesh out druid class features across all levels
- Add data files for Circle of Dreams, Spores, Stars, Blighted, Shepherd, and Wildfire
- Expand Circle of the Land and Circle of the Moon descriptions

## Testing
- `npm test` *(fails: ENOENT no package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a441db8fd0832e88e15388c6097e38