### PR TITLE
Add ability score improvement options and choice selectors

### DIFF
--- a/data/classes/artificer.json
+++ b/data/classes/artificer.json
@@ -184,6 +184,66 @@
         "Repeating Shot",
         "Returning Weapon"
       ]
+    },
+    {
+      "level": 4,
+      "name": "Ability Score Improvement",
+      "description": "Increase one ability score by 2, two ability scores by 1, or take a feat if allowed.",
+      "count": 1,
+      "type": "Ability Score Improvement",
+      "selection": [
+        "Increase one ability score by 2",
+        "Increase two ability scores by 1",
+        "Feat"
+      ]
+    },
+    {
+      "level": 8,
+      "name": "Ability Score Improvement",
+      "description": "Increase one ability score by 2, two ability scores by 1, or take a feat if allowed.",
+      "count": 1,
+      "type": "Ability Score Improvement",
+      "selection": [
+        "Increase one ability score by 2",
+        "Increase two ability scores by 1",
+        "Feat"
+      ]
+    },
+    {
+      "level": 12,
+      "name": "Ability Score Improvement",
+      "description": "Increase one ability score by 2, two ability scores by 1, or take a feat if allowed.",
+      "count": 1,
+      "type": "Ability Score Improvement",
+      "selection": [
+        "Increase one ability score by 2",
+        "Increase two ability scores by 1",
+        "Feat"
+      ]
+    },
+    {
+      "level": 16,
+      "name": "Ability Score Improvement",
+      "description": "Increase one ability score by 2, two ability scores by 1, or take a feat if allowed.",
+      "count": 1,
+      "type": "Ability Score Improvement",
+      "selection": [
+        "Increase one ability score by 2",
+        "Increase two ability scores by 1",
+        "Feat"
+      ]
+    },
+    {
+      "level": 19,
+      "name": "Ability Score Improvement",
+      "description": "Increase one ability score by 2, two ability scores by 1, or take a feat if allowed.",
+      "count": 1,
+      "type": "Ability Score Improvement",
+      "selection": [
+        "Increase one ability score by 2",
+        "Increase two ability scores by 1",
+        "Feat"
+      ]
     }
   ]
 }

--- a/data/classes/barbarian.json
+++ b/data/classes/barbarian.json
@@ -249,6 +249,66 @@
         "Perception",
         "Survival"
       ]
+    },
+    {
+      "level": 4,
+      "name": "Ability Score Improvement",
+      "description": "Increase one ability score by 2, two ability scores by 1, or take a feat if allowed.",
+      "count": 1,
+      "type": "Ability Score Improvement",
+      "selection": [
+        "Increase one ability score by 2",
+        "Increase two ability scores by 1",
+        "Feat"
+      ]
+    },
+    {
+      "level": 8,
+      "name": "Ability Score Improvement",
+      "description": "Increase one ability score by 2, two ability scores by 1, or take a feat if allowed.",
+      "count": 1,
+      "type": "Ability Score Improvement",
+      "selection": [
+        "Increase one ability score by 2",
+        "Increase two ability scores by 1",
+        "Feat"
+      ]
+    },
+    {
+      "level": 12,
+      "name": "Ability Score Improvement",
+      "description": "Increase one ability score by 2, two ability scores by 1, or take a feat if allowed.",
+      "count": 1,
+      "type": "Ability Score Improvement",
+      "selection": [
+        "Increase one ability score by 2",
+        "Increase two ability scores by 1",
+        "Feat"
+      ]
+    },
+    {
+      "level": 16,
+      "name": "Ability Score Improvement",
+      "description": "Increase one ability score by 2, two ability scores by 1, or take a feat if allowed.",
+      "count": 1,
+      "type": "Ability Score Improvement",
+      "selection": [
+        "Increase one ability score by 2",
+        "Increase two ability scores by 1",
+        "Feat"
+      ]
+    },
+    {
+      "level": 19,
+      "name": "Ability Score Improvement",
+      "description": "Increase one ability score by 2, two ability scores by 1, or take a feat if allowed.",
+      "count": 1,
+      "type": "Ability Score Improvement",
+      "selection": [
+        "Increase one ability score by 2",
+        "Increase two ability scores by 1",
+        "Feat"
+      ]
     }
   ]
 }

--- a/data/classes/bard.json
+++ b/data/classes/bard.json
@@ -246,6 +246,66 @@
         "Persuasion",
         "Stealth"
       ]
+    },
+    {
+      "level": 4,
+      "name": "Ability Score Improvement",
+      "description": "Increase one ability score by 2, two ability scores by 1, or take a feat if allowed.",
+      "count": 1,
+      "type": "Ability Score Improvement",
+      "selection": [
+        "Increase one ability score by 2",
+        "Increase two ability scores by 1",
+        "Feat"
+      ]
+    },
+    {
+      "level": 8,
+      "name": "Ability Score Improvement",
+      "description": "Increase one ability score by 2, two ability scores by 1, or take a feat if allowed.",
+      "count": 1,
+      "type": "Ability Score Improvement",
+      "selection": [
+        "Increase one ability score by 2",
+        "Increase two ability scores by 1",
+        "Feat"
+      ]
+    },
+    {
+      "level": 12,
+      "name": "Ability Score Improvement",
+      "description": "Increase one ability score by 2, two ability scores by 1, or take a feat if allowed.",
+      "count": 1,
+      "type": "Ability Score Improvement",
+      "selection": [
+        "Increase one ability score by 2",
+        "Increase two ability scores by 1",
+        "Feat"
+      ]
+    },
+    {
+      "level": 16,
+      "name": "Ability Score Improvement",
+      "description": "Increase one ability score by 2, two ability scores by 1, or take a feat if allowed.",
+      "count": 1,
+      "type": "Ability Score Improvement",
+      "selection": [
+        "Increase one ability score by 2",
+        "Increase two ability scores by 1",
+        "Feat"
+      ]
+    },
+    {
+      "level": 19,
+      "name": "Ability Score Improvement",
+      "description": "Increase one ability score by 2, two ability scores by 1, or take a feat if allowed.",
+      "count": 1,
+      "type": "Ability Score Improvement",
+      "selection": [
+        "Increase one ability score by 2",
+        "Increase two ability scores by 1",
+        "Feat"
+      ]
     }
   ]
 }

--- a/data/classes/cleric.json
+++ b/data/classes/cleric.json
@@ -301,6 +301,66 @@
         "Persuasion",
         "Religion"
       ]
+    },
+    {
+      "level": 4,
+      "name": "Ability Score Improvement",
+      "description": "Increase one ability score by 2, two ability scores by 1, or take a feat if allowed.",
+      "count": 1,
+      "type": "Ability Score Improvement",
+      "selection": [
+        "Increase one ability score by 2",
+        "Increase two ability scores by 1",
+        "Feat"
+      ]
+    },
+    {
+      "level": 8,
+      "name": "Ability Score Improvement",
+      "description": "Increase one ability score by 2, two ability scores by 1, or take a feat if allowed.",
+      "count": 1,
+      "type": "Ability Score Improvement",
+      "selection": [
+        "Increase one ability score by 2",
+        "Increase two ability scores by 1",
+        "Feat"
+      ]
+    },
+    {
+      "level": 12,
+      "name": "Ability Score Improvement",
+      "description": "Increase one ability score by 2, two ability scores by 1, or take a feat if allowed.",
+      "count": 1,
+      "type": "Ability Score Improvement",
+      "selection": [
+        "Increase one ability score by 2",
+        "Increase two ability scores by 1",
+        "Feat"
+      ]
+    },
+    {
+      "level": 16,
+      "name": "Ability Score Improvement",
+      "description": "Increase one ability score by 2, two ability scores by 1, or take a feat if allowed.",
+      "count": 1,
+      "type": "Ability Score Improvement",
+      "selection": [
+        "Increase one ability score by 2",
+        "Increase two ability scores by 1",
+        "Feat"
+      ]
+    },
+    {
+      "level": 19,
+      "name": "Ability Score Improvement",
+      "description": "Increase one ability score by 2, two ability scores by 1, or take a feat if allowed.",
+      "count": 1,
+      "type": "Ability Score Improvement",
+      "selection": [
+        "Increase one ability score by 2",
+        "Increase two ability scores by 1",
+        "Feat"
+      ]
     }
   ]
 }

--- a/data/classes/druid.json
+++ b/data/classes/druid.json
@@ -201,6 +201,66 @@
         "Shillelagh",
         "Thorn Whip"
       ]
+    },
+    {
+      "level": 4,
+      "name": "Ability Score Improvement",
+      "description": "Increase one ability score by 2, two ability scores by 1, or take a feat if allowed.",
+      "count": 1,
+      "type": "Ability Score Improvement",
+      "selection": [
+        "Increase one ability score by 2",
+        "Increase two ability scores by 1",
+        "Feat"
+      ]
+    },
+    {
+      "level": 8,
+      "name": "Ability Score Improvement",
+      "description": "Increase one ability score by 2, two ability scores by 1, or take a feat if allowed.",
+      "count": 1,
+      "type": "Ability Score Improvement",
+      "selection": [
+        "Increase one ability score by 2",
+        "Increase two ability scores by 1",
+        "Feat"
+      ]
+    },
+    {
+      "level": 12,
+      "name": "Ability Score Improvement",
+      "description": "Increase one ability score by 2, two ability scores by 1, or take a feat if allowed.",
+      "count": 1,
+      "type": "Ability Score Improvement",
+      "selection": [
+        "Increase one ability score by 2",
+        "Increase two ability scores by 1",
+        "Feat"
+      ]
+    },
+    {
+      "level": 16,
+      "name": "Ability Score Improvement",
+      "description": "Increase one ability score by 2, two ability scores by 1, or take a feat if allowed.",
+      "count": 1,
+      "type": "Ability Score Improvement",
+      "selection": [
+        "Increase one ability score by 2",
+        "Increase two ability scores by 1",
+        "Feat"
+      ]
+    },
+    {
+      "level": 19,
+      "name": "Ability Score Improvement",
+      "description": "Increase one ability score by 2, two ability scores by 1, or take a feat if allowed.",
+      "count": 1,
+      "type": "Ability Score Improvement",
+      "selection": [
+        "Increase one ability score by 2",
+        "Increase two ability scores by 1",
+        "Feat"
+      ]
     }
   ]
 }

--- a/data/classes/fighter.json
+++ b/data/classes/fighter.json
@@ -63,6 +63,90 @@
         "Protection",
         "Two-Weapon Fighting"
       ]
+    },
+    {
+      "level": 4,
+      "name": "Ability Score Improvement",
+      "description": "Increase one ability score by 2, two ability scores by 1, or take a feat if allowed.",
+      "count": 1,
+      "type": "Ability Score Improvement",
+      "selection": [
+        "Increase one ability score by 2",
+        "Increase two ability scores by 1",
+        "Feat"
+      ]
+    },
+    {
+      "level": 6,
+      "name": "Ability Score Improvement",
+      "description": "Increase one ability score by 2, two ability scores by 1, or take a feat if allowed.",
+      "count": 1,
+      "type": "Ability Score Improvement",
+      "selection": [
+        "Increase one ability score by 2",
+        "Increase two ability scores by 1",
+        "Feat"
+      ]
+    },
+    {
+      "level": 8,
+      "name": "Ability Score Improvement",
+      "description": "Increase one ability score by 2, two ability scores by 1, or take a feat if allowed.",
+      "count": 1,
+      "type": "Ability Score Improvement",
+      "selection": [
+        "Increase one ability score by 2",
+        "Increase two ability scores by 1",
+        "Feat"
+      ]
+    },
+    {
+      "level": 12,
+      "name": "Ability Score Improvement",
+      "description": "Increase one ability score by 2, two ability scores by 1, or take a feat if allowed.",
+      "count": 1,
+      "type": "Ability Score Improvement",
+      "selection": [
+        "Increase one ability score by 2",
+        "Increase two ability scores by 1",
+        "Feat"
+      ]
+    },
+    {
+      "level": 14,
+      "name": "Ability Score Improvement",
+      "description": "Increase one ability score by 2, two ability scores by 1, or take a feat if allowed.",
+      "count": 1,
+      "type": "Ability Score Improvement",
+      "selection": [
+        "Increase one ability score by 2",
+        "Increase two ability scores by 1",
+        "Feat"
+      ]
+    },
+    {
+      "level": 16,
+      "name": "Ability Score Improvement",
+      "description": "Increase one ability score by 2, two ability scores by 1, or take a feat if allowed.",
+      "count": 1,
+      "type": "Ability Score Improvement",
+      "selection": [
+        "Increase one ability score by 2",
+        "Increase two ability scores by 1",
+        "Feat"
+      ]
+    },
+    {
+      "level": 19,
+      "name": "Ability Score Improvement",
+      "description": "Increase one ability score by 2, two ability scores by 1, or take a feat if allowed.",
+      "count": 1,
+      "type": "Ability Score Improvement",
+      "selection": [
+        "Increase one ability score by 2",
+        "Increase two ability scores by 1",
+        "Feat"
+      ]
     }
   ]
 }

--- a/data/classes/monk.json
+++ b/data/classes/monk.json
@@ -56,6 +56,66 @@
         "Quarterstaff",
         "Spear"
       ]
+    },
+    {
+      "level": 4,
+      "name": "Ability Score Improvement",
+      "description": "Increase one ability score by 2, two ability scores by 1, or take a feat if allowed.",
+      "count": 1,
+      "type": "Ability Score Improvement",
+      "selection": [
+        "Increase one ability score by 2",
+        "Increase two ability scores by 1",
+        "Feat"
+      ]
+    },
+    {
+      "level": 8,
+      "name": "Ability Score Improvement",
+      "description": "Increase one ability score by 2, two ability scores by 1, or take a feat if allowed.",
+      "count": 1,
+      "type": "Ability Score Improvement",
+      "selection": [
+        "Increase one ability score by 2",
+        "Increase two ability scores by 1",
+        "Feat"
+      ]
+    },
+    {
+      "level": 12,
+      "name": "Ability Score Improvement",
+      "description": "Increase one ability score by 2, two ability scores by 1, or take a feat if allowed.",
+      "count": 1,
+      "type": "Ability Score Improvement",
+      "selection": [
+        "Increase one ability score by 2",
+        "Increase two ability scores by 1",
+        "Feat"
+      ]
+    },
+    {
+      "level": 16,
+      "name": "Ability Score Improvement",
+      "description": "Increase one ability score by 2, two ability scores by 1, or take a feat if allowed.",
+      "count": 1,
+      "type": "Ability Score Improvement",
+      "selection": [
+        "Increase one ability score by 2",
+        "Increase two ability scores by 1",
+        "Feat"
+      ]
+    },
+    {
+      "level": 19,
+      "name": "Ability Score Improvement",
+      "description": "Increase one ability score by 2, two ability scores by 1, or take a feat if allowed.",
+      "count": 1,
+      "type": "Ability Score Improvement",
+      "selection": [
+        "Increase one ability score by 2",
+        "Increase two ability scores by 1",
+        "Feat"
+      ]
     }
   ]
 }

--- a/data/classes/paladin.json
+++ b/data/classes/paladin.json
@@ -60,6 +60,66 @@
         "Great Weapon Fighting",
         "Protection"
       ]
+    },
+    {
+      "level": 4,
+      "name": "Ability Score Improvement",
+      "description": "Increase one ability score by 2, two ability scores by 1, or take a feat if allowed.",
+      "count": 1,
+      "type": "Ability Score Improvement",
+      "selection": [
+        "Increase one ability score by 2",
+        "Increase two ability scores by 1",
+        "Feat"
+      ]
+    },
+    {
+      "level": 8,
+      "name": "Ability Score Improvement",
+      "description": "Increase one ability score by 2, two ability scores by 1, or take a feat if allowed.",
+      "count": 1,
+      "type": "Ability Score Improvement",
+      "selection": [
+        "Increase one ability score by 2",
+        "Increase two ability scores by 1",
+        "Feat"
+      ]
+    },
+    {
+      "level": 12,
+      "name": "Ability Score Improvement",
+      "description": "Increase one ability score by 2, two ability scores by 1, or take a feat if allowed.",
+      "count": 1,
+      "type": "Ability Score Improvement",
+      "selection": [
+        "Increase one ability score by 2",
+        "Increase two ability scores by 1",
+        "Feat"
+      ]
+    },
+    {
+      "level": 16,
+      "name": "Ability Score Improvement",
+      "description": "Increase one ability score by 2, two ability scores by 1, or take a feat if allowed.",
+      "count": 1,
+      "type": "Ability Score Improvement",
+      "selection": [
+        "Increase one ability score by 2",
+        "Increase two ability scores by 1",
+        "Feat"
+      ]
+    },
+    {
+      "level": 19,
+      "name": "Ability Score Improvement",
+      "description": "Increase one ability score by 2, two ability scores by 1, or take a feat if allowed.",
+      "count": 1,
+      "type": "Ability Score Improvement",
+      "selection": [
+        "Increase one ability score by 2",
+        "Increase two ability scores by 1",
+        "Feat"
+      ]
     }
   ]
 }

--- a/data/classes/ranger.json
+++ b/data/classes/ranger.json
@@ -66,6 +66,66 @@
         "Swamp",
         "Underdark"
       ]
+    },
+    {
+      "level": 4,
+      "name": "Ability Score Improvement",
+      "description": "Increase one ability score by 2, two ability scores by 1, or take a feat if allowed.",
+      "count": 1,
+      "type": "Ability Score Improvement",
+      "selection": [
+        "Increase one ability score by 2",
+        "Increase two ability scores by 1",
+        "Feat"
+      ]
+    },
+    {
+      "level": 8,
+      "name": "Ability Score Improvement",
+      "description": "Increase one ability score by 2, two ability scores by 1, or take a feat if allowed.",
+      "count": 1,
+      "type": "Ability Score Improvement",
+      "selection": [
+        "Increase one ability score by 2",
+        "Increase two ability scores by 1",
+        "Feat"
+      ]
+    },
+    {
+      "level": 12,
+      "name": "Ability Score Improvement",
+      "description": "Increase one ability score by 2, two ability scores by 1, or take a feat if allowed.",
+      "count": 1,
+      "type": "Ability Score Improvement",
+      "selection": [
+        "Increase one ability score by 2",
+        "Increase two ability scores by 1",
+        "Feat"
+      ]
+    },
+    {
+      "level": 16,
+      "name": "Ability Score Improvement",
+      "description": "Increase one ability score by 2, two ability scores by 1, or take a feat if allowed.",
+      "count": 1,
+      "type": "Ability Score Improvement",
+      "selection": [
+        "Increase one ability score by 2",
+        "Increase two ability scores by 1",
+        "Feat"
+      ]
+    },
+    {
+      "level": 19,
+      "name": "Ability Score Improvement",
+      "description": "Increase one ability score by 2, two ability scores by 1, or take a feat if allowed.",
+      "count": 1,
+      "type": "Ability Score Improvement",
+      "selection": [
+        "Increase one ability score by 2",
+        "Increase two ability scores by 1",
+        "Feat"
+      ]
     }
   ]
 }

--- a/data/classes/rogue.json
+++ b/data/classes/rogue.json
@@ -66,6 +66,78 @@
         "Persuasion",
         "Stealth"
       ]
+    },
+    {
+      "level": 4,
+      "name": "Ability Score Improvement",
+      "description": "Increase one ability score by 2, two ability scores by 1, or take a feat if allowed.",
+      "count": 1,
+      "type": "Ability Score Improvement",
+      "selection": [
+        "Increase one ability score by 2",
+        "Increase two ability scores by 1",
+        "Feat"
+      ]
+    },
+    {
+      "level": 8,
+      "name": "Ability Score Improvement",
+      "description": "Increase one ability score by 2, two ability scores by 1, or take a feat if allowed.",
+      "count": 1,
+      "type": "Ability Score Improvement",
+      "selection": [
+        "Increase one ability score by 2",
+        "Increase two ability scores by 1",
+        "Feat"
+      ]
+    },
+    {
+      "level": 10,
+      "name": "Ability Score Improvement",
+      "description": "Increase one ability score by 2, two ability scores by 1, or take a feat if allowed.",
+      "count": 1,
+      "type": "Ability Score Improvement",
+      "selection": [
+        "Increase one ability score by 2",
+        "Increase two ability scores by 1",
+        "Feat"
+      ]
+    },
+    {
+      "level": 12,
+      "name": "Ability Score Improvement",
+      "description": "Increase one ability score by 2, two ability scores by 1, or take a feat if allowed.",
+      "count": 1,
+      "type": "Ability Score Improvement",
+      "selection": [
+        "Increase one ability score by 2",
+        "Increase two ability scores by 1",
+        "Feat"
+      ]
+    },
+    {
+      "level": 16,
+      "name": "Ability Score Improvement",
+      "description": "Increase one ability score by 2, two ability scores by 1, or take a feat if allowed.",
+      "count": 1,
+      "type": "Ability Score Improvement",
+      "selection": [
+        "Increase one ability score by 2",
+        "Increase two ability scores by 1",
+        "Feat"
+      ]
+    },
+    {
+      "level": 19,
+      "name": "Ability Score Improvement",
+      "description": "Increase one ability score by 2, two ability scores by 1, or take a feat if allowed.",
+      "count": 1,
+      "type": "Ability Score Improvement",
+      "selection": [
+        "Increase one ability score by 2",
+        "Increase two ability scores by 1",
+        "Feat"
+      ]
     }
   ]
 }

--- a/data/classes/sorcerer.json
+++ b/data/classes/sorcerer.json
@@ -54,6 +54,66 @@
         "Subtle Spell",
         "Twinned Spell"
       ]
+    },
+    {
+      "level": 4,
+      "name": "Ability Score Improvement",
+      "description": "Increase one ability score by 2, two ability scores by 1, or take a feat if allowed.",
+      "count": 1,
+      "type": "Ability Score Improvement",
+      "selection": [
+        "Increase one ability score by 2",
+        "Increase two ability scores by 1",
+        "Feat"
+      ]
+    },
+    {
+      "level": 8,
+      "name": "Ability Score Improvement",
+      "description": "Increase one ability score by 2, two ability scores by 1, or take a feat if allowed.",
+      "count": 1,
+      "type": "Ability Score Improvement",
+      "selection": [
+        "Increase one ability score by 2",
+        "Increase two ability scores by 1",
+        "Feat"
+      ]
+    },
+    {
+      "level": 12,
+      "name": "Ability Score Improvement",
+      "description": "Increase one ability score by 2, two ability scores by 1, or take a feat if allowed.",
+      "count": 1,
+      "type": "Ability Score Improvement",
+      "selection": [
+        "Increase one ability score by 2",
+        "Increase two ability scores by 1",
+        "Feat"
+      ]
+    },
+    {
+      "level": 16,
+      "name": "Ability Score Improvement",
+      "description": "Increase one ability score by 2, two ability scores by 1, or take a feat if allowed.",
+      "count": 1,
+      "type": "Ability Score Improvement",
+      "selection": [
+        "Increase one ability score by 2",
+        "Increase two ability scores by 1",
+        "Feat"
+      ]
+    },
+    {
+      "level": 19,
+      "name": "Ability Score Improvement",
+      "description": "Increase one ability score by 2, two ability scores by 1, or take a feat if allowed.",
+      "count": 1,
+      "type": "Ability Score Improvement",
+      "selection": [
+        "Increase one ability score by 2",
+        "Increase two ability scores by 1",
+        "Feat"
+      ]
     }
   ]
 }

--- a/data/classes/warlock.json
+++ b/data/classes/warlock.json
@@ -56,6 +56,66 @@
         "Pact of the Blade",
         "Pact of the Tome"
       ]
+    },
+    {
+      "level": 4,
+      "name": "Ability Score Improvement",
+      "description": "Increase one ability score by 2, two ability scores by 1, or take a feat if allowed.",
+      "count": 1,
+      "type": "Ability Score Improvement",
+      "selection": [
+        "Increase one ability score by 2",
+        "Increase two ability scores by 1",
+        "Feat"
+      ]
+    },
+    {
+      "level": 8,
+      "name": "Ability Score Improvement",
+      "description": "Increase one ability score by 2, two ability scores by 1, or take a feat if allowed.",
+      "count": 1,
+      "type": "Ability Score Improvement",
+      "selection": [
+        "Increase one ability score by 2",
+        "Increase two ability scores by 1",
+        "Feat"
+      ]
+    },
+    {
+      "level": 12,
+      "name": "Ability Score Improvement",
+      "description": "Increase one ability score by 2, two ability scores by 1, or take a feat if allowed.",
+      "count": 1,
+      "type": "Ability Score Improvement",
+      "selection": [
+        "Increase one ability score by 2",
+        "Increase two ability scores by 1",
+        "Feat"
+      ]
+    },
+    {
+      "level": 16,
+      "name": "Ability Score Improvement",
+      "description": "Increase one ability score by 2, two ability scores by 1, or take a feat if allowed.",
+      "count": 1,
+      "type": "Ability Score Improvement",
+      "selection": [
+        "Increase one ability score by 2",
+        "Increase two ability scores by 1",
+        "Feat"
+      ]
+    },
+    {
+      "level": 19,
+      "name": "Ability Score Improvement",
+      "description": "Increase one ability score by 2, two ability scores by 1, or take a feat if allowed.",
+      "count": 1,
+      "type": "Ability Score Improvement",
+      "selection": [
+        "Increase one ability score by 2",
+        "Increase two ability scores by 1",
+        "Feat"
+      ]
     }
   ]
 }

--- a/data/classes/wizard.json
+++ b/data/classes/wizard.json
@@ -110,6 +110,66 @@
         "Ray of Frost",
         "Light"
       ]
+    },
+    {
+      "level": 4,
+      "name": "Ability Score Improvement",
+      "description": "Increase one ability score by 2, two ability scores by 1, or take a feat if allowed.",
+      "count": 1,
+      "type": "Ability Score Improvement",
+      "selection": [
+        "Increase one ability score by 2",
+        "Increase two ability scores by 1",
+        "Feat"
+      ]
+    },
+    {
+      "level": 8,
+      "name": "Ability Score Improvement",
+      "description": "Increase one ability score by 2, two ability scores by 1, or take a feat if allowed.",
+      "count": 1,
+      "type": "Ability Score Improvement",
+      "selection": [
+        "Increase one ability score by 2",
+        "Increase two ability scores by 1",
+        "Feat"
+      ]
+    },
+    {
+      "level": 12,
+      "name": "Ability Score Improvement",
+      "description": "Increase one ability score by 2, two ability scores by 1, or take a feat if allowed.",
+      "count": 1,
+      "type": "Ability Score Improvement",
+      "selection": [
+        "Increase one ability score by 2",
+        "Increase two ability scores by 1",
+        "Feat"
+      ]
+    },
+    {
+      "level": 16,
+      "name": "Ability Score Improvement",
+      "description": "Increase one ability score by 2, two ability scores by 1, or take a feat if allowed.",
+      "count": 1,
+      "type": "Ability Score Improvement",
+      "selection": [
+        "Increase one ability score by 2",
+        "Increase two ability scores by 1",
+        "Feat"
+      ]
+    },
+    {
+      "level": 19,
+      "name": "Ability Score Improvement",
+      "description": "Increase one ability score by 2, two ability scores by 1, or take a feat if allowed.",
+      "count": 1,
+      "type": "Ability Score Improvement",
+      "selection": [
+        "Increase one ability score by 2",
+        "Increase two ability scores by 1",
+        "Feat"
+      ]
     }
   ]
 }

--- a/data/subclasses/abjuration.json
+++ b/data/subclasses/abjuration.json
@@ -40,7 +40,8 @@
       "selection": [
         "Abjuration Option 1",
         "Abjuration Option 2"
-      ]
+      ],
+      "type": "Abjuration Feature"
     }
   ]
 }

--- a/data/subclasses/alchemist.json
+++ b/data/subclasses/alchemist.json
@@ -44,7 +44,8 @@
       "selection": [
         "Alchemist Option 1",
         "Alchemist Option 2"
-      ]
+      ],
+      "type": "Alchemist Feature"
     }
   ]
 }

--- a/data/subclasses/ancestral_guardian.json
+++ b/data/subclasses/ancestral_guardian.json
@@ -36,7 +36,8 @@
       "selection": [
         "Ancestral Guardian Option 1",
         "Ancestral Guardian Option 2"
-      ]
+      ],
+      "type": "Ancestral Guardian Feature"
     }
   ]
 }

--- a/data/subclasses/ancients.json
+++ b/data/subclasses/ancients.json
@@ -40,7 +40,8 @@
       "selection": [
         "Oath of the Ancients Option 1",
         "Oath of the Ancients Option 2"
-      ]
+      ],
+      "type": "Oath of the Ancients Feature"
     }
   ]
 }

--- a/data/subclasses/arcana.json
+++ b/data/subclasses/arcana.json
@@ -42,7 +42,8 @@
       "selection": [
         "Arcana Domain Option 1",
         "Arcana Domain Option 2"
-      ]
+      ],
+      "type": "Arcana Domain Feature"
     }
   ]
 }

--- a/data/subclasses/arcane_trickster.json
+++ b/data/subclasses/arcane_trickster.json
@@ -40,7 +40,8 @@
       "selection": [
         "Arcane Trickster Option 1",
         "Arcane Trickster Option 2"
-      ]
+      ],
+      "type": "Arcane Trickster Feature"
     }
   ]
 }

--- a/data/subclasses/archfey.json
+++ b/data/subclasses/archfey.json
@@ -36,7 +36,8 @@
       "selection": [
         "The Archfey Option 1",
         "The Archfey Option 2"
-      ]
+      ],
+      "type": "The Archfey Feature"
     }
   ]
 }

--- a/data/subclasses/armorer.json
+++ b/data/subclasses/armorer.json
@@ -48,7 +48,8 @@
       "selection": [
         "Armorer Option 1",
         "Armorer Option 2"
-      ]
+      ],
+      "type": "Armorer Feature"
     }
   ]
 }

--- a/data/subclasses/artillerist.json
+++ b/data/subclasses/artillerist.json
@@ -44,7 +44,8 @@
       "selection": [
         "Artillerist Option 1",
         "Artillerist Option 2"
-      ]
+      ],
+      "type": "Artillerist Feature"
     }
   ]
 }

--- a/data/subclasses/assassin.json
+++ b/data/subclasses/assassin.json
@@ -40,7 +40,8 @@
       "selection": [
         "Assassin Option 1",
         "Assassin Option 2"
-      ]
+      ],
+      "type": "Assassin Feature"
     }
   ]
 }

--- a/data/subclasses/barbarian_wild_magic.json
+++ b/data/subclasses/barbarian_wild_magic.json
@@ -40,7 +40,8 @@
       "selection": [
         "Wild Magic Option 1",
         "Wild Magic Option 2"
-      ]
+      ],
+      "type": "Wild Magic Feature"
     }
   ]
 }

--- a/data/subclasses/battle_master.json
+++ b/data/subclasses/battle_master.json
@@ -40,7 +40,8 @@
       "selection": [
         "Battle Master Option 1",
         "Battle Master Option 2"
-      ]
+      ],
+      "type": "Battle Master Feature"
     }
   ]
 }

--- a/data/subclasses/battle_smith.json
+++ b/data/subclasses/battle_smith.json
@@ -48,7 +48,8 @@
       "selection": [
         "Battle Smith Option 1",
         "Battle Smith Option 2"
-      ]
+      ],
+      "type": "Battle Smith Feature"
     }
   ]
 }

--- a/data/subclasses/battlerager.json
+++ b/data/subclasses/battlerager.json
@@ -40,7 +40,8 @@
       "selection": [
         "Battlerager Option 1",
         "Battlerager Option 2"
-      ]
+      ],
+      "type": "Battlerager Feature"
     }
   ]
 }

--- a/data/subclasses/beast.json
+++ b/data/subclasses/beast.json
@@ -36,7 +36,8 @@
       "selection": [
         "Beast Option 1",
         "Beast Option 2"
-      ]
+      ],
+      "type": "Beast Feature"
     }
   ]
 }

--- a/data/subclasses/beast_master.json
+++ b/data/subclasses/beast_master.json
@@ -36,7 +36,8 @@
       "selection": [
         "Beast Master Option 1",
         "Beast Master Option 2"
-      ]
+      ],
+      "type": "Beast Master Feature"
     }
   ]
 }

--- a/data/subclasses/berserker.json
+++ b/data/subclasses/berserker.json
@@ -36,7 +36,8 @@
       "selection": [
         "Berserker Option 1",
         "Berserker Option 2"
-      ]
+      ],
+      "type": "Berserker Feature"
     }
   ]
 }

--- a/data/subclasses/champion.json
+++ b/data/subclasses/champion.json
@@ -42,7 +42,8 @@
       "selection": [
         "Champion Option 1",
         "Champion Option 2"
-      ]
+      ],
+      "type": "Champion Feature"
     }
   ]
 }

--- a/data/subclasses/circle_of_dreams.json
+++ b/data/subclasses/circle_of_dreams.json
@@ -36,7 +36,8 @@
       "selection": [
         "Circle of Dreams Option 1",
         "Circle of Dreams Option 2"
-      ]
+      ],
+      "type": "Circle of Dreams Feature"
     }
   ]
 }

--- a/data/subclasses/circle_of_spores.json
+++ b/data/subclasses/circle_of_spores.json
@@ -44,7 +44,8 @@
       "selection": [
         "Circle of Spores Option 1",
         "Circle of Spores Option 2"
-      ]
+      ],
+      "type": "Circle of Spores Feature"
     }
   ]
 }

--- a/data/subclasses/circle_of_stars.json
+++ b/data/subclasses/circle_of_stars.json
@@ -40,7 +40,8 @@
       "selection": [
         "Circle of Stars Option 1",
         "Circle of Stars Option 2"
-      ]
+      ],
+      "type": "Circle of Stars Feature"
     }
   ]
 }

--- a/data/subclasses/circle_of_the_blighted.json
+++ b/data/subclasses/circle_of_the_blighted.json
@@ -48,7 +48,8 @@
       "selection": [
         "Circle of the Blighted Option 1",
         "Circle of the Blighted Option 2"
-      ]
+      ],
+      "type": "Circle of the Blighted Feature"
     }
   ]
 }

--- a/data/subclasses/circle_of_the_land.json
+++ b/data/subclasses/circle_of_the_land.json
@@ -44,7 +44,8 @@
       "selection": [
         "Circle of the Land Option 1",
         "Circle of the Land Option 2"
-      ]
+      ],
+      "type": "Circle of the Land Feature"
     }
   ]
 }

--- a/data/subclasses/circle_of_the_moon.json
+++ b/data/subclasses/circle_of_the_moon.json
@@ -40,7 +40,8 @@
       "selection": [
         "Circle of the Moon Option 1",
         "Circle of the Moon Option 2"
-      ]
+      ],
+      "type": "Circle of the Moon Feature"
     }
   ]
 }

--- a/data/subclasses/circle_of_the_shepherd.json
+++ b/data/subclasses/circle_of_the_shepherd.json
@@ -40,7 +40,8 @@
       "selection": [
         "Circle of the Shepherd Option 1",
         "Circle of the Shepherd Option 2"
-      ]
+      ],
+      "type": "Circle of the Shepherd Feature"
     }
   ]
 }

--- a/data/subclasses/circle_of_wildfire.json
+++ b/data/subclasses/circle_of_wildfire.json
@@ -40,7 +40,8 @@
       "selection": [
         "Circle of Wildfire Option 1",
         "Circle of Wildfire Option 2"
-      ]
+      ],
+      "type": "Circle of Wildfire Feature"
     }
   ]
 }

--- a/data/subclasses/college_of_creation.json
+++ b/data/subclasses/college_of_creation.json
@@ -34,7 +34,8 @@
       "selection": [
         "College of Creation Option 1",
         "College of Creation Option 2"
-      ]
+      ],
+      "type": "College of Creation Feature"
     }
   ]
 }

--- a/data/subclasses/college_of_eloquence.json
+++ b/data/subclasses/college_of_eloquence.json
@@ -38,7 +38,8 @@
       "selection": [
         "College of Eloquence Option 1",
         "College of Eloquence Option 2"
-      ]
+      ],
+      "type": "College of Eloquence Feature"
     }
   ]
 }

--- a/data/subclasses/college_of_glamour.json
+++ b/data/subclasses/college_of_glamour.json
@@ -34,7 +34,8 @@
       "selection": [
         "College of Glamour Option 1",
         "College of Glamour Option 2"
-      ]
+      ],
+      "type": "College of Glamour Feature"
     }
   ]
 }

--- a/data/subclasses/college_of_lore.json
+++ b/data/subclasses/college_of_lore.json
@@ -34,7 +34,8 @@
       "selection": [
         "College of Lore Option 1",
         "College of Lore Option 2"
-      ]
+      ],
+      "type": "College of Lore Feature"
     }
   ]
 }

--- a/data/subclasses/college_of_spirits.json
+++ b/data/subclasses/college_of_spirits.json
@@ -38,7 +38,8 @@
       "selection": [
         "College of Spirits Option 1",
         "College of Spirits Option 2"
-      ]
+      ],
+      "type": "College of Spirits Feature"
     }
   ]
 }

--- a/data/subclasses/college_of_swords.json
+++ b/data/subclasses/college_of_swords.json
@@ -38,7 +38,8 @@
       "selection": [
         "College of Swords Option 1",
         "College of Swords Option 2"
-      ]
+      ],
+      "type": "College of Swords Feature"
     }
   ]
 }

--- a/data/subclasses/college_of_valor.json
+++ b/data/subclasses/college_of_valor.json
@@ -34,7 +34,8 @@
       "selection": [
         "College of Valor Option 1",
         "College of Valor Option 2"
-      ]
+      ],
+      "type": "College of Valor Feature"
     }
   ]
 }

--- a/data/subclasses/college_of_whispers.json
+++ b/data/subclasses/college_of_whispers.json
@@ -34,7 +34,8 @@
       "selection": [
         "College of Whispers Option 1",
         "College of Whispers Option 2"
-      ]
+      ],
+      "type": "College of Whispers Feature"
     }
   ]
 }

--- a/data/subclasses/conjuration.json
+++ b/data/subclasses/conjuration.json
@@ -40,7 +40,8 @@
       "selection": [
         "Conjuration Option 1",
         "Conjuration Option 2"
-      ]
+      ],
+      "type": "Conjuration Feature"
     }
   ]
 }

--- a/data/subclasses/death.json
+++ b/data/subclasses/death.json
@@ -46,7 +46,8 @@
       "selection": [
         "Death Domain Option 1",
         "Death Domain Option 2"
-      ]
+      ],
+      "type": "Death Domain Feature"
     }
   ]
 }

--- a/data/subclasses/devotion.json
+++ b/data/subclasses/devotion.json
@@ -40,7 +40,8 @@
       "selection": [
         "Oath of Devotion Option 1",
         "Oath of Devotion Option 2"
-      ]
+      ],
+      "type": "Oath of Devotion Feature"
     }
   ]
 }

--- a/data/subclasses/divination.json
+++ b/data/subclasses/divination.json
@@ -40,7 +40,8 @@
       "selection": [
         "Divination Option 1",
         "Divination Option 2"
-      ]
+      ],
+      "type": "Divination Feature"
     }
   ]
 }

--- a/data/subclasses/draconic_bloodline.json
+++ b/data/subclasses/draconic_bloodline.json
@@ -40,7 +40,8 @@
       "selection": [
         "Draconic Bloodline Option 1",
         "Draconic Bloodline Option 2"
-      ]
+      ],
+      "type": "Draconic Bloodline Feature"
     }
   ]
 }

--- a/data/subclasses/eldritch_knight.json
+++ b/data/subclasses/eldritch_knight.json
@@ -46,7 +46,8 @@
       "selection": [
         "Eldritch Knight Option 1",
         "Eldritch Knight Option 2"
-      ]
+      ],
+      "type": "Eldritch Knight Feature"
     }
   ]
 }

--- a/data/subclasses/enchantment.json
+++ b/data/subclasses/enchantment.json
@@ -40,7 +40,8 @@
       "selection": [
         "Enchantment Option 1",
         "Enchantment Option 2"
-      ]
+      ],
+      "type": "Enchantment Feature"
     }
   ]
 }

--- a/data/subclasses/evocation.json
+++ b/data/subclasses/evocation.json
@@ -40,7 +40,8 @@
       "selection": [
         "Evocation Option 1",
         "Evocation Option 2"
-      ]
+      ],
+      "type": "Evocation Feature"
     }
   ]
 }

--- a/data/subclasses/fiend.json
+++ b/data/subclasses/fiend.json
@@ -36,7 +36,8 @@
       "selection": [
         "The Fiend Option 1",
         "The Fiend Option 2"
-      ]
+      ],
+      "type": "The Fiend Feature"
     }
   ]
 }

--- a/data/subclasses/forge.json
+++ b/data/subclasses/forge.json
@@ -46,7 +46,8 @@
       "selection": [
         "Forge Domain Option 1",
         "Forge Domain Option 2"
-      ]
+      ],
+      "type": "Forge Domain Feature"
     }
   ]
 }

--- a/data/subclasses/four_elements.json
+++ b/data/subclasses/four_elements.json
@@ -36,7 +36,8 @@
       "selection": [
         "Way of the Four Elements Option 1",
         "Way of the Four Elements Option 2"
-      ]
+      ],
+      "type": "Way of the Four Elements Feature"
     }
   ]
 }

--- a/data/subclasses/giant.json
+++ b/data/subclasses/giant.json
@@ -40,7 +40,8 @@
       "selection": [
         "Giant Option 1",
         "Giant Option 2"
-      ]
+      ],
+      "type": "Giant Feature"
     }
   ]
 }

--- a/data/subclasses/grave.json
+++ b/data/subclasses/grave.json
@@ -46,7 +46,8 @@
       "selection": [
         "Grave Domain Option 1",
         "Grave Domain Option 2"
-      ]
+      ],
+      "type": "Grave Domain Feature"
     }
   ]
 }

--- a/data/subclasses/great_old_one.json
+++ b/data/subclasses/great_old_one.json
@@ -36,7 +36,8 @@
       "selection": [
         "The Great Old One Option 1",
         "The Great Old One Option 2"
-      ]
+      ],
+      "type": "The Great Old One Feature"
     }
   ]
 }

--- a/data/subclasses/hunter.json
+++ b/data/subclasses/hunter.json
@@ -36,7 +36,8 @@
       "selection": [
         "Hunter Option 1",
         "Hunter Option 2"
-      ]
+      ],
+      "type": "Hunter Feature"
     }
   ]
 }

--- a/data/subclasses/illusion.json
+++ b/data/subclasses/illusion.json
@@ -40,7 +40,8 @@
       "selection": [
         "Illusion Option 1",
         "Illusion Option 2"
-      ]
+      ],
+      "type": "Illusion Feature"
     }
   ]
 }

--- a/data/subclasses/knowledge.json
+++ b/data/subclasses/knowledge.json
@@ -42,7 +42,8 @@
       "selection": [
         "Knowledge Domain Option 1",
         "Knowledge Domain Option 2"
-      ]
+      ],
+      "type": "Knowledge Domain Feature"
     }
   ]
 }

--- a/data/subclasses/life.json
+++ b/data/subclasses/life.json
@@ -46,7 +46,8 @@
       "selection": [
         "Life Domain Option 1",
         "Life Domain Option 2"
-      ]
+      ],
+      "type": "Life Domain Feature"
     }
   ]
 }

--- a/data/subclasses/light.json
+++ b/data/subclasses/light.json
@@ -46,7 +46,8 @@
       "selection": [
         "Light Domain Option 1",
         "Light Domain Option 2"
-      ]
+      ],
+      "type": "Light Domain Feature"
     }
   ]
 }

--- a/data/subclasses/nature.json
+++ b/data/subclasses/nature.json
@@ -46,7 +46,8 @@
       "selection": [
         "Nature Domain Option 1",
         "Nature Domain Option 2"
-      ]
+      ],
+      "type": "Nature Domain Feature"
     }
   ]
 }

--- a/data/subclasses/necromancy.json
+++ b/data/subclasses/necromancy.json
@@ -40,7 +40,8 @@
       "selection": [
         "Necromancy Option 1",
         "Necromancy Option 2"
-      ]
+      ],
+      "type": "Necromancy Feature"
     }
   ]
 }

--- a/data/subclasses/open_hand.json
+++ b/data/subclasses/open_hand.json
@@ -36,7 +36,8 @@
       "selection": [
         "Way of the Open Hand Option 1",
         "Way of the Open Hand Option 2"
-      ]
+      ],
+      "type": "Way of the Open Hand Feature"
     }
   ]
 }

--- a/data/subclasses/order.json
+++ b/data/subclasses/order.json
@@ -46,7 +46,8 @@
       "selection": [
         "Order Domain Option 1",
         "Order Domain Option 2"
-      ]
+      ],
+      "type": "Order Domain Feature"
     }
   ]
 }

--- a/data/subclasses/peace.json
+++ b/data/subclasses/peace.json
@@ -46,7 +46,8 @@
       "selection": [
         "Peace Domain Option 1",
         "Peace Domain Option 2"
-      ]
+      ],
+      "type": "Peace Domain Feature"
     }
   ]
 }

--- a/data/subclasses/shadow.json
+++ b/data/subclasses/shadow.json
@@ -36,7 +36,8 @@
       "selection": [
         "Way of Shadow Option 1",
         "Way of Shadow Option 2"
-      ]
+      ],
+      "type": "Way of Shadow Feature"
     }
   ]
 }

--- a/data/subclasses/storm_herald.json
+++ b/data/subclasses/storm_herald.json
@@ -36,7 +36,8 @@
       "selection": [
         "Storm Herald Option 1",
         "Storm Herald Option 2"
-      ]
+      ],
+      "type": "Storm Herald Feature"
     }
   ]
 }

--- a/data/subclasses/tempest.json
+++ b/data/subclasses/tempest.json
@@ -46,7 +46,8 @@
       "selection": [
         "Tempest Domain Option 1",
         "Tempest Domain Option 2"
-      ]
+      ],
+      "type": "Tempest Domain Feature"
     }
   ]
 }

--- a/data/subclasses/thief.json
+++ b/data/subclasses/thief.json
@@ -40,7 +40,8 @@
       "selection": [
         "Thief Option 1",
         "Thief Option 2"
-      ]
+      ],
+      "type": "Thief Feature"
     }
   ]
 }

--- a/data/subclasses/totem_warrior.json
+++ b/data/subclasses/totem_warrior.json
@@ -40,7 +40,8 @@
       "selection": [
         "Totem Warrior Option 1",
         "Totem Warrior Option 2"
-      ]
+      ],
+      "type": "Totem Warrior Feature"
     }
   ]
 }

--- a/data/subclasses/transmutation.json
+++ b/data/subclasses/transmutation.json
@@ -40,7 +40,8 @@
       "selection": [
         "Transmutation Option 1",
         "Transmutation Option 2"
-      ]
+      ],
+      "type": "Transmutation Feature"
     }
   ]
 }

--- a/data/subclasses/trickery.json
+++ b/data/subclasses/trickery.json
@@ -42,7 +42,8 @@
       "selection": [
         "Trickery Domain Option 1",
         "Trickery Domain Option 2"
-      ]
+      ],
+      "type": "Trickery Domain Feature"
     }
   ]
 }

--- a/data/subclasses/twilight.json
+++ b/data/subclasses/twilight.json
@@ -50,7 +50,8 @@
       "selection": [
         "Twilight Domain Option 1",
         "Twilight Domain Option 2"
-      ]
+      ],
+      "type": "Twilight Domain Feature"
     }
   ]
 }

--- a/data/subclasses/vengeance.json
+++ b/data/subclasses/vengeance.json
@@ -40,7 +40,8 @@
       "selection": [
         "Oath of Vengeance Option 1",
         "Oath of Vengeance Option 2"
-      ]
+      ],
+      "type": "Oath of Vengeance Feature"
     }
   ]
 }

--- a/data/subclasses/war.json
+++ b/data/subclasses/war.json
@@ -46,7 +46,8 @@
       "selection": [
         "War Domain Option 1",
         "War Domain Option 2"
-      ]
+      ],
+      "type": "War Domain Feature"
     }
   ]
 }

--- a/data/subclasses/wild_magic.json
+++ b/data/subclasses/wild_magic.json
@@ -40,7 +40,8 @@
       "selection": [
         "Wild Magic Option 1",
         "Wild Magic Option 2"
-      ]
+      ],
+      "type": "Wild Magic Feature"
     }
   ]
 }

--- a/data/subclasses/zealot.json
+++ b/data/subclasses/zealot.json
@@ -40,7 +40,8 @@
       "selection": [
         "Zealot Option 1",
         "Zealot Option 2"
-      ]
+      ],
+      "type": "Zealot Feature"
     }
   ]
 }

--- a/js/script.js
+++ b/js/script.js
@@ -649,7 +649,8 @@ const extraCategoryAliases = {
   "Fighting Style": "Fighting Style",
   "Additional Fighting Style": "Fighting Style",
   "Divine Domain": "Divine Domain",
-  "Metamagic": "Metamagic"
+  "Metamagic": "Metamagic",
+  "Ability Score Improvement": "Ability Score Improvement"
 };
 
 const extraCategoryDescriptions = {
@@ -658,7 +659,8 @@ const extraCategoryDescriptions = {
   "Tool Proficiency": "Seleziona le competenze negli strumenti.",
   "Fighting Style": "Scegli il tuo stile di combattimento.",
   "Divine Domain": "Seleziona il tuo dominio divino.",
-  "Metamagic": "Scegli le opzioni di Metamagia."
+  "Metamagic": "Scegli le opzioni di Metamagia.",
+  "Ability Score Improvement": "Aumenta i punteggi di caratteristica o scegli un talento."
 };
 
 /**


### PR DESCRIPTION
## Summary
- add ability score improvement choices to all classes
- include type selectors for all subclass choices
- document ability score improvement category in frontend script

## Testing
- `jq empty data/classes/*.json data/subclasses/*.json`
- `node --version` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68a458131ee4832ea6cffcbc9c59147f