### PR TITLE
Add progress tracker and persist form data

### DIFF
--- a/index.html
+++ b/index.html
@@ -58,12 +58,31 @@
   #subclassSelect {
     display: none;
   }
+
+  #progressContainer {
+    width: 100%;
+    background-color: #e0e0e0;
+    height: 10px;
+    border-radius: 5px;
+    margin: 10px 0;
+  }
+
+  #progressBar {
+    height: 100%;
+    width: 0%;
+    background-color: #28a745;
+    border-radius: 5px;
+    transition: width 0.3s ease;
+  }
   </style>
 </head>
-<body onload="initializeValues()">
+<body>
   <header>
     <h1>Character Creator - Foundry</h1>
   </header>
+  <div id="progressContainer">
+    <div id="progressBar"></div>
+  </div>
   <!-- Navigazione a step -->
   <nav>
     <button id="btnStep1">Step 1: Nome & Livello</button>

--- a/js/main.js
+++ b/js/main.js
@@ -1,4 +1,4 @@
-import { showStep } from './ui.js';
+import { showStep, loadFormData } from './ui.js';
 import { convertRaceData } from './raceData.js';
 import { loadSpells, filterSpells } from './spellcasting.js';
 import { loadDropdownData, loadLanguages, handleError } from './common.js';
@@ -60,7 +60,9 @@ document.addEventListener('DOMContentLoaded', () => {
       }
     });
 
-  showStep('step1');
+  initializeValues();
+  const lastStep = loadFormData();
+  showStep(lastStep || 'step1');
 
   document.getElementById('raceSelect').addEventListener('change', displayRaceTraits);
   document.getElementById('levelSelect').addEventListener('change', () => displayRaceTraits());
@@ -116,5 +118,4 @@ document.addEventListener('DOMContentLoaded', () => {
       .catch(error => handleError('Errore caricando i dati della razza: ' + error));
   });
 
-  initializeValues();
 });

--- a/js/ui.js
+++ b/js/ui.js
@@ -1,4 +1,7 @@
 export function showStep(stepId) {
+  // Salva i dati correnti prima di cambiare step
+  saveFormData();
+
   const steps = document.querySelectorAll('.step');
   steps.forEach(step => {
     if (step.id === stepId) {
@@ -7,4 +10,44 @@ export function showStep(stepId) {
       step.classList.remove('active');
     }
   });
+
+  updateProgress(stepId);
+  localStorage.setItem('currentStep', stepId);
+}
+
+function updateProgress(stepId) {
+  const progressBar = document.getElementById('progressBar');
+  if (!progressBar) return;
+  const steps = Array.from(document.querySelectorAll('.step'));
+  const index = steps.findIndex(step => step.id === stepId);
+  const percent = ((index + 1) / steps.length) * 100;
+  progressBar.style.width = `${percent}%`;
+}
+
+function saveFormData() {
+  const fields = document.querySelectorAll('input, select, textarea');
+  fields.forEach(field => {
+    if (!field.id) return;
+    if (field.type === 'checkbox' || field.type === 'radio') {
+      localStorage.setItem(field.id, field.checked);
+    } else {
+      localStorage.setItem(field.id, field.value);
+    }
+  });
+}
+
+export function loadFormData() {
+  const fields = document.querySelectorAll('input, select, textarea');
+  fields.forEach(field => {
+    if (!field.id) return;
+    const stored = localStorage.getItem(field.id);
+    if (stored !== null) {
+      if (field.type === 'checkbox' || field.type === 'radio') {
+        field.checked = stored === 'true';
+      } else {
+        field.value = stored;
+      }
+    }
+  });
+  return localStorage.getItem('currentStep');
 }


### PR DESCRIPTION
## Summary
- add progress bar to character creation flow
- persist step state and input values with localStorage to resume progress
- update initialization to load saved data and reflect progress

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a48dbf4014832e9314efdfe5701d2a