### PR TITLE
refactor: modularize frontend scripts

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,9 +4,7 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Character Creator - Foundry</title>
-  <!-- Includi il file script.js unificato -->
-  <script src="js/script.js" defer></script>
-  <script src="js/step5.js" defer></script>
+  <script type="module" src="js/main.js"></script>
   <style>
     /* Stili per un look moderno e una buona UX */
     body {
@@ -397,29 +395,5 @@
       <button id="generateJson" class="primary">Genera JSON</button>
     </div>
   </div>
-  <!-- Script per la navigazione fra gli step -->
-  <script>
-    document.addEventListener("DOMContentLoaded", () => {
-      const steps = document.querySelectorAll(".step");
-      function showStep(stepId) {
-        steps.forEach(step => {
-          if (step.id === stepId) {
-            step.classList.add("active");
-          } else {
-            step.classList.remove("active");
-          }
-        });
-      }
-      document.getElementById("btnStep1").addEventListener("click", () => showStep("step1"));
-      document.getElementById("btnStep2").addEventListener("click", () => showStep("step2"));
-      document.getElementById("btnStep3").addEventListener("click", () => showStep("step3"));
-      document.getElementById("btnStep4").addEventListener("click", () => showStep("step4"));
-      document.getElementById("btnStep5").addEventListener("click", () => showStep("step5"));
-      document.getElementById("btnStep6").addEventListener("click", () => showStep("step6"));
-      document.getElementById("btnStep8").addEventListener("click", () => showStep("step8"));
-      // Inizialmente mostra lo step 1
-      showStep("step1");
-    });
-  </script>
 </body>
 </html>

--- a/js/common.js
+++ b/js/common.js
@@ -3,7 +3,7 @@
 // -------------------------
 // Caricamento dati e popolamento dropdown
 // -------------------------
-function loadDropdownData(jsonPath, selectId, key) {
+export function loadDropdownData(jsonPath, selectId, key) {
   fetch(jsonPath)
     .then(response => response.json())
     .then(data => {
@@ -21,7 +21,7 @@ function loadDropdownData(jsonPath, selectId, key) {
     .catch(error => handleError(`Errore caricando ${jsonPath}: ${error}`));
 }
 
-function populateDropdown(selectId, options) {
+export function populateDropdown(selectId, options) {
   const select = document.getElementById(selectId);
   if (!select) {
     handleError(`Elemento #${selectId} non trovato!`);
@@ -37,128 +37,9 @@ function populateDropdown(selectId, options) {
 }
 
 // -------------------------
-// Conversione dei dati della razza (raw JSON → formato standard)
-// -------------------------
-function convertRaceData(rawData) {
-  // Size
-  let size = "Unknown";
-  if (Array.isArray(rawData.size)) {
-    size = (rawData.size[0] === "M") ? "Medium" : (rawData.size[0] === "S") ? "Small" : rawData.size[0];
-  } else {
-    size = rawData.size || "Unknown";
-  }
-
-  // Speed
-  let speed = {};
-  if (rawData.speed) {
-    if (typeof rawData.speed === "object") {
-      for (let key in rawData.speed) {
-        speed[key] = (typeof rawData.speed[key] === "boolean")
-          ? (key === "fly" ? "equal to your walking speed" : "unknown")
-          : rawData.speed[key];
-      }
-    } else {
-      speed = rawData.speed;
-    }
-  }
-
-  // Senses
-  let senses = {};
-  if (rawData.senses && typeof rawData.senses === "object") {
-    senses = rawData.senses;
-  } else if (rawData.darkvision) {
-    senses.darkvision = rawData.darkvision;
-  }
-
-  // Ability Bonus (minimale gestione)
-  let ability_bonus = { options: [] };
-  if (rawData.ability && Array.isArray(rawData.ability)) {
-    rawData.ability.forEach(ability => {
-      if (ability.choose && ability.choose.weighted) {
-        const weights = ability.choose.weighted.weights;
-        if (weights.length === 2 && weights.includes(2)) {
-          ability_bonus.options.push({ type: "fixed", values: { any: 2, any_other: 1 } });
-        } else if (weights.length === 3) {
-          ability_bonus.options.push({ type: "three", values: { any: 1, any_other: 1, any_other_2: 1 } });
-        }
-      }
-    });
-  }
-
-  // Tratti
-  let traits = [];
-  const rawEntries = rawData.entries || [];
-  rawEntries.forEach(entry => {
-    if (entry.name && entry.entries) {
-      // Un semplice concatenamento dei testi delle entry
-      const description = Array.isArray(entry.entries) ? entry.entries.join(" ") : entry.entries;
-      traits.push({
-        name: entry.name,
-        description: description,
-        level_requirement: 1
-      });
-    }
-  });
-
-  // Lingue
-  let languages = { fixed: [], choice: 0, options: [] };
-  if (rawData.languageProficiencies && rawData.languageProficiencies.length > 0) {
-    const lp = rawData.languageProficiencies[0];
-    for (let lang in lp) {
-      if (lp[lang] === true) {
-        languages.fixed.push(lang.charAt(0).toUpperCase() + lang.slice(1));
-      } else if (typeof lp[lang] === "number") {
-        languages.choice = lp[lang];
-      }
-    }
-    if (languages.choice > 0 && languages.options.length === 0) {
-      languages.options.push("Any other language you and your DM agree is appropriate");
-    }
-  }
-
-  // Skill Choices
-  let skill_choices = null;
-  if (rawData.skillProficiencies && rawData.skillProficiencies.length > 0) {
-    const sp = rawData.skillProficiencies[0].choose;
-    if (sp && sp.from) {
-      const count = sp.count ? sp.count : 1;
-      skill_choices = { number: count, options: sp.from };
-    }
-  }
-
-  // Tool Choices
-  let tool_choices = null;
-  if (rawData.toolProficiencies && Array.isArray(rawData.toolProficiencies)) {
-    rawData.toolProficiencies.forEach(tp => {
-      if (tp.choose && tp.choose.from) {
-        tool_choices = { number: 1, options: tp.choose.from };
-      }
-    });
-  }
-
-  // Spellcasting (qui manteniamo la struttura originale, che potrà essere ulteriormente elaborata)
-  let spellcasting = rawData.additionalSpells || null;
-
-  return {
-    name: rawData.name,
-    source: rawData.source + (rawData.page ? `, page ${rawData.page}` : ""),
-    size: size,
-    speed: speed,
-    senses: senses,
-    ability_bonus: ability_bonus,
-    traits: traits,
-    rawEntries: rawEntries,
-    spellcasting: spellcasting,
-    languages: languages,
-    skill_choices: skill_choices,
-    tool_choices: tool_choices
-  };
-}
-
-// -------------------------
 // Funzione per caricare le lingue da un file JSON
 // -------------------------
-function loadLanguages(callback) {
+export function loadLanguages(callback) {
   fetch("data/languages.json")
     .then(response => response.json())
     .then(data => {
@@ -172,49 +53,9 @@ function loadLanguages(callback) {
 }
 
 // -------------------------
-// Helper per estrarre il nome di uno spell (ricorsivamente)
-// -------------------------
-function extractSpellName(data) {
-  if (Array.isArray(data)) {
-    if (typeof data[0] === "string") {
-      return data[0].split("#")[0];
-    }
-  } else if (typeof data === "object") {
-    for (let key in data) {
-      const result = extractSpellName(data[key]);
-      if (result) return result;
-    }
-  }
-  return null;
-}
-
-// -------------------------
-// Filtro incantesimi (es. "level=0|class=Wizard")
-// -------------------------
-function filterSpells(spells, filterString) {
-  const conditions = filterString.split("|");
-  return spells.filter(spell => {
-    let valid = true;
-    conditions.forEach(cond => {
-      const parts = cond.split("=");
-      if (parts.length === 2) {
-        const key = parts[0].trim().toLowerCase();
-        const value = parts[1].trim().toLowerCase();
-        if (key === "level") {
-          if (parseInt(spell.level) !== parseInt(value)) valid = false;
-        } else if (key === "class") {
-          if (!spell.spell_list.map(x => x.toLowerCase()).includes(value)) valid = false;
-        }
-      }
-    });
-    return valid;
-  });
-}
-
-// -------------------------
 // Funzione per mostrare un messaggio d'errore
 // -------------------------
-function handleError(message) {
+export function handleError(message) {
   console.error("❌ " + message);
   alert("⚠️ " + message);
 }
@@ -222,7 +63,7 @@ function handleError(message) {
 // -------------------------
 // Funzione per il rendering di tabelle (es. per alcune entry)
 // -------------------------
-function renderTables(entries) {
+export function renderTables(entries) {
   let html = "";
   if (!entries || !Array.isArray(entries)) return html;
   entries.forEach(entry => {

--- a/js/main.js
+++ b/js/main.js
@@ -1,0 +1,119 @@
+import { showStep } from './ui.js';
+import { convertRaceData } from './raceData.js';
+import { loadSpells, filterSpells } from './spellcasting.js';
+import { loadDropdownData, loadLanguages, handleError } from './common.js';
+import {
+  gatherExtraSelections,
+  updateSubclasses,
+  renderClassFeatures,
+  openExtrasModal,
+  displayRaceTraits,
+  generateFinalJson,
+  initializeValues,
+  setAvailableLanguages
+} from './script.js';
+import './step5.js';
+
+let classSelectionConfirmed = false;
+
+document.addEventListener('DOMContentLoaded', () => {
+  console.log('✅ Main.js caricato!');
+  const modal = document.getElementById('raceExtrasModal');
+  if (modal) modal.style.display = 'none';
+
+  if (sessionStorage.getItem('popupOpened') === 'true') {
+    console.log('🛑 Il pop-up non verrà riaperto automaticamente.');
+    sessionStorage.removeItem('popupOpened');
+  }
+
+  loadDropdownData('data/races.json', 'raceSelect', 'races');
+  loadDropdownData('data/classes.json', 'classSelect', 'classes');
+  loadLanguages(langs => {
+    setAvailableLanguages(langs);
+  });
+
+  document.getElementById('btnStep1').addEventListener('click', () => showStep('step1'));
+  document.getElementById('btnStep2').addEventListener('click', () => showStep('step2'));
+  document.getElementById('btnStep3').addEventListener('click', () => showStep('step3'));
+  document.getElementById('btnStep4').addEventListener('click', () => showStep('step4'));
+  document.getElementById('btnStep5').addEventListener('click', () => showStep('step5'));
+  document.getElementById('btnStep6').addEventListener('click', () => showStep('step6'));
+  document.getElementById('btnStep8').addEventListener('click', () => showStep('step8'));
+
+  const classSelectElem = document.getElementById('classSelect');
+  const subclassSelectElem = document.getElementById('subclassSelect');
+  const levelSelectElem = document.getElementById('levelSelect');
+  if (classSelectElem) classSelectElem.addEventListener('change', updateSubclasses);
+  if (subclassSelectElem)
+    subclassSelectElem.addEventListener('change', async () => {
+      const selections = await renderClassFeatures();
+      if (classSelectionConfirmed && selections.length > 0) {
+        openExtrasModal(selections, 'class');
+      }
+    });
+  if (levelSelectElem)
+    levelSelectElem.addEventListener('change', async () => {
+      const selections = await renderClassFeatures();
+      if (classSelectionConfirmed && selections.length > 0) {
+        openExtrasModal(selections, 'class');
+      }
+    });
+
+  showStep('step1');
+
+  document.getElementById('raceSelect').addEventListener('change', displayRaceTraits);
+  document.getElementById('levelSelect').addEventListener('change', () => displayRaceTraits());
+  document.getElementById('generateJson').addEventListener('click', generateFinalJson);
+
+  document.getElementById('confirmClassSelection').addEventListener('click', async () => {
+    const classSelect = document.getElementById('classSelect');
+    const subclassSelect = document.getElementById('subclassSelect');
+    if (!classSelect.value) {
+      alert('⚠️ Seleziona una classe prima di procedere!');
+      return;
+    }
+    if (subclassSelect.style.display !== 'none' && !subclassSelect.value) {
+      alert('⚠️ Seleziona una sottoclasse prima di procedere!');
+      return;
+    }
+    classSelectionConfirmed = true;
+    const selections = await renderClassFeatures();
+    if (selections.length > 0) {
+      openExtrasModal(selections, 'class');
+    }
+    classSelect.disabled = true;
+    subclassSelect.disabled = true;
+    document.getElementById('confirmClassSelection').style.display = 'none';
+  });
+
+  document.getElementById('confirmRaceSelection').addEventListener('click', () => {
+    const selectedRace = document.getElementById('raceSelect').value;
+    if (!selectedRace) {
+      alert('⚠️ Seleziona una razza prima di procedere!');
+      return;
+    }
+
+    fetch(selectedRace)
+      .then(response => response.json())
+      .then(data => {
+        const raceData = convertRaceData(data);
+        document.getElementById('raceTraits').style.display = 'none';
+        const selections = gatherExtraSelections(raceData, 'race');
+        if (raceData.spellcasting && raceData.spellcasting.spell_choices && raceData.spellcasting.spell_choices.type === 'filter') {
+          loadSpells(spellList => {
+            const filtered = filterSpells(spellList, raceData.spellcasting.spell_choices.filter).map(spell => spell.name);
+            selections.push({ name: 'Cantrips', description: 'Choose a spell.', selection: filtered, count: 1 });
+            sessionStorage.setItem('popupOpened', 'true');
+            openExtrasModal(selections);
+          });
+        } else {
+          sessionStorage.setItem('popupOpened', 'true');
+          openExtrasModal(selections);
+        }
+        document.getElementById('confirmRaceSelection').style.display = 'none';
+      })
+      .catch(error => handleError('Errore caricando i dati della razza: ' + error));
+  });
+
+  initializeValues();
+});

--- a/js/raceData.js
+++ b/js/raceData.js
@@ -1,0 +1,122 @@
+export function convertRaceData(rawData) {
+  // Size
+  let size = "Unknown";
+  if (Array.isArray(rawData.size)) {
+    size = (rawData.size[0] === "M") ? "Medium" : (rawData.size[0] === "S") ? "Small" : rawData.size[0];
+  } else {
+    size = rawData.size || "Unknown";
+  }
+
+  // Speed
+  let speed = {};
+  if (rawData.speed) {
+    if (typeof rawData.speed === 'object') {
+      for (let key in rawData.speed) {
+        speed[key] = (typeof rawData.speed[key] === 'boolean')
+          ? (key === 'fly' ? 'equal to your walking speed' : 'unknown')
+          : rawData.speed[key];
+      }
+    } else {
+      speed = rawData.speed;
+    }
+  }
+
+  // Senses
+  let senses = {};
+  if (rawData.senses && typeof rawData.senses === 'object') {
+    senses = rawData.senses;
+  } else if (rawData.darkvision) {
+    senses.darkvision = rawData.darkvision;
+  }
+
+  // Ability Bonus
+  let ability_bonus = { options: [] };
+  if (rawData.ability && Array.isArray(rawData.ability)) {
+    rawData.ability.forEach(ability => {
+      if (ability.choose && ability.choose.weighted) {
+        const weights = ability.choose.weighted.weights;
+        if (weights.length === 2 && weights.includes(2)) {
+          ability_bonus.options.push({ type: 'fixed', values: { any: 2, any_other: 1 } });
+        } else if (weights.length === 3) {
+          ability_bonus.options.push({ type: 'three', values: { any: 1, any_other: 1, any_other_2: 1 } });
+        }
+      }
+    });
+  }
+
+  // Variant Feature and Traits
+  let variant_feature_choices = null;
+  let traits = [];
+  const rawEntries = rawData.entries || [];
+  rawEntries.forEach(entry => {
+    if (entry.type === 'inset' && entry.name && entry.name.toLowerCase().includes('variant feature')) {
+      let variantText = '';
+      if (Array.isArray(entry.entries)) {
+        variantText = entry.entries.map(opt => {
+          let optDesc = Array.isArray(opt.entries) ? opt.entries.join(' ') : opt.entries;
+          return `${opt.name}: ${optDesc}`;
+        }).join(' | ');
+      }
+      traits.push({
+        name: entry.name,
+        description: variantText,
+        level_requirement: 1
+      });
+    }
+  });
+
+  // Languages
+  let languages = { fixed: [], choice: 0, options: [] };
+  if (rawData.languageProficiencies && rawData.languageProficiencies.length > 0) {
+    const lp = rawData.languageProficiencies[0];
+    for (let lang in lp) {
+      if (lp[lang] === true) {
+        languages.fixed.push(lang.charAt(0).toUpperCase() + lang.slice(1));
+      } else if (typeof lp[lang] === 'number') {
+        languages.choice = lp[lang];
+      }
+    }
+    if (languages.choice > 0 && languages.options.length === 0) {
+      languages.options.push('Any other language you and your DM agree is appropriate');
+    }
+  }
+
+  // Skill Choices
+  let skill_choices = null;
+  if (rawData.skillProficiencies && rawData.skillProficiencies.length > 0) {
+    const sp = rawData.skillProficiencies[0].choose;
+    if (sp && sp.from) {
+      const count = sp.count ? sp.count : 1;
+      skill_choices = { number: count, options: sp.from };
+    }
+  }
+
+  // Tool Choices
+  let tool_choices = null;
+  if (rawData.toolProficiencies && Array.isArray(rawData.toolProficiencies)) {
+    rawData.toolProficiencies.forEach(tp => {
+      if (tp.choose && tp.choose.from) {
+        tool_choices = { number: 1, options: tp.choose.from };
+      }
+    });
+  }
+
+  // Spellcasting (if present)
+  let spellcasting = rawData.additionalSpells || null;
+
+  return {
+    name: rawData.name,
+    source: rawData.source + (rawData.page ? `, page ${rawData.page}` : ''),
+    size: size,
+    speed: speed,
+    senses: senses,
+    ability_bonus: ability_bonus,
+    traits: traits,
+    rawEntries: rawEntries,
+    spellcasting: spellcasting,
+    languages: languages,
+    skill_choices: skill_choices,
+    tool_choices: tool_choices,
+    variant_feature_choices
+  };
+}

--- a/js/spellcasting.js
+++ b/js/spellcasting.js
@@ -1,0 +1,96 @@
+export function loadSpells(callback) {
+  fetch('data/spells.json')
+    .then(response => response.json())
+    .then(data => {
+      console.log('📖 Incantesimi caricati:', data);
+      callback(data);
+    })
+    .catch(error => console.error('❌ Errore nel caricamento degli incantesimi:', error));
+}
+
+export function filterSpells(spells, filterString) {
+  const conditions = filterString.split('|');
+  return spells.filter(spell => {
+    let valid = true;
+    conditions.forEach(cond => {
+      const parts = cond.split('=');
+      if (parts.length === 2) {
+        const key = parts[0].trim().toLowerCase();
+        const value = parts[1].trim().toLowerCase();
+        if (key === 'level') {
+          if (parseInt(spell.level) !== parseInt(value)) valid = false;
+        } else if (key === 'class') {
+          if (!spell.spell_list || !spell.spell_list.map(x => x.toLowerCase()).includes(value)) valid = false;
+        }
+      }
+    });
+    return valid;
+  });
+}
+
+export function handleSpellcasting(data, containerId) {
+  const container = document.getElementById(containerId);
+  if (!container) return;
+
+  container.innerHTML = '';
+
+  if (data.spellcasting) {
+    console.log(`🔍 JSON Spellcasting per ${data.name}:`, data.spellcasting);
+
+    if (data.spellcasting.fixed_spell) {
+      container.innerHTML += `<p><strong>✨ Incantesimo assegnato:</strong> ${data.spellcasting.fixed_spell}</p>`;
+    }
+
+    if (data.spellcasting.spell_choices) {
+      if (data.spellcasting.spell_choices.type === 'fixed_list') {
+        const options = data.spellcasting.spell_choices.options
+          .map(spell => `<option value="${spell}">${spell}</option>`)
+          .join('');
+        container.innerHTML += `
+          <p><strong>🔮 Scegli un incantesimo:</strong></p>
+          <select id="spellSelection">
+            <option value="">Seleziona...</option>${options}
+          </select>`;
+      } else if (data.spellcasting.spell_choices.type === 'filter') {
+        const filterParts = data.spellcasting.spell_choices.filter.split('|');
+        const spellLevel = filterParts.find(part => part.startsWith('level='))?.split('=')[1];
+        const spellClass = filterParts.find(part => part.startsWith('class='))?.split('=')[1];
+
+        if (spellLevel && spellClass) {
+          loadSpells(spellList => {
+            const filteredSpells = spellList
+              .filter(spell => parseInt(spell.level) === parseInt(spellLevel) && spell.spell_list.includes(spellClass))
+              .map(spell => `<option value="${spell.name}">${spell.name}</option>`)
+              .join('');
+
+            if (filteredSpells) {
+              container.innerHTML += `
+                <p><strong>🔮 Scegli un Cantrip da ${spellClass}:</strong></p>
+                <select id="spellSelection">
+                  <option value="">Seleziona...</option>${filteredSpells}
+                </select>`;
+            } else {
+              container.innerHTML += `<p><strong>⚠️ Nessun Cantrip disponibile per ${spellClass}.</strong></p>`;
+            }
+          });
+        } else {
+          container.innerHTML += `<p><strong>⚠️ Errore: Il filtro incantesimi non è valido per questa razza.</strong></p>`;
+        }
+      }
+    }
+
+    if (data.spellcasting.ability_choices && Array.isArray(data.spellcasting.ability_choices)) {
+      console.log(`🧙‍♂️ Verifica dell'abilità di lancio per ${data.name}:`, data.spellcasting.ability_choices);
+      if (data.spellcasting.ability_choices.length > 1) {
+        const abilityOptions = data.spellcasting.ability_choices
+          .map(a => `<option value="${a.toUpperCase()}">${a.toUpperCase()}</option>`)
+          .join('');
+        container.innerHTML += `
+          <p><strong>🧠 Seleziona l'abilità di lancio:</strong></p>
+          <select id="castingAbility">
+            <option value="">Seleziona...</option>${abilityOptions}
+          </select>`;
+      }
+    }
+  }
+}

--- a/js/step5.js
+++ b/js/step5.js
@@ -1,4 +1,5 @@
 // Step 5: Background selection and feat handling
+import { loadDropdownData } from './common.js';
 
 let featPathIndex = {};
 let currentFeatData = null;

--- a/js/ui.js
+++ b/js/ui.js
@@ -1,0 +1,10 @@
+export function showStep(stepId) {
+  const steps = document.querySelectorAll('.step');
+  steps.forEach(step => {
+    if (step.id === stepId) {
+      step.classList.add('active');
+    } else {
+      step.classList.remove('active');
+    }
+  });
+}


### PR DESCRIPTION
## Summary
- break monolithic script.js into UI, race data, and spellcasting modules
- centralize shared helpers in common.js and add main.js entry point
- update HTML to load ES modules and wire events via main.js

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a4842d75d8832eb7c3ba777e0451cc