### PR TITLE
Hide extra selection summaries when not applicable

### DIFF
--- a/index.html
+++ b/index.html
@@ -291,10 +291,10 @@
       <br><br>
       <button id="confirmClassSelection" class="btn btn-primary">Seleziona Classe</button>
       <div id="classFeatures"></div>
-      <div id="fightingStyleSelection"></div>
-      <div id="divineDomainSelection"></div>
-      <div id="metamagicSelection"></div>
-      <div id="abilityImprovementSelection"></div>
+      <div id="fightingStyleSelection" style="display:none;"></div>
+      <div id="divineDomainSelection" style="display:none;"></div>
+      <div id="metamagicSelection" style="display:none;"></div>
+      <div id="abilityImprovementSelection" style="display:none;"></div>
     </div>
     <!-- Step 5: Equipaggiamento -->
     <div id="step5" class="step">

--- a/js/script.js
+++ b/js/script.js
@@ -386,15 +386,16 @@ function updateExtraSelectionsView() {
 
   function updateContainer(id, title, dataKey) {
     const container = document.getElementById(id);
-    if (container) {
-      const values = (selectedData[dataKey] || []).filter(v => v);
-      if (values.length > 0) {
-        container.innerHTML = `<p><strong>${title}:</strong> ${values.join(", ")}</p>`;
-        container.style.display = "block";
-      } else {
-        container.innerHTML = `<p><strong>${title}:</strong> Nessuna selezione.</p>`;
-        container.style.display = "block";
-      }
+    if (!container) return;
+
+    const values = (selectedData[dataKey] || []).filter(v => v);
+
+    if (values.length > 0) {
+      container.innerHTML = `<p><strong>${title}:</strong> ${values.join(", ")}</p>`;
+      container.style.display = "block";
+    } else {
+      container.innerHTML = "";
+      container.style.display = "none";
     }
   }
 
@@ -410,7 +411,12 @@ function updateExtraSelectionsView() {
     "Ability Score Improvement": ["abilityImprovementSelection", "Ability Score Improvement"]
   };
   Object.entries(summaryMap).forEach(([key, [id, title]]) => {
-    updateContainer(id, title, key);
+    if (selectedData[key] !== undefined) {
+      updateContainer(id, title, key);
+    } else {
+      const container = document.getElementById(id);
+      if (container) container.style.display = "none";
+    }
   });
 
   console.log("✅ Extra selections aggiornate:", selectedData);


### PR DESCRIPTION
## Summary
- Hide extra selection areas in HTML until a class provides data
- Guard extra selection summaries against undefined data and hide when empty

## Testing
- `npm test` *(fails: enoent package.json)*
- `node --check js/script.js`


------
https://chatgpt.com/codex/tasks/task_e_68a4a5ff7db8832e83bc3a48e7097390