### PR TITLE
Fix feat loading for ability score improvements

### DIFF
--- a/js/script.js
+++ b/js/script.js
@@ -116,7 +116,11 @@ function loadFeats(callback) {
     .then(response => response.json())
     .then(data => {
       if (data.feats) {
-        availableFeats = data.feats;
+        if (Array.isArray(data.feats)) {
+          availableFeats = data.feats;
+        } else if (typeof data.feats === "object") {
+          availableFeats = Object.keys(data.feats).map(name => ({ name }));
+        }
         callback(availableFeats);
       } else {
         handleError("Nessun feat trovato nel file JSON.");


### PR DESCRIPTION
## Summary
- Convert feat JSON mapping into an array of feat names when loading
- Prevent `feats.filter` runtime error when choosing Ability Score Improvement feats

## Testing
- `npm test` *(fails: ENOENT package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a4934439a0832eb952b711a5c7fdaf