### PR TITLE
Add equipment selection step

### DIFF
--- a/data/equipment.json
+++ b/data/equipment.json
@@ -1,0 +1,59 @@
+{
+  "standard": [
+    "Zaino",
+    "Torce (10)",
+    "Razioni (10 giorni)",
+    "Corda (50 piedi)",
+    "Borraccia",
+    "Acciarino e pietra focaia"
+  ],
+  "classes": {
+    "Fighter": {
+      "fixed": ["Scudo"],
+      "choices": [
+        {
+          "label": "Armatura",
+          "type": "radio",
+          "options": [
+            { "value": "Cotta di maglia", "label": "Cotta di maglia" },
+            { "value": "Armatura di cuoio borchiato e arco lungo", "label": "Armatura di cuoio borchiato e arco lungo" }
+          ]
+        },
+        {
+          "label": "Arma",
+          "type": "radio",
+          "options": [
+            { "value": "Arma marziale e scudo", "label": "Arma marziale e scudo" },
+            { "value": "Due armi marziali", "label": "Due armi marziali" }
+          ]
+        }
+      ]
+    },
+    "Wizard": {
+      "fixed": ["Libro degli incantesimi"],
+      "choices": [
+        {
+          "label": "Arma",
+          "type": "radio",
+          "options": [
+            { "value": "Bastone ferrato", "label": "Bastone ferrato" },
+            { "value": "Pugnale", "label": "Pugnale" }
+          ]
+        },
+        {
+          "label": "Focus arcano",
+          "type": "radio",
+          "options": [
+            { "value": "Borsa delle componenti", "label": "Borsa delle componenti" },
+            { "value": "Focus arcano", "label": "Focus arcano" }
+          ]
+        }
+      ]
+    }
+  },
+  "upgrades": {
+    "minLevel": 11,
+    "armor": ["Mezza armatura di piastre", "Armatura a piastre"],
+    "weapon": "Arma incantata"
+  }
+}

--- a/index.html
+++ b/index.html
@@ -111,8 +111,8 @@
     <button id="btnStep2">Step 2: Razza</button>
     <button id="btnStep3">Step 3: Point Buy</button>
     <button id="btnStep4">Step 4: Classe</button>
-    <button id="btnStep5">Step 5: Background</button>
-    <button id="btnStep6">Step 6: Equipaggiamento</button>
+    <button id="btnStep5">Step 5: Equipaggiamento</button>
+    <button id="btnStep6">Step 6: Background</button>
     <button id="btnStep8">Step 8: Recap & Esportazione</button>
   </nav>
   <!-- Container degli step -->
@@ -372,9 +372,17 @@
       <div id="metamagicSelection"></div>
       <div id="abilityImprovementSelection"></div>
     </div>
-    <!-- Step 5: Background -->
+    <!-- Step 5: Equipaggiamento -->
     <div id="step5" class="step">
-      <h2>Step 5: Background</h2>
+      <h2>Step 5: Equipaggiamento</h2>
+      <div id="standardEquipment"></div>
+      <div id="classEquipmentChoices"></div>
+      <div id="equipmentUpgrades"></div>
+      <button id="confirmEquipment" class="primary">Conferma Equipaggiamento</button>
+    </div>
+<!-- Step 6: Background -->
+    <div id="step6" class="step">
+      <h2>Step 6: Background</h2>
       <label for="backgroundSelect">Background:</label>
       <select id="backgroundSelect">
         <option value="">Seleziona un background</option>
@@ -383,10 +391,6 @@
       <div id="backgroundTools"></div>
       <div id="backgroundLanguages"></div>
       <div id="backgroundFeat"></div>
-    </div>
-    <!-- Step 6: Equipaggiamento -->
-    <div id="step6" class="step">
-      <h2>Step 6: Equipaggiamento</h2>
     </div>
     <!-- Step 8: Recap & Esportazione -->
     <div id="step8" class="step">

--- a/js/main.js
+++ b/js/main.js
@@ -13,6 +13,7 @@ import {
   setAvailableLanguages
 } from './script.js';
 import './step5.js';
+import './step6.js';
 
 let classSelectionConfirmed = false;
 

--- a/js/script.js
+++ b/js/script.js
@@ -296,6 +296,7 @@ function renderTables(entries) {
 let selectedData = sessionStorage.getItem("selectedData")
   ? JSON.parse(sessionStorage.getItem("selectedData"))
   : {};
+window.selectedData = selectedData;
 let extraSelections = [];
 let currentSelectionIndex = 0;
 // Cached list of all languages loaded from JSON
@@ -991,6 +992,7 @@ function generateFinalJson() {
       languages: window.backgroundData.languages || []
     } : { skills: [], tools: [], languages: [] },
     background_feat: window.backgroundData ? window.backgroundData.feat || "" : "",
+    equipment: selectedData.equipment || { standard: [], class: [], upgrades: [] },
     languages: {
       selected: selectedData["Languages"] || []
     },

--- a/js/step5.js
+++ b/js/step5.js
@@ -1,186 +1,133 @@
-// Step 5: Background selection and feat handling
-import { loadDropdownData } from './common.js';
+// Step 5: Equipment selection
+let equipmentData = null;
 
-let featPathIndex = {};
-let currentFeatData = null;
+function renderEquipment() {
+  if (!equipmentData) return;
+  const className = document.getElementById('classSelect').value;
+  const level = parseInt(document.getElementById('levelSelect').value || '1', 10);
+  const standardDiv = document.getElementById('standardEquipment');
+  const classDiv = document.getElementById('classEquipmentChoices');
+  const upgradeDiv = document.getElementById('equipmentUpgrades');
 
-function resetBackgroundTalentFields() {
-  ["str", "dex", "con", "int", "wis", "cha"].forEach(ab => {
-    const el = document.getElementById(ab + "BackgroundTalent");
-    if (el) el.value = 0;
-  });
-}
+  standardDiv.innerHTML = `<h3>Equipaggiamento Standard</h3><ul>${equipmentData.standard
+    .map(item => `<li>${item}</li>`)
+    .join('')}</ul>`;
 
-function applyFeatAbilityChoices() {
-  resetBackgroundTalentFields();
-  if (currentFeatData && currentFeatData.fixedAbilities) {
-    currentFeatData.fixedAbilities.forEach(obj => {
-      const ability = Object.keys(obj)[0];
-      const val = obj[ability];
-      const el = document.getElementById(ability + "BackgroundTalent");
-      if (el) el.value = val;
-    });
-  }
-  const selects = document.querySelectorAll(".featAbilityChoice");
-  selects.forEach(sel => {
-    if (sel.value) {
-      const amt = parseInt(sel.dataset.amount || "1");
-      const el = document.getElementById(sel.value + "BackgroundTalent");
-      if (el) el.value = amt;
+  classDiv.innerHTML = '';
+  upgradeDiv.innerHTML = '';
+
+  const classInfo = equipmentData.classes[className];
+  if (classInfo) {
+    if (Array.isArray(classInfo.fixed) && classInfo.fixed.length > 0) {
+      const fixedP = document.createElement('p');
+      fixedP.innerHTML = `<strong>Equipaggiamento fisso:</strong> ${classInfo.fixed.join(', ')}`;
+      classDiv.appendChild(fixedP);
     }
-  });
-  updateFinalScores();
+    if (Array.isArray(classInfo.choices)) {
+      classInfo.choices.forEach((choice, idx) => {
+        const group = document.createElement('div');
+        const lbl = document.createElement('p');
+        lbl.innerHTML = `<strong>${choice.label || 'Scegli'}:</strong>`;
+        group.appendChild(lbl);
+        choice.options.forEach((opt, oIdx) => {
+          const id = `equipChoice_${idx}_${oIdx}`;
+          const input = document.createElement('input');
+          input.type = choice.type === 'checkbox' ? 'checkbox' : 'radio';
+          input.name = `equipChoice_${idx}`;
+          input.id = id;
+          input.value = opt.value || opt;
+          const lab = document.createElement('label');
+          lab.htmlFor = id;
+          lab.textContent = opt.label || opt;
+          group.appendChild(input);
+          group.appendChild(lab);
+          group.appendChild(document.createElement('br'));
+        });
+        classDiv.appendChild(group);
+      });
+    }
+  } else {
+    classDiv.innerHTML = '<p>Nessun equipaggiamento specifico per questa classe.</p>';
+  }
+
+  if (equipmentData.upgrades && level >= (equipmentData.upgrades.minLevel || 0)) {
+    const up = equipmentData.upgrades;
+    const head = document.createElement('h3');
+    head.textContent = 'Opzioni Avanzate';
+    upgradeDiv.appendChild(head);
+    if (Array.isArray(up.armor)) {
+      const armorLabel = document.createElement('p');
+      armorLabel.innerHTML = '<strong>Armatura:</strong>';
+      upgradeDiv.appendChild(armorLabel);
+      up.armor.forEach((armor, idx) => {
+        const id = `upgradeArmor_${idx}`;
+        const input = document.createElement('input');
+        input.type = 'radio';
+        input.name = 'upgradeArmor';
+        input.id = id;
+        input.value = armor;
+        const lab = document.createElement('label');
+        lab.htmlFor = id;
+        lab.textContent = armor;
+        upgradeDiv.appendChild(input);
+        upgradeDiv.appendChild(lab);
+        upgradeDiv.appendChild(document.createElement('br'));
+      });
+    }
+    if (up.weapon) {
+      const id = 'upgradeWeapon';
+      const input = document.createElement('input');
+      input.type = 'checkbox';
+      input.id = id;
+      input.value = up.weapon;
+      const lab = document.createElement('label');
+      lab.htmlFor = id;
+      lab.textContent = up.weapon;
+      upgradeDiv.appendChild(input);
+      upgradeDiv.appendChild(lab);
+    }
+  }
 }
 
-document.addEventListener("DOMContentLoaded", () => {
-  const step = document.getElementById("step5");
+document.addEventListener('DOMContentLoaded', () => {
+  const step = document.getElementById('step5');
   if (!step) return;
 
-  window.backgroundData = { name: "", skills: [], tools: [], languages: [], feat: "" };
+  if (!window.selectedData) {
+    window.selectedData = {};
+  }
 
-  loadDropdownData("data/backgrounds.json", "backgroundSelect", "backgrounds");
-  fetch("data/feats.json").then(r => r.json()).then(d => { featPathIndex = d.feats || {}; });
+  fetch('data/equipment.json')
+    .then(r => r.json())
+    .then(data => {
+      equipmentData = data;
+      renderEquipment();
+      const classSel = document.getElementById('classSelect');
+      const levelSel = document.getElementById('levelSelect');
+      if (classSel) classSel.addEventListener('change', renderEquipment);
+      if (levelSel) levelSel.addEventListener('change', renderEquipment);
+    });
 
-  document.getElementById("backgroundSelect").addEventListener("change", async e => {
-    const val = e.target.value;
-    if (!val) return;
-    const res = await fetch(val);
-    const data = await res.json();
-    backgroundData.name = data.name;
-
-    const skillDiv = document.getElementById("backgroundSkills");
-    skillDiv.innerHTML = "";
-    backgroundData.skills = Array.isArray(data.skills) ? data.skills.slice() : [];
-    if (backgroundData.skills.length > 0) {
-      skillDiv.innerHTML = `<p><strong>Abilità:</strong> ${backgroundData.skills.join(", ")}</p>`;
-    }
-    if (data.skillChoices) {
-      const num = data.skillChoices.choose || 0;
-      const opts = data.skillChoices.options || [];
-      skillDiv.innerHTML += `<p><strong>Scegli ${num} abilità:</strong></p>`;
-      for (let i = 0; i < num; i++) {
-        const sel = document.createElement("select");
-        sel.className = "backgroundSkillChoice";
-        sel.innerHTML = `<option value="">Seleziona</option>` + opts.map(o => `<option value="${o}">${o}</option>`).join("");
-        sel.addEventListener("change", () => {
-          const chosen = Array.from(document.querySelectorAll(".backgroundSkillChoice")).map(s => s.value).filter(Boolean);
-          backgroundData.skills = (data.skills || []).concat(chosen);
-        });
-        skillDiv.appendChild(sel);
-      }
-    }
-
-    const toolDiv = document.getElementById("backgroundTools");
-    toolDiv.innerHTML = "";
-    backgroundData.tools = Array.isArray(data.tools) ? data.tools.slice() : [];
-    if (Array.isArray(data.tools) && data.tools.length > 0) {
-      toolDiv.innerHTML = `<p><strong>Strumenti:</strong> ${data.tools.join(", ")}</p>`;
-    }
-    if (data.tools && data.tools.choose) {
-      const num = data.tools.choose;
-      const opts = data.tools.options || [];
-      toolDiv.innerHTML += `<p><strong>Scegli ${num} strumento:</strong></p>`;
-      for (let i = 0; i < num; i++) {
-        const sel = document.createElement("select");
-        sel.className = "backgroundToolChoice";
-        sel.innerHTML = `<option value="">Seleziona</option>` + opts.map(o => `<option value="${o}">${o}</option>`).join("");
-        sel.addEventListener("change", () => {
-          const chosen = Array.from(document.querySelectorAll(".backgroundToolChoice")).map(s => s.value).filter(Boolean);
-          backgroundData.tools = chosen;
-        });
-        toolDiv.appendChild(sel);
-      }
-    }
-    if (data.toolChoices) {
-      const num = data.toolChoices.choose || 0;
-      const opts = data.toolChoices.options || [];
-      toolDiv.innerHTML += `<p><strong>Scegli ${num} strumento:</strong></p>`;
-      for (let i = 0; i < num; i++) {
-        const sel = document.createElement("select");
-        sel.className = "backgroundToolChoice";
-        sel.innerHTML = `<option value="">Seleziona</option>` + opts.map(o => `<option value="${o}">${o}</option>`).join("");
-        sel.addEventListener("change", () => {
-          const chosen = Array.from(document.querySelectorAll(".backgroundToolChoice")).map(s => s.value).filter(Boolean);
-          const base = Array.isArray(data.tools) ? data.tools.slice() : [];
-          backgroundData.tools = base.concat(chosen);
-        });
-        toolDiv.appendChild(sel);
-      }
-    }
-
-    const langDiv = document.getElementById("backgroundLanguages");
-    langDiv.innerHTML = "";
-    backgroundData.languages = Array.isArray(data.languages) ? data.languages.slice() : [];
-    if (Array.isArray(data.languages) && data.languages.length > 0) {
-      langDiv.innerHTML = `<p><strong>Linguaggi:</strong> ${data.languages.join(", ")}</p>`;
-    } else if (data.languages && data.languages.choose) {
-      const num = data.languages.choose;
-      const opts = data.languages.options || [];
-      langDiv.innerHTML = `<p><strong>Scegli ${num} linguaggi:</strong></p>`;
-      for (let i = 0; i < num; i++) {
-        const sel = document.createElement("select");
-        sel.className = "backgroundLanguageChoice";
-        sel.innerHTML = `<option value="">Seleziona</option>` + opts.map(o => `<option value="${o}">${o}</option>`).join("");
-        sel.addEventListener("change", () => {
-          const chosen = Array.from(document.querySelectorAll(".backgroundLanguageChoice")).map(s => s.value).filter(Boolean);
-          backgroundData.languages = chosen;
-        });
-        langDiv.appendChild(sel);
-      }
-    }
-
-    const featDiv = document.getElementById("backgroundFeat");
-    featDiv.innerHTML = "";
-    backgroundData.feat = "";
-    currentFeatData = null;
-    if (Array.isArray(data.featOptions) && data.featOptions.length > 0) {
-      const label = document.createElement("label");
-      label.htmlFor = "backgroundFeatSelect";
-      label.textContent = "Feat:";
-      const select = document.createElement("select");
-      select.id = "backgroundFeatSelect";
-      select.innerHTML = `<option value="">Seleziona un talento</option>` +
-        data.featOptions
-          .map(name => `<option value="${name}">${name}</option>`)
-          .join("");
-      const abilDiv = document.createElement("div");
-      abilDiv.id = "featAbilityChoices";
-      select.addEventListener("change", () => {
-        currentFeatData = null;
-        abilDiv.innerHTML = "";
-        backgroundData.feat = select.value || "";
-        resetBackgroundTalentFields();
-        if (!select.value || !featPathIndex[select.value]) {
-          updateFinalScores();
-          return;
-        }
-        fetch(featPathIndex[select.value])
-          .then(r => r.json())
-          .then(feat => {
-            const fixed = [];
-            if (feat.ability) {
-              feat.ability.forEach(ab => {
-                if (ab.choose) {
-                  const sel = document.createElement("select");
-                  sel.className = "featAbilityChoice";
-                  sel.dataset.amount = ab.choose.amount || 1;
-                  sel.innerHTML = `<option value="">Seleziona caratteristica</option>` +
-                    ab.choose.from.map(a => `<option value="${a}">${a.toUpperCase()}</option>`).join("");
-                  sel.addEventListener("change", applyFeatAbilityChoices);
-                  abilDiv.appendChild(sel);
-                } else {
-                  fixed.push(ab);
-                }
-              });
-            }
-            currentFeatData = { fixedAbilities: fixed };
-            applyFeatAbilityChoices();
-          });
-      });
-      featDiv.appendChild(label);
-      featDiv.appendChild(select);
-      featDiv.appendChild(abilDiv);
-    }
-  });
+  const confirmBtn = document.getElementById('confirmEquipment');
+  if (confirmBtn) {
+    confirmBtn.addEventListener('click', () => {
+      const className = document.getElementById('classSelect').value;
+      const classInfo = equipmentData.classes[className] || { fixed: [] };
+      const chosen = [];
+      if (Array.isArray(classInfo.fixed)) chosen.push(...classInfo.fixed);
+      document
+        .querySelectorAll('#classEquipmentChoices input:checked')
+        .forEach(el => chosen.push(el.value));
+      const upgrades = [];
+      document
+        .querySelectorAll('#equipmentUpgrades input:checked')
+        .forEach(el => upgrades.push(el.value));
+      window.selectedData.equipment = {
+        standard: equipmentData.standard,
+        class: chosen,
+        upgrades: upgrades
+      };
+      sessionStorage.setItem('selectedData', JSON.stringify(window.selectedData));
+    });
+  }
 });
-

--- a/js/step6.js
+++ b/js/step6.js
@@ -1,0 +1,186 @@
+// Step 6: Background selection and feat handling
+import { loadDropdownData } from './common.js';
+
+let featPathIndex = {};
+let currentFeatData = null;
+
+function resetBackgroundTalentFields() {
+  ["str", "dex", "con", "int", "wis", "cha"].forEach(ab => {
+    const el = document.getElementById(ab + "BackgroundTalent");
+    if (el) el.value = 0;
+  });
+}
+
+function applyFeatAbilityChoices() {
+  resetBackgroundTalentFields();
+  if (currentFeatData && currentFeatData.fixedAbilities) {
+    currentFeatData.fixedAbilities.forEach(obj => {
+      const ability = Object.keys(obj)[0];
+      const val = obj[ability];
+      const el = document.getElementById(ability + "BackgroundTalent");
+      if (el) el.value = val;
+    });
+  }
+  const selects = document.querySelectorAll(".featAbilityChoice");
+  selects.forEach(sel => {
+    if (sel.value) {
+      const amt = parseInt(sel.dataset.amount || "1");
+      const el = document.getElementById(sel.value + "BackgroundTalent");
+      if (el) el.value = amt;
+    }
+  });
+  updateFinalScores();
+}
+
+document.addEventListener("DOMContentLoaded", () => {
+  const step = document.getElementById("step6");
+  if (!step) return;
+
+  window.backgroundData = { name: "", skills: [], tools: [], languages: [], feat: "" };
+
+  loadDropdownData("data/backgrounds.json", "backgroundSelect", "backgrounds");
+  fetch("data/feats.json").then(r => r.json()).then(d => { featPathIndex = d.feats || {}; });
+
+  document.getElementById("backgroundSelect").addEventListener("change", async e => {
+    const val = e.target.value;
+    if (!val) return;
+    const res = await fetch(val);
+    const data = await res.json();
+    backgroundData.name = data.name;
+
+    const skillDiv = document.getElementById("backgroundSkills");
+    skillDiv.innerHTML = "";
+    backgroundData.skills = Array.isArray(data.skills) ? data.skills.slice() : [];
+    if (backgroundData.skills.length > 0) {
+      skillDiv.innerHTML = `<p><strong>Abilità:</strong> ${backgroundData.skills.join(", ")}</p>`;
+    }
+    if (data.skillChoices) {
+      const num = data.skillChoices.choose || 0;
+      const opts = data.skillChoices.options || [];
+      skillDiv.innerHTML += `<p><strong>Scegli ${num} abilità:</strong></p>`;
+      for (let i = 0; i < num; i++) {
+        const sel = document.createElement("select");
+        sel.className = "backgroundSkillChoice";
+        sel.innerHTML = `<option value="">Seleziona</option>` + opts.map(o => `<option value="${o}">${o}</option>`).join("");
+        sel.addEventListener("change", () => {
+          const chosen = Array.from(document.querySelectorAll(".backgroundSkillChoice")).map(s => s.value).filter(Boolean);
+          backgroundData.skills = (data.skills || []).concat(chosen);
+        });
+        skillDiv.appendChild(sel);
+      }
+    }
+
+    const toolDiv = document.getElementById("backgroundTools");
+    toolDiv.innerHTML = "";
+    backgroundData.tools = Array.isArray(data.tools) ? data.tools.slice() : [];
+    if (Array.isArray(data.tools) && data.tools.length > 0) {
+      toolDiv.innerHTML = `<p><strong>Strumenti:</strong> ${data.tools.join(", ")}</p>`;
+    }
+    if (data.tools && data.tools.choose) {
+      const num = data.tools.choose;
+      const opts = data.tools.options || [];
+      toolDiv.innerHTML += `<p><strong>Scegli ${num} strumento:</strong></p>`;
+      for (let i = 0; i < num; i++) {
+        const sel = document.createElement("select");
+        sel.className = "backgroundToolChoice";
+        sel.innerHTML = `<option value="">Seleziona</option>` + opts.map(o => `<option value="${o}">${o}</option>`).join("");
+        sel.addEventListener("change", () => {
+          const chosen = Array.from(document.querySelectorAll(".backgroundToolChoice")).map(s => s.value).filter(Boolean);
+          backgroundData.tools = chosen;
+        });
+        toolDiv.appendChild(sel);
+      }
+    }
+    if (data.toolChoices) {
+      const num = data.toolChoices.choose || 0;
+      const opts = data.toolChoices.options || [];
+      toolDiv.innerHTML += `<p><strong>Scegli ${num} strumento:</strong></p>`;
+      for (let i = 0; i < num; i++) {
+        const sel = document.createElement("select");
+        sel.className = "backgroundToolChoice";
+        sel.innerHTML = `<option value="">Seleziona</option>` + opts.map(o => `<option value="${o}">${o}</option>`).join("");
+        sel.addEventListener("change", () => {
+          const chosen = Array.from(document.querySelectorAll(".backgroundToolChoice")).map(s => s.value).filter(Boolean);
+          const base = Array.isArray(data.tools) ? data.tools.slice() : [];
+          backgroundData.tools = base.concat(chosen);
+        });
+        toolDiv.appendChild(sel);
+      }
+    }
+
+    const langDiv = document.getElementById("backgroundLanguages");
+    langDiv.innerHTML = "";
+    backgroundData.languages = Array.isArray(data.languages) ? data.languages.slice() : [];
+    if (Array.isArray(data.languages) && data.languages.length > 0) {
+      langDiv.innerHTML = `<p><strong>Linguaggi:</strong> ${data.languages.join(", ")}</p>`;
+    } else if (data.languages && data.languages.choose) {
+      const num = data.languages.choose;
+      const opts = data.languages.options || [];
+      langDiv.innerHTML = `<p><strong>Scegli ${num} linguaggi:</strong></p>`;
+      for (let i = 0; i < num; i++) {
+        const sel = document.createElement("select");
+        sel.className = "backgroundLanguageChoice";
+        sel.innerHTML = `<option value="">Seleziona</option>` + opts.map(o => `<option value="${o}">${o}</option>`).join("");
+        sel.addEventListener("change", () => {
+          const chosen = Array.from(document.querySelectorAll(".backgroundLanguageChoice")).map(s => s.value).filter(Boolean);
+          backgroundData.languages = chosen;
+        });
+        langDiv.appendChild(sel);
+      }
+    }
+
+    const featDiv = document.getElementById("backgroundFeat");
+    featDiv.innerHTML = "";
+    backgroundData.feat = "";
+    currentFeatData = null;
+    if (Array.isArray(data.featOptions) && data.featOptions.length > 0) {
+      const label = document.createElement("label");
+      label.htmlFor = "backgroundFeatSelect";
+      label.textContent = "Feat:";
+      const select = document.createElement("select");
+      select.id = "backgroundFeatSelect";
+      select.innerHTML = `<option value="">Seleziona un talento</option>` +
+        data.featOptions
+          .map(name => `<option value="${name}">${name}</option>`)
+          .join("");
+      const abilDiv = document.createElement("div");
+      abilDiv.id = "featAbilityChoices";
+      select.addEventListener("change", () => {
+        currentFeatData = null;
+        abilDiv.innerHTML = "";
+        backgroundData.feat = select.value || "";
+        resetBackgroundTalentFields();
+        if (!select.value || !featPathIndex[select.value]) {
+          updateFinalScores();
+          return;
+        }
+        fetch(featPathIndex[select.value])
+          .then(r => r.json())
+          .then(feat => {
+            const fixed = [];
+            if (feat.ability) {
+              feat.ability.forEach(ab => {
+                if (ab.choose) {
+                  const sel = document.createElement("select");
+                  sel.className = "featAbilityChoice";
+                  sel.dataset.amount = ab.choose.amount || 1;
+                  sel.innerHTML = `<option value="">Seleziona caratteristica</option>` +
+                    ab.choose.from.map(a => `<option value="${a}">${a.toUpperCase()}</option>`).join("");
+                  sel.addEventListener("change", applyFeatAbilityChoices);
+                  abilDiv.appendChild(sel);
+                } else {
+                  fixed.push(ab);
+                }
+              });
+            }
+            currentFeatData = { fixedAbilities: fixed };
+            applyFeatAbilityChoices();
+          });
+      });
+      featDiv.appendChild(label);
+      featDiv.appendChild(select);
+      featDiv.appendChild(abilDiv);
+    }
+  });
+});
+

--- a/js/step8.js
+++ b/js/step8.js
@@ -20,7 +20,8 @@ document.addEventListener("DOMContentLoaded", () => {
         tools: window.backgroundData.tools || [],
         languages: window.backgroundData.languages || []
       } : { skills: [], tools: [], languages: [] },
-      background_feat: window.backgroundData ? window.backgroundData.feat || "" : ""
+      background_feat: window.backgroundData ? window.backgroundData.feat || "" : "",
+      equipment: window.selectedData ? window.selectedData.equipment || {} : {}
     };
     downloadJsonFile(character.name.replace(/[^a-z0-9]/gi, '_').toLowerCase() + "_character.json", character);
     document.getElementById("finalRecap").innerHTML = `<pre>${JSON.stringify(character, null, 2)}</pre>`;


### PR DESCRIPTION
## Summary
- add equipment data and step for selecting gear
- load equipment based on class and level, including tier-3 upgrades
- export equipment choices with final character data

## Testing
- `node --check js/step5.js`
- `node --check js/step6.js`
- `node --check js/main.js`
- `node --check js/script.js`
- `node --check js/step8.js`
- `npm test` *(fails: ENOENT package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a4881455f4832e9f403e7506b73af2