### PR TITLE
Add Druid core traits and equipment options

### DIFF
--- a/data/classes/druid.json
+++ b/data/classes/druid.json
@@ -1,6 +1,49 @@
 {
   "name": "Druid",
   "description": "A wielder of nature's magic who can cast spells and shapeshift into beasts.",
+  "hit_die": "d8",
+  "hp_at_1st_level": "8 + your Constitution modifier",
+  "hp_at_higher_levels": "1d8 (or 5) + your Constitution modifier per Druid level after 1st",
+  "saving_throws": ["Intelligence", "Wisdom"],
+  "skill_proficiencies": {
+    "choose": 2,
+    "options": [
+      "Arcana",
+      "Animal Handling",
+      "Insight",
+      "Medicine",
+      "Nature",
+      "Perception",
+      "Religion",
+      "Survival"
+    ]
+  },
+  "weapon_proficiencies": [
+    "clubs",
+    "daggers",
+    "darts",
+    "javelins",
+    "maces",
+    "quarterstaffs",
+    "scimitars",
+    "sickles",
+    "slings",
+    "spears"
+  ],
+  "tool_proficiencies": ["Herbalism kit"],
+  "armor_proficiencies": ["light armor", "medium armor", "shields (non-metal)"],
+  "starting_equipment": {
+    "choices": [
+      ["Wooden shield", "Any simple weapon"],
+      ["Scimitar", "Any simple melee weapon"]
+    ],
+    "fixed": ["Leather armor", "Explorer's pack", "Druidic focus"],
+    "gold_alternative": "2d4 × 10 gp"
+  },
+  "multiclassing": {
+    "prerequisites": {"Wisdom": 13},
+    "proficiencies": {"armor": ["light armor", "medium armor", "shields (non-metal)"]}
+  },
   "features_by_level": {
     "1": [
       {
@@ -189,6 +232,23 @@
     }
   ],
   "choices": [
+    {
+      "level": 1,
+      "name": "Skill Proficiency",
+      "description": "Choose two skills from the druid list",
+      "count": 2,
+      "type": "skills",
+      "selection": [
+        "Arcana",
+        "Animal Handling",
+        "Insight",
+        "Medicine",
+        "Nature",
+        "Perception",
+        "Religion",
+        "Survival"
+      ]
+    },
     {
       "level": 1,
       "name": "Cantrip",

--- a/data/equipment.json
+++ b/data/equipment.json
@@ -49,6 +49,28 @@
           ]
         }
       ]
+    },
+    "Druid": {
+      "fixed": ["Armatura di cuoio", "Pacchetto da esploratore", "Focus druidico"],
+      "choices": [
+        {
+          "label": "Scudo o Arma",
+          "type": "radio",
+          "options": [
+            { "value": "Scudo di legno", "label": "Scudo di legno" },
+            { "value": "Arma semplice", "label": "Arma semplice" }
+          ]
+        },
+        {
+          "label": "Arma secondaria",
+          "type": "radio",
+          "options": [
+            { "value": "Scimitarra", "label": "Scimitarra" },
+            { "value": "Arma semplice da mischia", "label": "Arma semplice da mischia" }
+          ]
+        }
+      ],
+      "goldAlternative": "2d4 × 10 gp"
     }
   },
   "upgrades": {

--- a/js/script.js
+++ b/js/script.js
@@ -813,6 +813,52 @@ async function renderClassFeatures() {
     html += `<p>${data.description}</p>`;
   }
 
+  if (data.hit_die) {
+    html += `<p><strong>Hit Die:</strong> ${data.hit_die}</p>`;
+  }
+  if (data.hp_at_1st_level) {
+    html += `<p><strong>Hit Points at 1st Level:</strong> ${data.hp_at_1st_level}</p>`;
+  }
+  if (data.hp_at_higher_levels) {
+    html += `<p><strong>Hit Points at Higher Levels:</strong> ${data.hp_at_higher_levels}</p>`;
+  }
+  if (data.saving_throws) {
+    html += `<p><strong>Saving Throw Proficiencies:</strong> ${data.saving_throws.join(", ")}</p>`;
+  }
+  if (data.weapon_proficiencies) {
+    html += `<p><strong>Weapon Proficiencies:</strong> ${data.weapon_proficiencies.join(", ")}</p>`;
+  }
+  if (data.tool_proficiencies) {
+    html += `<p><strong>Tool Proficiencies:</strong> ${data.tool_proficiencies.join(", ")}</p>`;
+  }
+  if (data.armor_proficiencies) {
+    html += `<p><strong>Armor Training:</strong> ${data.armor_proficiencies.join(", ")}</p>`;
+  }
+  if (data.skill_proficiencies && data.skill_proficiencies.choose) {
+    html += `<p><strong>Skill Proficiencies:</strong> Choose ${data.skill_proficiencies.choose} from ${data.skill_proficiencies.options.join(", ")}</p>`;
+  }
+  if (data.starting_equipment) {
+    let equipText = "";
+    if (Array.isArray(data.starting_equipment.fixed) && data.starting_equipment.fixed.length > 0) {
+      equipText += data.starting_equipment.fixed.join(", ");
+    }
+    if (Array.isArray(data.starting_equipment.choices)) {
+      data.starting_equipment.choices.forEach(choice => {
+        equipText += `; ${choice[0]} or ${choice[1]}`;
+      });
+    }
+    if (data.starting_equipment.gold_alternative) {
+      equipText += `; or ${data.starting_equipment.gold_alternative} to buy equipment`;
+    }
+    html += `<p><strong>Starting Equipment:</strong> ${equipText.replace(/^; /, "")}</p>`;
+  }
+  if (data.multiclassing && data.multiclassing.prerequisites) {
+    const prereqs = Object.entries(data.multiclassing.prerequisites)
+      .map(([ability, score]) => `${ability} ${score}`)
+      .join(", ");
+    html += `<p><strong>Multiclassing Prerequisite:</strong> ${prereqs}</p>`;
+  }
+
   // Fetch subclass data first if one is selected
   let subData = null;
   if (subclassName) {


### PR DESCRIPTION
## Summary
- define Druid core traits including hit points, proficiencies, starting gear and multiclass prerequisites
- prompt for Druid skill proficiencies and equipment choices
- render class core trait info in the UI

## Testing
- `python -m json.tool data/classes/druid.json`
- `python -m json.tool data/equipment.json`
- `node --check js/script.js`

------
https://chatgpt.com/codex/tasks/task_e_68a4a539a4f4832eb69649a9d2b1a101