### PR TITLE
feat: add class choice summaries

### DIFF
--- a/index.html
+++ b/index.html
@@ -96,7 +96,8 @@
       margin-top: 10px;
     }
     /* Contenitori per le sezioni extra */
-    #spellSelectionContainer, #languageSelection, #skillSelectionContainer, #toolSelectionContainer, #variantFeatureSelectionContainer, #variantExtraContainer {
+    #spellSelectionContainer, #languageSelection, #skillSelectionContainer, #toolSelectionContainer, #variantFeatureSelectionContainer, #variantExtraContainer,
+    #fightingStyleSelection, #divineDomainSelection, #metamagicSelection {
       margin-top: 15px;
     }
   </style>
@@ -360,6 +361,9 @@
       <br><br>
       <button id="confirmClassSelection" class="primary">Seleziona Classe</button>
       <div id="classFeatures"></div>
+      <div id="fightingStyleSelection"></div>
+      <div id="divineDomainSelection"></div>
+      <div id="metamagicSelection"></div>
     </div>
     <!-- Step 8: Recap & Esportazione -->
     <div id="step8" class="step">

--- a/js/script.js
+++ b/js/script.js
@@ -645,13 +645,20 @@ const extraCategoryAliases = {
   "Cantrip": "Cantrips",
   "Cantrips": "Cantrips",
   "Skill Proficiency": "Skill Proficiency",
-  "Tool Proficiency": "Tool Proficiency"
+  "Tool Proficiency": "Tool Proficiency",
+  "Fighting Style": "Fighting Style",
+  "Additional Fighting Style": "Fighting Style",
+  "Divine Domain": "Divine Domain",
+  "Metamagic": "Metamagic"
 };
 
 const extraCategoryDescriptions = {
   "Cantrips": "Scegli i tuoi cantrip.",
   "Skill Proficiency": "Seleziona le competenze nelle abilità.",
-  "Tool Proficiency": "Seleziona le competenze negli strumenti."
+  "Tool Proficiency": "Seleziona le competenze negli strumenti.",
+  "Fighting Style": "Scegli il tuo stile di combattimento.",
+  "Divine Domain": "Seleziona il tuo dominio divino.",
+  "Metamagic": "Scegli le opzioni di Metamagia."
 };
 
 /**
@@ -717,7 +724,10 @@ function updateExtraSelectionsView() {
     "Skill Proficiency": ["skillSelectionContainer", "Skill Proficiency"],
     "Tool Proficiency": ["toolSelectionContainer", "Tool Proficiency"],
     "Spellcasting": ["spellSelectionContainer", "Spellcasting"],
-    "Cantrips": ["spellSelectionContainer", "Cantrips"]
+    "Cantrips": ["spellSelectionContainer", "Cantrips"],
+    "Fighting Style": ["fightingStyleSelection", "Fighting Style"],
+    "Divine Domain": ["divineDomainSelection", "Divine Domain"],
+    "Metamagic": ["metamagicSelection", "Metamagic"]
   };
   Object.entries(summaryMap).forEach(([key, [id, title]]) => {
     updateContainer(id, title, key);


### PR DESCRIPTION
## Summary
- handle class extra selections like Fighting Style, Divine Domain, and Metamagic
- show chosen class options in Step 4 summary

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a44eccfa90832ea9bff95405ea1d46