### PR TITLE
Add background selection with feat-driven ability boosts

### DIFF
--- a/data/backgrounds.json
+++ b/data/backgrounds.json
@@ -1,0 +1,6 @@
+{
+  "backgrounds": {
+    "Acolyte": "data/backgrounds/acolyte.json",
+    "Soldier": "data/backgrounds/soldier.json"
+  }
+}

--- a/data/backgrounds/acolyte.json
+++ b/data/backgrounds/acolyte.json
@@ -1,0 +1,10 @@
+{
+  "name": "Acolyte",
+  "skills": ["Insight", "Religion"],
+  "tools": ["Calligrapher's supplies"],
+  "languages": {
+    "choose": 1,
+    "options": ["Celestial", "Draconic", "Dwarvish"]
+  },
+  "featOptions": ["Chef", "Durable"]
+}

--- a/data/backgrounds/soldier.json
+++ b/data/backgrounds/soldier.json
@@ -1,0 +1,10 @@
+{
+  "name": "Soldier",
+  "skills": ["Athletics", "Intimidation"],
+  "tools": {
+    "choose": 1,
+    "options": ["Smith's tools", "Vehicles (land)"]
+  },
+  "languages": [],
+  "featOptions": ["Athlete"]
+}

--- a/index.html
+++ b/index.html
@@ -6,6 +6,7 @@
   <title>Character Creator - Foundry</title>
   <!-- Includi il file script.js unificato -->
   <script src="js/script.js" defer></script>
+  <script src="js/step5.js" defer></script>
   <style>
     /* Stili per un look moderno e una buona UX */
     body {
@@ -112,7 +113,8 @@
     <button id="btnStep2">Step 2: Razza</button>
     <button id="btnStep3">Step 3: Point Buy</button>
     <button id="btnStep4">Step 4: Classe</button>
-    <button id="btnStep5">Step 5: Equipaggiamento</button>
+    <button id="btnStep5">Step 5: Background</button>
+    <button id="btnStep6">Step 6: Equipaggiamento</button>
     <button id="btnStep8">Step 8: Recap & Esportazione</button>
   </nav>
   <!-- Container degli step -->
@@ -345,6 +347,12 @@
           <td id="chaFinalScore">8</td>
         </tr>
       </table>
+      <input type="hidden" id="strBackgroundTalent" value="0">
+      <input type="hidden" id="dexBackgroundTalent" value="0">
+      <input type="hidden" id="conBackgroundTalent" value="0">
+      <input type="hidden" id="intBackgroundTalent" value="0">
+      <input type="hidden" id="wisBackgroundTalent" value="0">
+      <input type="hidden" id="chaBackgroundTalent" value="0">
     </div>
     <!-- Step 4: Tratti Extra -->
     <div id="step4" class="step">
@@ -365,6 +373,22 @@
       <div id="divineDomainSelection"></div>
       <div id="metamagicSelection"></div>
       <div id="abilityImprovementSelection"></div>
+    </div>
+    <!-- Step 5: Background -->
+    <div id="step5" class="step">
+      <h2>Step 5: Background</h2>
+      <label for="backgroundSelect">Background:</label>
+      <select id="backgroundSelect">
+        <option value="">Seleziona un background</option>
+      </select>
+      <div id="backgroundSkills"></div>
+      <div id="backgroundTools"></div>
+      <div id="backgroundLanguages"></div>
+      <div id="backgroundFeat"></div>
+    </div>
+    <!-- Step 6: Equipaggiamento -->
+    <div id="step6" class="step">
+      <h2>Step 6: Equipaggiamento</h2>
     </div>
     <!-- Step 8: Recap & Esportazione -->
     <div id="step8" class="step">
@@ -391,6 +415,7 @@
       document.getElementById("btnStep3").addEventListener("click", () => showStep("step3"));
       document.getElementById("btnStep4").addEventListener("click", () => showStep("step4"));
       document.getElementById("btnStep5").addEventListener("click", () => showStep("step5"));
+      document.getElementById("btnStep6").addEventListener("click", () => showStep("step6"));
       document.getElementById("btnStep8").addEventListener("click", () => showStep("step8"));
       // Inizialmente mostra lo step 1
       showStep("step1");

--- a/js/script.js
+++ b/js/script.js
@@ -1319,6 +1319,7 @@ function generateFinalJson() {
     race: document.getElementById("raceSelect").selectedOptions[0]?.text || "Nessuna",
     class: document.getElementById("classSelect").selectedOptions[0]?.text || "Nessuna",
     subclass: document.getElementById("subclassSelect").selectedOptions[0]?.text || "Nessuna",
+    background: window.backgroundData ? window.backgroundData.name : "Nessuno",
     stats: {
       strength: document.getElementById("strFinalScore").textContent,
       dexterity: document.getElementById("dexFinalScore").textContent,
@@ -1335,6 +1336,12 @@ function generateFinalJson() {
       wisdom: document.getElementById("wisRaceModifier").textContent,
       charisma: document.getElementById("chaRaceModifier").textContent
     },
+    background_proficiencies: window.backgroundData ? {
+      skills: window.backgroundData.skills || [],
+      tools: window.backgroundData.tools || [],
+      languages: window.backgroundData.languages || []
+    } : { skills: [], tools: [], languages: [] },
+    background_feat: window.backgroundData ? window.backgroundData.feat || "" : "",
     languages: {
       selected: selectedData["Languages"] || []
     },
@@ -1480,6 +1487,7 @@ document.addEventListener("DOMContentLoaded", () => {
   document.getElementById("btnStep3").addEventListener("click", () => showStep("step3"));
   document.getElementById("btnStep4").addEventListener("click", () => showStep("step4"));
   document.getElementById("btnStep5").addEventListener("click", () => showStep("step5"));
+  document.getElementById("btnStep6").addEventListener("click", () => showStep("step6"));
 
   const classSelectElem = document.getElementById("classSelect");
   const subclassSelectElem = document.getElementById("subclassSelect");

--- a/js/step5.js
+++ b/js/step5.js
@@ -1,0 +1,170 @@
+// Step 5: Background selection and feat handling
+
+let featPathIndex = {};
+let currentFeatData = null;
+
+function resetBackgroundTalentFields() {
+  ["str", "dex", "con", "int", "wis", "cha"].forEach(ab => {
+    const el = document.getElementById(ab + "BackgroundTalent");
+    if (el) el.value = 0;
+  });
+}
+
+function applyFeatAbilityChoices() {
+  resetBackgroundTalentFields();
+  if (currentFeatData && currentFeatData.fixedAbilities) {
+    currentFeatData.fixedAbilities.forEach(obj => {
+      const ability = Object.keys(obj)[0];
+      const val = obj[ability];
+      const el = document.getElementById(ability + "BackgroundTalent");
+      if (el) el.value = val;
+    });
+  }
+  const selects = document.querySelectorAll(".featAbilityChoice");
+  selects.forEach(sel => {
+    if (sel.value) {
+      const amt = parseInt(sel.dataset.amount || "1");
+      const el = document.getElementById(sel.value + "BackgroundTalent");
+      if (el) el.value = amt;
+    }
+  });
+  updateFinalScores();
+}
+
+document.addEventListener("DOMContentLoaded", () => {
+  const step = document.getElementById("step5");
+  if (!step) return;
+
+  window.backgroundData = { name: "", skills: [], tools: [], languages: [], feat: "" };
+
+  loadDropdownData("data/backgrounds.json", "backgroundSelect", "backgrounds");
+  fetch("data/feats.json").then(r => r.json()).then(d => { featPathIndex = d.feats || {}; });
+
+  document.getElementById("backgroundSelect").addEventListener("change", async e => {
+    const val = e.target.value;
+    if (!val) return;
+    const res = await fetch(val);
+    const data = await res.json();
+    backgroundData.name = data.name;
+
+    const skillDiv = document.getElementById("backgroundSkills");
+    skillDiv.innerHTML = "";
+    backgroundData.skills = Array.isArray(data.skills) ? data.skills.slice() : [];
+    if (backgroundData.skills.length > 0) {
+      skillDiv.innerHTML = `<p><strong>Abilità:</strong> ${backgroundData.skills.join(", ")}</p>`;
+    }
+    if (data.skillChoices) {
+      const num = data.skillChoices.choose || 0;
+      const opts = data.skillChoices.options || [];
+      skillDiv.innerHTML += `<p><strong>Scegli ${num} abilità:</strong></p>`;
+      for (let i = 0; i < num; i++) {
+        const sel = document.createElement("select");
+        sel.className = "backgroundSkillChoice";
+        sel.innerHTML = `<option value="">Seleziona</option>` + opts.map(o => `<option value="${o}">${o}</option>`).join("");
+        sel.addEventListener("change", () => {
+          const chosen = Array.from(document.querySelectorAll(".backgroundSkillChoice")).map(s => s.value).filter(Boolean);
+          backgroundData.skills = (data.skills || []).concat(chosen);
+        });
+        skillDiv.appendChild(sel);
+      }
+    }
+
+    const toolDiv = document.getElementById("backgroundTools");
+    toolDiv.innerHTML = "";
+    backgroundData.tools = Array.isArray(data.tools) ? data.tools.slice() : [];
+    if (Array.isArray(data.tools) && data.tools.length > 0) {
+      toolDiv.innerHTML = `<p><strong>Strumenti:</strong> ${data.tools.join(", ")}</p>`;
+    }
+    if (data.tools && data.tools.choose) {
+      const num = data.tools.choose;
+      const opts = data.tools.options || [];
+      toolDiv.innerHTML += `<p><strong>Scegli ${num} strumento:</strong></p>`;
+      for (let i = 0; i < num; i++) {
+        const sel = document.createElement("select");
+        sel.className = "backgroundToolChoice";
+        sel.innerHTML = `<option value="">Seleziona</option>` + opts.map(o => `<option value="${o}">${o}</option>`).join("");
+        sel.addEventListener("change", () => {
+          const chosen = Array.from(document.querySelectorAll(".backgroundToolChoice")).map(s => s.value).filter(Boolean);
+          backgroundData.tools = chosen;
+        });
+        toolDiv.appendChild(sel);
+      }
+    }
+
+    const langDiv = document.getElementById("backgroundLanguages");
+    langDiv.innerHTML = "";
+    backgroundData.languages = Array.isArray(data.languages) ? data.languages.slice() : [];
+    if (Array.isArray(data.languages) && data.languages.length > 0) {
+      langDiv.innerHTML = `<p><strong>Linguaggi:</strong> ${data.languages.join(", ")}</p>`;
+    } else if (data.languages && data.languages.choose) {
+      const num = data.languages.choose;
+      const opts = data.languages.options || [];
+      langDiv.innerHTML = `<p><strong>Scegli ${num} linguaggi:</strong></p>`;
+      for (let i = 0; i < num; i++) {
+        const sel = document.createElement("select");
+        sel.className = "backgroundLanguageChoice";
+        sel.innerHTML = `<option value="">Seleziona</option>` + opts.map(o => `<option value="${o}">${o}</option>`).join("");
+        sel.addEventListener("change", () => {
+          const chosen = Array.from(document.querySelectorAll(".backgroundLanguageChoice")).map(s => s.value).filter(Boolean);
+          backgroundData.languages = chosen;
+        });
+        langDiv.appendChild(sel);
+      }
+    }
+
+    const featDiv = document.getElementById("backgroundFeat");
+    featDiv.innerHTML = "";
+    backgroundData.feat = "";
+    currentFeatData = null;
+    if (Array.isArray(data.featOptions) && data.featOptions.length > 0) {
+      const label = document.createElement("label");
+      label.htmlFor = "backgroundFeatSelect";
+      label.textContent = "Feat:";
+      const select = document.createElement("select");
+      select.id = "backgroundFeatSelect";
+      select.innerHTML = `<option value="">Seleziona un talento</option>` +
+        data.featOptions
+          .filter(name => featPathIndex[name])
+          .map(name => `<option value="${name}">${name}</option>`)
+          .join("");
+      const abilDiv = document.createElement("div");
+      abilDiv.id = "featAbilityChoices";
+      select.addEventListener("change", () => {
+        currentFeatData = null;
+        abilDiv.innerHTML = "";
+        backgroundData.feat = select.value || "";
+        resetBackgroundTalentFields();
+        if (!select.value || !featPathIndex[select.value]) {
+          updateFinalScores();
+          return;
+        }
+        fetch(featPathIndex[select.value])
+          .then(r => r.json())
+          .then(feat => {
+            const fixed = [];
+            if (feat.ability) {
+              feat.ability.forEach(ab => {
+                if (ab.choose) {
+                  const sel = document.createElement("select");
+                  sel.className = "featAbilityChoice";
+                  sel.dataset.amount = ab.choose.amount || 1;
+                  sel.innerHTML = `<option value="">Seleziona caratteristica</option>` +
+                    ab.choose.from.map(a => `<option value="${a}">${a.toUpperCase()}</option>`).join("");
+                  sel.addEventListener("change", applyFeatAbilityChoices);
+                  abilDiv.appendChild(sel);
+                } else {
+                  fixed.push(ab);
+                }
+              });
+            }
+            currentFeatData = { fixedAbilities: fixed };
+            applyFeatAbilityChoices();
+          });
+      });
+      featDiv.appendChild(label);
+      featDiv.appendChild(select);
+      featDiv.appendChild(abilDiv);
+    }
+  });
+});
+

--- a/js/step8.js
+++ b/js/step8.js
@@ -14,7 +14,13 @@ document.addEventListener("DOMContentLoaded", () => {
     const character = {
       name: document.getElementById("characterName") ? document.getElementById("characterName").value : "",
       level: document.getElementById("levelSelect") ? document.getElementById("levelSelect").value : "",
-      // Aggiungi qui gli altri campi raccolti dagli step precedenti
+      background: window.backgroundData ? window.backgroundData.name : "",
+      background_proficiencies: window.backgroundData ? {
+        skills: window.backgroundData.skills || [],
+        tools: window.backgroundData.tools || [],
+        languages: window.backgroundData.languages || []
+      } : { skills: [], tools: [], languages: [] },
+      background_feat: window.backgroundData ? window.backgroundData.feat || "" : ""
     };
     downloadJsonFile(character.name.replace(/[^a-z0-9]/gi, '_').toLowerCase() + "_character.json", character);
     document.getElementById("finalRecap").innerHTML = `<pre>${JSON.stringify(character, null, 2)}</pre>`;


### PR DESCRIPTION
## Summary
- add background dataset and loader to support background selection
- implement step 5 UI and logic for skills, tools, languages, and feats
- include background details in navigation and final export

## Testing
- `npm test` *(fails: ENOENT: no such file or directory, open '/workspace/foundry-character-creator/package.json')*

------
https://chatgpt.com/codex/tasks/task_e_68a48176c158832eaaa76119b067bf8d