### PR TITLE
Unify extra feature selections for races and classes

### DIFF
--- a/data/classes/artificer.json
+++ b/data/classes/artificer.json
@@ -177,6 +177,7 @@
       "name": "Infusion",
       "description": "Choose two infusions to learn",
       "count": 2,
+      "type": "infusion",
       "selection": [
         "Enhanced Defense",
         "Enhanced Weapon",

--- a/data/classes/barbarian.json
+++ b/data/classes/barbarian.json
@@ -240,6 +240,7 @@
       "name": "Primal Knowledge",
       "description": "Gain proficiency in one skill from the barbarian list",
       "count": 1,
+      "type": "skills",
       "selection": [
         "Animal Handling",
         "Athletics",

--- a/data/classes/bard.json
+++ b/data/classes/bard.json
@@ -234,6 +234,7 @@
       "name": "Expertise",
       "description": "Choose two skills to gain expertise in",
       "count": 2,
+      "type": "skills",
       "selection": [
         "Acrobatics",
         "Athletics",

--- a/data/classes/cleric.json
+++ b/data/classes/cleric.json
@@ -293,6 +293,7 @@
       "name": "Skill Proficiency",
       "description": "Choose two skills from the cleric list",
       "count": 2,
+      "type": "skills",
       "selection": [
         "History",
         "Insight",

--- a/data/classes/druid.json
+++ b/data/classes/druid.json
@@ -194,6 +194,7 @@
       "name": "Cantrip",
       "description": "Choose two druid cantrips to learn",
       "count": 2,
+      "type": "cantrips",
       "selection": [
         "Guidance",
         "Produce Flame",

--- a/data/classes/fighter.json
+++ b/data/classes/fighter.json
@@ -54,6 +54,7 @@
       "name": "Fighting Style",
       "description": "Choose a fighting style",
       "count": 1,
+      "type": "fighting style",
       "selection": [
         "Archery",
         "Defense",

--- a/data/classes/monk.json
+++ b/data/classes/monk.json
@@ -50,6 +50,7 @@
       "name": "Monk Weapon",
       "description": "Choose a monk weapon to focus on",
       "count": 1,
+      "type": "weapon",
       "selection": [
         "Shortsword",
         "Quarterstaff",

--- a/data/classes/paladin.json
+++ b/data/classes/paladin.json
@@ -53,6 +53,7 @@
       "name": "Fighting Style",
       "description": "Choose a fighting style",
       "count": 1,
+      "type": "fighting style",
       "selection": [
         "Defense",
         "Dueling",

--- a/data/classes/ranger.json
+++ b/data/classes/ranger.json
@@ -41,6 +41,7 @@
       "name": "Favored Enemy",
       "description": "Choose a type of favored enemy",
       "count": 1,
+      "type": "favored enemy",
       "selection": [
         "Aberrations",
         "Beasts",
@@ -54,6 +55,7 @@
       "name": "Natural Explorer",
       "description": "Choose one type of favored terrain",
       "count": 1,
+      "type": "favored terrain",
       "selection": [
         "Arctic",
         "Coast",

--- a/data/classes/rogue.json
+++ b/data/classes/rogue.json
@@ -53,6 +53,7 @@
       "name": "Expertise",
       "description": "Choose two skills to gain expertise in",
       "count": 2,
+      "type": "skills",
       "selection": [
         "Acrobatics",
         "Athletics",

--- a/data/classes/sorcerer.json
+++ b/data/classes/sorcerer.json
@@ -43,6 +43,7 @@
       "name": "Metamagic",
       "description": "Choose two Metamagic options",
       "count": 2,
+      "type": "metamagic",
       "selection": [
         "Careful Spell",
         "Distant Spell",

--- a/data/classes/warlock.json
+++ b/data/classes/warlock.json
@@ -50,6 +50,7 @@
       "name": "Pact Boon",
       "description": "Choose a pact boon",
       "count": 1,
+      "type": "pact boon",
       "selection": [
         "Pact of the Chain",
         "Pact of the Blade",

--- a/data/classes/wizard.json
+++ b/data/classes/wizard.json
@@ -103,6 +103,7 @@
       "name": "Cantrip",
       "description": "Choose two wizard cantrips to learn",
       "count": 2,
+      "type": "cantrips",
       "selection": [
         "Mage Hand",
         "Prestidigitation",


### PR DESCRIPTION
## Summary
- centralize race and class extra feature handling with new `gatherExtraSelections` helper
- include subclass and all extra selections in exported character JSON
- annotate class choice data with explicit `type` metadata

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a452336dec832e8a26e14145a2faa3