### PR TITLE
fix: synchronize class choice counts

### DIFF
--- a/data/classes/artificer.json
+++ b/data/classes/artificer.json
@@ -201,7 +201,7 @@
       "level": 8,
       "name": "Ability Score Improvement",
       "description": "Increase one ability score by 2, two ability scores by 1, or take a feat if allowed.",
-      "count": 1,
+      "count": 2,
       "type": "Ability Score Improvement",
       "selection": [
         "Increase one ability score by 2",
@@ -213,7 +213,7 @@
       "level": 12,
       "name": "Ability Score Improvement",
       "description": "Increase one ability score by 2, two ability scores by 1, or take a feat if allowed.",
-      "count": 1,
+      "count": 3,
       "type": "Ability Score Improvement",
       "selection": [
         "Increase one ability score by 2",
@@ -225,7 +225,7 @@
       "level": 16,
       "name": "Ability Score Improvement",
       "description": "Increase one ability score by 2, two ability scores by 1, or take a feat if allowed.",
-      "count": 1,
+      "count": 4,
       "type": "Ability Score Improvement",
       "selection": [
         "Increase one ability score by 2",
@@ -237,7 +237,7 @@
       "level": 19,
       "name": "Ability Score Improvement",
       "description": "Increase one ability score by 2, two ability scores by 1, or take a feat if allowed.",
-      "count": 1,
+      "count": 5,
       "type": "Ability Score Improvement",
       "selection": [
         "Increase one ability score by 2",

--- a/data/classes/barbarian.json
+++ b/data/classes/barbarian.json
@@ -266,7 +266,7 @@
       "level": 8,
       "name": "Ability Score Improvement",
       "description": "Increase one ability score by 2, two ability scores by 1, or take a feat if allowed.",
-      "count": 1,
+      "count": 2,
       "type": "Ability Score Improvement",
       "selection": [
         "Increase one ability score by 2",
@@ -278,7 +278,7 @@
       "level": 12,
       "name": "Ability Score Improvement",
       "description": "Increase one ability score by 2, two ability scores by 1, or take a feat if allowed.",
-      "count": 1,
+      "count": 3,
       "type": "Ability Score Improvement",
       "selection": [
         "Increase one ability score by 2",
@@ -290,7 +290,7 @@
       "level": 16,
       "name": "Ability Score Improvement",
       "description": "Increase one ability score by 2, two ability scores by 1, or take a feat if allowed.",
-      "count": 1,
+      "count": 4,
       "type": "Ability Score Improvement",
       "selection": [
         "Increase one ability score by 2",
@@ -302,7 +302,7 @@
       "level": 19,
       "name": "Ability Score Improvement",
       "description": "Increase one ability score by 2, two ability scores by 1, or take a feat if allowed.",
-      "count": 1,
+      "count": 5,
       "type": "Ability Score Improvement",
       "selection": [
         "Increase one ability score by 2",

--- a/data/classes/bard.json
+++ b/data/classes/bard.json
@@ -263,7 +263,7 @@
       "level": 8,
       "name": "Ability Score Improvement",
       "description": "Increase one ability score by 2, two ability scores by 1, or take a feat if allowed.",
-      "count": 1,
+      "count": 2,
       "type": "Ability Score Improvement",
       "selection": [
         "Increase one ability score by 2",
@@ -272,10 +272,28 @@
       ]
     },
     {
+      "level": 10,
+      "name": "Expertise",
+      "description": "Choose two additional skills to gain expertise in",
+      "count": 4,
+      "type": "skills",
+      "selection": [
+        "Acrobatics",
+        "Athletics",
+        "Deception",
+        "Insight",
+        "Intimidation",
+        "Investigation",
+        "Performance",
+        "Persuasion",
+        "Stealth"
+      ]
+    },
+    {
       "level": 12,
       "name": "Ability Score Improvement",
       "description": "Increase one ability score by 2, two ability scores by 1, or take a feat if allowed.",
-      "count": 1,
+      "count": 3,
       "type": "Ability Score Improvement",
       "selection": [
         "Increase one ability score by 2",
@@ -287,7 +305,7 @@
       "level": 16,
       "name": "Ability Score Improvement",
       "description": "Increase one ability score by 2, two ability scores by 1, or take a feat if allowed.",
-      "count": 1,
+      "count": 4,
       "type": "Ability Score Improvement",
       "selection": [
         "Increase one ability score by 2",
@@ -299,7 +317,7 @@
       "level": 19,
       "name": "Ability Score Improvement",
       "description": "Increase one ability score by 2, two ability scores by 1, or take a feat if allowed.",
-      "count": 1,
+      "count": 5,
       "type": "Ability Score Improvement",
       "selection": [
         "Increase one ability score by 2",

--- a/data/classes/cleric.json
+++ b/data/classes/cleric.json
@@ -318,7 +318,7 @@
       "level": 8,
       "name": "Ability Score Improvement",
       "description": "Increase one ability score by 2, two ability scores by 1, or take a feat if allowed.",
-      "count": 1,
+      "count": 2,
       "type": "Ability Score Improvement",
       "selection": [
         "Increase one ability score by 2",
@@ -330,7 +330,7 @@
       "level": 12,
       "name": "Ability Score Improvement",
       "description": "Increase one ability score by 2, two ability scores by 1, or take a feat if allowed.",
-      "count": 1,
+      "count": 3,
       "type": "Ability Score Improvement",
       "selection": [
         "Increase one ability score by 2",
@@ -342,7 +342,7 @@
       "level": 16,
       "name": "Ability Score Improvement",
       "description": "Increase one ability score by 2, two ability scores by 1, or take a feat if allowed.",
-      "count": 1,
+      "count": 4,
       "type": "Ability Score Improvement",
       "selection": [
         "Increase one ability score by 2",
@@ -354,7 +354,7 @@
       "level": 19,
       "name": "Ability Score Improvement",
       "description": "Increase one ability score by 2, two ability scores by 1, or take a feat if allowed.",
-      "count": 1,
+      "count": 5,
       "type": "Ability Score Improvement",
       "selection": [
         "Increase one ability score by 2",

--- a/data/classes/druid.json
+++ b/data/classes/druid.json
@@ -218,7 +218,7 @@
       "level": 8,
       "name": "Ability Score Improvement",
       "description": "Increase one ability score by 2, two ability scores by 1, or take a feat if allowed.",
-      "count": 1,
+      "count": 2,
       "type": "Ability Score Improvement",
       "selection": [
         "Increase one ability score by 2",
@@ -230,7 +230,7 @@
       "level": 12,
       "name": "Ability Score Improvement",
       "description": "Increase one ability score by 2, two ability scores by 1, or take a feat if allowed.",
-      "count": 1,
+      "count": 3,
       "type": "Ability Score Improvement",
       "selection": [
         "Increase one ability score by 2",
@@ -242,7 +242,7 @@
       "level": 16,
       "name": "Ability Score Improvement",
       "description": "Increase one ability score by 2, two ability scores by 1, or take a feat if allowed.",
-      "count": 1,
+      "count": 4,
       "type": "Ability Score Improvement",
       "selection": [
         "Increase one ability score by 2",
@@ -254,7 +254,7 @@
       "level": 19,
       "name": "Ability Score Improvement",
       "description": "Increase one ability score by 2, two ability scores by 1, or take a feat if allowed.",
-      "count": 1,
+      "count": 5,
       "type": "Ability Score Improvement",
       "selection": [
         "Increase one ability score by 2",

--- a/data/classes/fighter.json
+++ b/data/classes/fighter.json
@@ -80,7 +80,7 @@
       "level": 6,
       "name": "Ability Score Improvement",
       "description": "Increase one ability score by 2, two ability scores by 1, or take a feat if allowed.",
-      "count": 1,
+      "count": 2,
       "type": "Ability Score Improvement",
       "selection": [
         "Increase one ability score by 2",
@@ -92,7 +92,7 @@
       "level": 8,
       "name": "Ability Score Improvement",
       "description": "Increase one ability score by 2, two ability scores by 1, or take a feat if allowed.",
-      "count": 1,
+      "count": 3,
       "type": "Ability Score Improvement",
       "selection": [
         "Increase one ability score by 2",
@@ -101,10 +101,25 @@
       ]
     },
     {
+      "level": 10,
+      "name": "Additional Fighting Style",
+      "description": "Choose an additional fighting style",
+      "count": 2,
+      "type": "fighting style",
+      "selection": [
+        "Archery",
+        "Defense",
+        "Dueling",
+        "Great Weapon Fighting",
+        "Protection",
+        "Two-Weapon Fighting"
+      ]
+    },
+    {
       "level": 12,
       "name": "Ability Score Improvement",
       "description": "Increase one ability score by 2, two ability scores by 1, or take a feat if allowed.",
-      "count": 1,
+      "count": 4,
       "type": "Ability Score Improvement",
       "selection": [
         "Increase one ability score by 2",
@@ -116,7 +131,7 @@
       "level": 14,
       "name": "Ability Score Improvement",
       "description": "Increase one ability score by 2, two ability scores by 1, or take a feat if allowed.",
-      "count": 1,
+      "count": 5,
       "type": "Ability Score Improvement",
       "selection": [
         "Increase one ability score by 2",
@@ -128,7 +143,7 @@
       "level": 16,
       "name": "Ability Score Improvement",
       "description": "Increase one ability score by 2, two ability scores by 1, or take a feat if allowed.",
-      "count": 1,
+      "count": 6,
       "type": "Ability Score Improvement",
       "selection": [
         "Increase one ability score by 2",
@@ -140,7 +155,7 @@
       "level": 19,
       "name": "Ability Score Improvement",
       "description": "Increase one ability score by 2, two ability scores by 1, or take a feat if allowed.",
-      "count": 1,
+      "count": 7,
       "type": "Ability Score Improvement",
       "selection": [
         "Increase one ability score by 2",

--- a/data/classes/monk.json
+++ b/data/classes/monk.json
@@ -73,7 +73,7 @@
       "level": 8,
       "name": "Ability Score Improvement",
       "description": "Increase one ability score by 2, two ability scores by 1, or take a feat if allowed.",
-      "count": 1,
+      "count": 2,
       "type": "Ability Score Improvement",
       "selection": [
         "Increase one ability score by 2",
@@ -85,7 +85,7 @@
       "level": 12,
       "name": "Ability Score Improvement",
       "description": "Increase one ability score by 2, two ability scores by 1, or take a feat if allowed.",
-      "count": 1,
+      "count": 3,
       "type": "Ability Score Improvement",
       "selection": [
         "Increase one ability score by 2",
@@ -97,7 +97,7 @@
       "level": 16,
       "name": "Ability Score Improvement",
       "description": "Increase one ability score by 2, two ability scores by 1, or take a feat if allowed.",
-      "count": 1,
+      "count": 4,
       "type": "Ability Score Improvement",
       "selection": [
         "Increase one ability score by 2",
@@ -109,7 +109,7 @@
       "level": 19,
       "name": "Ability Score Improvement",
       "description": "Increase one ability score by 2, two ability scores by 1, or take a feat if allowed.",
-      "count": 1,
+      "count": 5,
       "type": "Ability Score Improvement",
       "selection": [
         "Increase one ability score by 2",

--- a/data/classes/paladin.json
+++ b/data/classes/paladin.json
@@ -77,7 +77,7 @@
       "level": 8,
       "name": "Ability Score Improvement",
       "description": "Increase one ability score by 2, two ability scores by 1, or take a feat if allowed.",
-      "count": 1,
+      "count": 2,
       "type": "Ability Score Improvement",
       "selection": [
         "Increase one ability score by 2",
@@ -89,7 +89,7 @@
       "level": 12,
       "name": "Ability Score Improvement",
       "description": "Increase one ability score by 2, two ability scores by 1, or take a feat if allowed.",
-      "count": 1,
+      "count": 3,
       "type": "Ability Score Improvement",
       "selection": [
         "Increase one ability score by 2",
@@ -101,7 +101,7 @@
       "level": 16,
       "name": "Ability Score Improvement",
       "description": "Increase one ability score by 2, two ability scores by 1, or take a feat if allowed.",
-      "count": 1,
+      "count": 4,
       "type": "Ability Score Improvement",
       "selection": [
         "Increase one ability score by 2",
@@ -113,7 +113,7 @@
       "level": 19,
       "name": "Ability Score Improvement",
       "description": "Increase one ability score by 2, two ability scores by 1, or take a feat if allowed.",
-      "count": 1,
+      "count": 5,
       "type": "Ability Score Improvement",
       "selection": [
         "Increase one ability score by 2",

--- a/data/classes/ranger.json
+++ b/data/classes/ranger.json
@@ -83,7 +83,7 @@
       "level": 8,
       "name": "Ability Score Improvement",
       "description": "Increase one ability score by 2, two ability scores by 1, or take a feat if allowed.",
-      "count": 1,
+      "count": 2,
       "type": "Ability Score Improvement",
       "selection": [
         "Increase one ability score by 2",
@@ -95,7 +95,7 @@
       "level": 12,
       "name": "Ability Score Improvement",
       "description": "Increase one ability score by 2, two ability scores by 1, or take a feat if allowed.",
-      "count": 1,
+      "count": 3,
       "type": "Ability Score Improvement",
       "selection": [
         "Increase one ability score by 2",
@@ -107,7 +107,7 @@
       "level": 16,
       "name": "Ability Score Improvement",
       "description": "Increase one ability score by 2, two ability scores by 1, or take a feat if allowed.",
-      "count": 1,
+      "count": 4,
       "type": "Ability Score Improvement",
       "selection": [
         "Increase one ability score by 2",
@@ -119,7 +119,7 @@
       "level": 19,
       "name": "Ability Score Improvement",
       "description": "Increase one ability score by 2, two ability scores by 1, or take a feat if allowed.",
-      "count": 1,
+      "count": 5,
       "type": "Ability Score Improvement",
       "selection": [
         "Increase one ability score by 2",

--- a/data/classes/rogue.json
+++ b/data/classes/rogue.json
@@ -80,10 +80,29 @@
       ]
     },
     {
+      "level": 6,
+      "name": "Expertise",
+      "description": "Choose two additional skills to gain expertise in",
+      "count": 4,
+      "type": "skills",
+      "selection": [
+        "Acrobatics",
+        "Athletics",
+        "Deception",
+        "Insight",
+        "Intimidation",
+        "Investigation",
+        "Perception",
+        "Performance",
+        "Persuasion",
+        "Stealth"
+      ]
+    },
+    {
       "level": 8,
       "name": "Ability Score Improvement",
       "description": "Increase one ability score by 2, two ability scores by 1, or take a feat if allowed.",
-      "count": 1,
+      "count": 2,
       "type": "Ability Score Improvement",
       "selection": [
         "Increase one ability score by 2",
@@ -95,7 +114,7 @@
       "level": 10,
       "name": "Ability Score Improvement",
       "description": "Increase one ability score by 2, two ability scores by 1, or take a feat if allowed.",
-      "count": 1,
+      "count": 3,
       "type": "Ability Score Improvement",
       "selection": [
         "Increase one ability score by 2",
@@ -107,7 +126,7 @@
       "level": 12,
       "name": "Ability Score Improvement",
       "description": "Increase one ability score by 2, two ability scores by 1, or take a feat if allowed.",
-      "count": 1,
+      "count": 4,
       "type": "Ability Score Improvement",
       "selection": [
         "Increase one ability score by 2",
@@ -119,7 +138,7 @@
       "level": 16,
       "name": "Ability Score Improvement",
       "description": "Increase one ability score by 2, two ability scores by 1, or take a feat if allowed.",
-      "count": 1,
+      "count": 5,
       "type": "Ability Score Improvement",
       "selection": [
         "Increase one ability score by 2",
@@ -131,7 +150,7 @@
       "level": 19,
       "name": "Ability Score Improvement",
       "description": "Increase one ability score by 2, two ability scores by 1, or take a feat if allowed.",
-      "count": 1,
+      "count": 6,
       "type": "Ability Score Improvement",
       "selection": [
         "Increase one ability score by 2",

--- a/data/classes/sorcerer.json
+++ b/data/classes/sorcerer.json
@@ -71,7 +71,7 @@
       "level": 8,
       "name": "Ability Score Improvement",
       "description": "Increase one ability score by 2, two ability scores by 1, or take a feat if allowed.",
-      "count": 1,
+      "count": 2,
       "type": "Ability Score Improvement",
       "selection": [
         "Increase one ability score by 2",
@@ -80,10 +80,27 @@
       ]
     },
     {
+      "level": 10,
+      "name": "Metamagic",
+      "description": "Choose an additional Metamagic option",
+      "count": 3,
+      "type": "metamagic",
+      "selection": [
+        "Careful Spell",
+        "Distant Spell",
+        "Empowered Spell",
+        "Extended Spell",
+        "Heightened Spell",
+        "Quickened Spell",
+        "Subtle Spell",
+        "Twinned Spell"
+      ]
+    },
+    {
       "level": 12,
       "name": "Ability Score Improvement",
       "description": "Increase one ability score by 2, two ability scores by 1, or take a feat if allowed.",
-      "count": 1,
+      "count": 3,
       "type": "Ability Score Improvement",
       "selection": [
         "Increase one ability score by 2",
@@ -95,7 +112,7 @@
       "level": 16,
       "name": "Ability Score Improvement",
       "description": "Increase one ability score by 2, two ability scores by 1, or take a feat if allowed.",
-      "count": 1,
+      "count": 4,
       "type": "Ability Score Improvement",
       "selection": [
         "Increase one ability score by 2",
@@ -104,10 +121,27 @@
       ]
     },
     {
+      "level": 17,
+      "name": "Metamagic",
+      "description": "Choose an additional Metamagic option",
+      "count": 4,
+      "type": "metamagic",
+      "selection": [
+        "Careful Spell",
+        "Distant Spell",
+        "Empowered Spell",
+        "Extended Spell",
+        "Heightened Spell",
+        "Quickened Spell",
+        "Subtle Spell",
+        "Twinned Spell"
+      ]
+    },
+    {
       "level": 19,
       "name": "Ability Score Improvement",
       "description": "Increase one ability score by 2, two ability scores by 1, or take a feat if allowed.",
-      "count": 1,
+      "count": 5,
       "type": "Ability Score Improvement",
       "selection": [
         "Increase one ability score by 2",

--- a/data/classes/warlock.json
+++ b/data/classes/warlock.json
@@ -73,7 +73,7 @@
       "level": 8,
       "name": "Ability Score Improvement",
       "description": "Increase one ability score by 2, two ability scores by 1, or take a feat if allowed.",
-      "count": 1,
+      "count": 2,
       "type": "Ability Score Improvement",
       "selection": [
         "Increase one ability score by 2",
@@ -85,7 +85,7 @@
       "level": 12,
       "name": "Ability Score Improvement",
       "description": "Increase one ability score by 2, two ability scores by 1, or take a feat if allowed.",
-      "count": 1,
+      "count": 3,
       "type": "Ability Score Improvement",
       "selection": [
         "Increase one ability score by 2",
@@ -97,7 +97,7 @@
       "level": 16,
       "name": "Ability Score Improvement",
       "description": "Increase one ability score by 2, two ability scores by 1, or take a feat if allowed.",
-      "count": 1,
+      "count": 4,
       "type": "Ability Score Improvement",
       "selection": [
         "Increase one ability score by 2",
@@ -109,7 +109,7 @@
       "level": 19,
       "name": "Ability Score Improvement",
       "description": "Increase one ability score by 2, two ability scores by 1, or take a feat if allowed.",
-      "count": 1,
+      "count": 5,
       "type": "Ability Score Improvement",
       "selection": [
         "Increase one ability score by 2",

--- a/data/classes/wizard.json
+++ b/data/classes/wizard.json
@@ -127,7 +127,7 @@
       "level": 8,
       "name": "Ability Score Improvement",
       "description": "Increase one ability score by 2, two ability scores by 1, or take a feat if allowed.",
-      "count": 1,
+      "count": 2,
       "type": "Ability Score Improvement",
       "selection": [
         "Increase one ability score by 2",
@@ -139,7 +139,7 @@
       "level": 12,
       "name": "Ability Score Improvement",
       "description": "Increase one ability score by 2, two ability scores by 1, or take a feat if allowed.",
-      "count": 1,
+      "count": 3,
       "type": "Ability Score Improvement",
       "selection": [
         "Increase one ability score by 2",
@@ -151,7 +151,7 @@
       "level": 16,
       "name": "Ability Score Improvement",
       "description": "Increase one ability score by 2, two ability scores by 1, or take a feat if allowed.",
-      "count": 1,
+      "count": 4,
       "type": "Ability Score Improvement",
       "selection": [
         "Increase one ability score by 2",
@@ -163,7 +163,7 @@
       "level": 19,
       "name": "Ability Score Improvement",
       "description": "Increase one ability score by 2, two ability scores by 1, or take a feat if allowed.",
-      "count": 1,
+      "count": 5,
       "type": "Ability Score Improvement",
       "selection": [
         "Increase one ability score by 2",


### PR DESCRIPTION
## Summary
- ensure repeated class choices track cumulative totals
- add missing choices for additional fighter fighting style, sorcerer metamagic, bard and rogue expertise

## Testing
- `node - <<'NODE'
const fs=require('fs');const path='data/classes';
let ok=true;
fs.readdirSync(path).forEach(file=>{const data=JSON.parse(fs.readFileSync(`${path}/${file}`,'utf8'));if(data.choices){const map={};data.choices.forEach(ch=>{if(map[ch.name] && ch.count<=map[ch.name]){console.log('Non-increasing',file,ch.name,ch.count);ok=false;}map[ch.name]=ch.count;});}});
if(ok)console.log('All counts increasing');
NODE`


------
https://chatgpt.com/codex/tasks/task_e_68a45cb7c0b4832e827bc13b823af910