### PR TITLE
Fix duplicate utility definitions causing load errors

### DIFF
--- a/js/script.js
+++ b/js/script.js
@@ -216,80 +216,6 @@ function handleExtraAncestry(data, containerId) {
   }
 }
 
-// ==================== COMMON UTILITY FUNCTIONS ====================
-function filterSpells(spells, filterString) {
-  const conditions = filterString.split("|");
-  return spells.filter(spell => {
-    let valid = true;
-    conditions.forEach(cond => {
-      const parts = cond.split("=");
-      if (parts.length === 2) {
-        const key = parts[0].trim().toLowerCase();
-        const value = parts[1].trim().toLowerCase();
-        if (key === "level") {
-          if (parseInt(spell.level) !== parseInt(value)) valid = false;
-        } else if (key === "class") {
-          if (!spell.spell_list || !spell.spell_list.map(x => x.toLowerCase()).includes(value)) valid = false;
-        }
-      }
-    });
-    return valid;
-  });
-}
-
-
-// ==================== RACE DATA CONVERSION ====================
-// ==================== RENDERING DI TABELLE ====================
-function renderTables(entries) {
-  let html = "";
-  if (!entries || !Array.isArray(entries)) return html;
-  entries.forEach(entry => {
-    if (entry.entries && Array.isArray(entry.entries)) {
-      entry.entries.forEach(subEntry => {
-        if (typeof subEntry === "object" && subEntry.type === "table") {
-          html += `<div class="table-container" style="margin-top:1em; margin-bottom:1em;">`;
-          if (subEntry.caption) {
-            html += `<p><strong>${subEntry.caption}</strong></p>`;
-          }
-          html += `<table border="1" style="width:100%; border-collapse: collapse;">`;
-          if (subEntry.colLabels && Array.isArray(subEntry.colLabels)) {
-            html += `<thead><tr>`;
-            subEntry.colLabels.forEach(label => {
-              html += `<th style="padding: 0.5em; text-align: center;">${label}</th>`;
-            });
-            html += `</tr></thead>`;
-          }
-          if (subEntry.rows && Array.isArray(subEntry.rows)) {
-            html += `<tbody>`;
-            subEntry.rows.forEach(row => {
-              html += `<tr>`;
-              row.forEach(cell => {
-                html += `<td style="padding: 0.5em; text-align: center;">${cell}</td>`;
-              });
-              html += `</tr>`;
-            });
-            html += `</tbody>`;
-          }
-          html += `</table>`;
-          if (entry.name && entry.name.toLowerCase().includes("ancestry")) {
-            let optsHtml = `<option value="">Seleziona...</option>`;
-            subEntry.rows.forEach(row => {
-              const optVal = JSON.stringify(row);
-              const optLabel = `${row[0]} (${row[1]})`;
-              optsHtml += `<option value='${optVal}'>${optLabel}</option>`;
-            });
-            html += `<p><strong>Seleziona Ancestry:</strong>
-                      <select id="ancestrySelect">${optsHtml}</select>
-                     </p>`;
-          }
-          html += `</div>`;
-        }
-      });
-    }
-  });
-  return html;
-}
-
 // ==================== POPUP FOR EXTRA SELECTIONS ====================
 
 // Global variables for the extra selections popup
@@ -1131,7 +1057,6 @@ export {
   openExtrasModal,
   displayRaceTraits,
   generateFinalJson,
-  initializeValues,
-  setAvailableLanguages
+  initializeValues
 };
 


### PR DESCRIPTION
## Summary
- Remove in-file implementations of `filterSpells` and `renderTables` to avoid duplicate declarations
- Drop redundant export of `setAvailableLanguages`

## Testing
- `for f in js/*.js; do echo Checking $f; node --check $f; done`
- `node js/script.js` *(fails: ReferenceError: sessionStorage is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_68a48f22b2c8832e995cf65c24486e75