### PR TITLE
Add fighter class and subclasses

### DIFF
--- a/data/classes/fighter.json
+++ b/data/classes/fighter.json
@@ -2,13 +2,13 @@
   "name": "Fighter",
   "subclasses": [
     {
-      "name": "Champion",
+      "name": "Arcane Archer",
       "features": [
-        "Improved Critical",
-        "Remarkable Athlete",
-        "Additional Fighting Style",
-        "Superior Critical",
-        "Survivor"
+        "Arcane Archer Lore",
+        "Arcane Shot",
+        "Magic Arrow",
+        "Curving Shot",
+        "Ever-Ready Shot"
       ]
     },
     {
@@ -22,6 +22,39 @@
       ]
     },
     {
+      "name": "Cavalier",
+      "features": [
+        "Bonus Proficiency",
+        "Born to the Saddle",
+        "Unwavering Mark",
+        "Warding Maneuver",
+        "Hold the Line",
+        "Ferocious Charger",
+        "Vigilant Defender"
+      ]
+    },
+    {
+      "name": "Champion",
+      "features": [
+        "Improved Critical",
+        "Remarkable Athlete",
+        "Additional Fighting Style",
+        "Superior Critical",
+        "Survivor"
+      ]
+    },
+    {
+      "name": "Echo Knight",
+      "features": [
+        "Manifest Echo",
+        "Unleash Incarnation",
+        "Echo Avatar",
+        "Shadow Martyr",
+        "Reclaim Potential",
+        "Legion of One"
+      ]
+    },
+    {
       "name": "Eldritch Knight",
       "features": [
         "Spellcasting",
@@ -31,20 +64,182 @@
         "Arcane Charge",
         "Improved War Magic"
       ]
+    },
+    {
+      "name": "Psi Warrior",
+      "features": [
+        "Psionic Power",
+        "Telekinetic Adept",
+        "Guarded Mind",
+        "Bulwark of Force",
+        "Telekinetic Master"
+      ]
+    },
+    {
+      "name": "Purple Dragon Knight (Banneret)",
+      "features": [
+        "Rallying Cry",
+        "Royal Envoy",
+        "Inspiring Surge",
+        "Bulwark"
+      ]
+    },
+    {
+      "name": "Rune Knight",
+      "features": [
+        "Bonus Proficiencies",
+        "Rune Carver",
+        "Giant's Might",
+        "Runic Shield",
+        "Great Stature",
+        "Master of Runes",
+        "Runic Juggernaut"
+      ]
+    },
+    {
+      "name": "Samurai",
+      "features": [
+        "Bonus Proficiency",
+        "Fighting Spirit",
+        "Elegant Courtier",
+        "Tireless Spirit",
+        "Rapid Strike",
+        "Strength before Death"
+      ]
     }
   ],
-  "description": "Description for Fighter class.",
+  "description": "A master of martial combat, skilled with a variety of weapons and armor.",
   "features_by_level": {
     "1": [
       {
-        "name": "Fighter Feature 1",
-        "description": "Description for Fighter feature at level 1."
+        "name": "Fighting Style",
+        "description": "Adopt a particular style of fighting as your specialty." 
+      },
+      {
+        "name": "Second Wind",
+        "description": "Use a bonus action to regain hit points equal to 1d10 + your fighter level once per short or long rest."
       }
     ],
     "2": [
       {
-        "name": "Fighter Feature 2",
-        "description": "Description for Fighter feature at level 2."
+        "name": "Action Surge",
+        "description": "Take one additional action on your turn; usable once per short or long rest."
+      }
+    ],
+    "3": [
+      {
+        "name": "Martial Archetype",
+        "description": "Choose an archetype that grants features at 3rd, 7th, 10th, 15th, and 18th levels."
+      }
+    ],
+    "4": [
+      {
+        "name": "Ability Score Improvement",
+        "description": "Increase one ability score by 2 or two scores by 1, or take a feat if allowed."
+      },
+      {
+        "name": "Martial Versatility",
+        "description": "(Optional) When you gain an Ability Score Improvement, you can replace a fighting style or a maneuver you know."
+      }
+    ],
+    "5": [
+      {
+        "name": "Extra Attack",
+        "description": "Attack twice, instead of once, whenever you take the Attack action on your turn."
+      }
+    ],
+    "6": [
+      {
+        "name": "Ability Score Improvement",
+        "description": "Increase one ability score by 2 or two scores by 1, or take a feat if allowed."
+      }
+    ],
+    "7": [
+      {
+        "name": "Martial Archetype Feature",
+        "description": "Gain a feature from your chosen Martial Archetype."
+      }
+    ],
+    "8": [
+      {
+        "name": "Ability Score Improvement",
+        "description": "Increase one ability score by 2 or two scores by 1, or take a feat if allowed."
+      }
+    ],
+    "9": [
+      {
+        "name": "Indomitable",
+        "description": "Reroll a failed saving throw once per long rest."
+      }
+    ],
+    "10": [
+      {
+        "name": "Martial Archetype Feature",
+        "description": "Gain a feature from your chosen Martial Archetype."
+      }
+    ],
+    "11": [
+      {
+        "name": "Extra Attack (2)",
+        "description": "You can attack three times whenever you take the Attack action on your turn."
+      }
+    ],
+    "12": [
+      {
+        "name": "Ability Score Improvement",
+        "description": "Increase one ability score by 2 or two scores by 1, or take a feat if allowed."
+      }
+    ],
+    "13": [
+      {
+        "name": "Indomitable (two uses)",
+        "description": "You can use Indomitable twice between long rests."
+      }
+    ],
+    "14": [
+      {
+        "name": "Ability Score Improvement",
+        "description": "Increase one ability score by 2 or two scores by 1, or take a feat if allowed."
+      }
+    ],
+    "15": [
+      {
+        "name": "Martial Archetype Feature",
+        "description": "Gain a feature from your chosen Martial Archetype."
+      }
+    ],
+    "16": [
+      {
+        "name": "Ability Score Improvement",
+        "description": "Increase one ability score by 2 or two scores by 1, or take a feat if allowed."
+      }
+    ],
+    "17": [
+      {
+        "name": "Action Surge (two uses)",
+        "description": "You can use Action Surge twice between rests, but only once per turn."
+      },
+      {
+        "name": "Indomitable (three uses)",
+        "description": "You can use Indomitable three times between long rests."
+      }
+    ],
+    "18": [
+      {
+        "name": "Martial Archetype Feature",
+        "description": "Gain a feature from your chosen Martial Archetype."
+      }
+    ],
+    "19": [
+      {
+        "name": "Ability Score Improvement",
+        "description": "Increase one ability score by 2 or two scores by 1, or take a feat if allowed."
+      }
+    ],
+    "20": [
+      {
+        "name": "Extra Attack (3)",
+        "description": "You can attack four times whenever you take the Attack action on your turn."
       }
     ]
   },
@@ -57,11 +252,16 @@
       "type": "fighting style",
       "selection": [
         "Archery",
+        "Blind Fighting",
         "Defense",
         "Dueling",
         "Great Weapon Fighting",
+        "Interception",
         "Protection",
-        "Two-Weapon Fighting"
+        "Superior Technique",
+        "Thrown Weapon Fighting",
+        "Two-Weapon Fighting",
+        "Unarmed Fighting"
       ]
     },
     {
@@ -98,21 +298,6 @@
         "Increase one ability score by 2",
         "Increase two ability scores by 1",
         "Feat"
-      ]
-    },
-    {
-      "level": 10,
-      "name": "Additional Fighting Style",
-      "description": "Choose an additional fighting style",
-      "count": 2,
-      "type": "fighting style",
-      "selection": [
-        "Archery",
-        "Defense",
-        "Dueling",
-        "Great Weapon Fighting",
-        "Protection",
-        "Two-Weapon Fighting"
       ]
     },
     {
@@ -165,3 +350,4 @@
     }
   ]
 }
+

--- a/data/subclasses/arcane_archer.json
+++ b/data/subclasses/arcane_archer.json
@@ -1,0 +1,58 @@
+{
+  "name": "Arcane Archer",
+  "description": "Arcane Archers weave magic into their arrows to produce supernatural effects.",
+  "features_by_level": {
+    "3": [
+      {
+        "name": "Arcane Archer Lore",
+        "description": "Gain proficiency in Arcana or Nature and learn the prestidigitation or druidcraft cantrip."
+      },
+      {
+        "name": "Arcane Shot",
+        "description": "Learn two magical shot options to apply to arrows, usable twice per short or long rest."
+      },
+      {
+        "name": "Arcane Shot Options",
+        "description": "Choose from options like Banishing Arrow, Beguiling Arrow, and more to infuse your shots with magic."
+      }
+    ],
+    "7": [
+      {
+        "name": "Magic Arrow",
+        "description": "Your nonmagical arrows become magical for overcoming resistance and immunity."
+      },
+      {
+        "name": "Curving Shot",
+        "description": "Use a bonus action to reroll a missed attack against a different target within 60 feet."
+      },
+      {
+        "name": "Additional Arcane Shot Option",
+        "description": "Learn one additional Arcane Shot option."
+      }
+    ],
+    "10": [
+      {
+        "name": "Additional Arcane Shot Option",
+        "description": "Learn one additional Arcane Shot option."
+      }
+    ],
+    "15": [
+      {
+        "name": "Ever-Ready Shot",
+        "description": "If you roll initiative and have no Arcane Shot uses, regain one use."
+      },
+      {
+        "name": "Additional Arcane Shot Option",
+        "description": "Learn one additional Arcane Shot option."
+      }
+    ],
+    "18": [
+      {
+        "name": "Additional Arcane Shot Option",
+        "description": "Learn one additional Arcane Shot option; your options also deal extra damage."
+      }
+    ]
+  },
+  "choices": []
+}
+

--- a/data/subclasses/battle_master.json
+++ b/data/subclasses/battle_master.json
@@ -5,43 +5,161 @@
     "3": [
       {
         "name": "Combat Superiority",
-        "description": "Description for Combat Superiority."
+        "description": "Learn maneuvers fueled by superiority dice to enhance your attacks."
       },
       {
         "name": "Student of War",
-        "description": "Description for Student of War."
+        "description": "Gain proficiency with one type of artisan's tools of your choice."
       }
     ],
     "7": [
       {
         "name": "Know Your Enemy",
-        "description": "Description for Know Your Enemy."
+        "description": "Spend 1 minute observing or interacting with a creature to learn about its capabilities compared to yours."
       }
     ],
     "10": [
       {
         "name": "Improved Combat Superiority",
-        "description": "Description for Improved Combat Superiority."
+        "description": "Your superiority dice turn into d10s."
       }
     ],
     "15": [
       {
         "name": "Relentless",
-        "description": "Description for Relentless."
+        "description": "Regain 1 superiority die if you start combat with none."
       }
     ]
   },
   "choices": [
     {
       "level": 3,
-      "name": "Battle Master Feature",
-      "description": "Choose an option for the Battle Master subclass",
-      "count": 1,
+      "name": "Maneuvers",
+      "description": "Choose three maneuvers to learn",
+      "count": 3,
+      "type": "maneuver",
       "selection": [
-        "Battle Master Option 1",
-        "Battle Master Option 2"
-      ],
-      "type": "Battle Master Feature"
+        "Commander's Strike",
+        "Disarming Attack",
+        "Distracting Strike",
+        "Evasive Footwork",
+        "Feinting Attack",
+        "Goading Attack",
+        "Lunging Attack",
+        "Maneuvering Attack",
+        "Menacing Attack",
+        "Parry",
+        "Precision Attack",
+        "Pushing Attack",
+        "Rally",
+        "Riposte",
+        "Sweeping Attack",
+        "Trip Attack",
+        "Ambush",
+        "Bait and Switch",
+        "Brace",
+        "Commanding Presence",
+        "Grappling Strike",
+        "Quick Toss",
+        "Tactical Assessment"
+      ]
+    },
+    {
+      "level": 7,
+      "name": "Additional Maneuvers",
+      "description": "Learn two additional maneuvers",
+      "count": 2,
+      "type": "maneuver",
+      "selection": [
+        "Commander's Strike",
+        "Disarming Attack",
+        "Distracting Strike",
+        "Evasive Footwork",
+        "Feinting Attack",
+        "Goading Attack",
+        "Lunging Attack",
+        "Maneuvering Attack",
+        "Menacing Attack",
+        "Parry",
+        "Precision Attack",
+        "Pushing Attack",
+        "Rally",
+        "Riposte",
+        "Sweeping Attack",
+        "Trip Attack",
+        "Ambush",
+        "Bait and Switch",
+        "Brace",
+        "Commanding Presence",
+        "Grappling Strike",
+        "Quick Toss",
+        "Tactical Assessment"
+      ]
+    },
+    {
+      "level": 10,
+      "name": "Additional Maneuvers",
+      "description": "Learn two additional maneuvers",
+      "count": 2,
+      "type": "maneuver",
+      "selection": [
+        "Commander's Strike",
+        "Disarming Attack",
+        "Distracting Strike",
+        "Evasive Footwork",
+        "Feinting Attack",
+        "Goading Attack",
+        "Lunging Attack",
+        "Maneuvering Attack",
+        "Menacing Attack",
+        "Parry",
+        "Precision Attack",
+        "Pushing Attack",
+        "Rally",
+        "Riposte",
+        "Sweeping Attack",
+        "Trip Attack",
+        "Ambush",
+        "Bait and Switch",
+        "Brace",
+        "Commanding Presence",
+        "Grappling Strike",
+        "Quick Toss",
+        "Tactical Assessment"
+      ]
+    },
+    {
+      "level": 15,
+      "name": "Additional Maneuvers",
+      "description": "Learn two additional maneuvers",
+      "count": 2,
+      "type": "maneuver",
+      "selection": [
+        "Commander's Strike",
+        "Disarming Attack",
+        "Distracting Strike",
+        "Evasive Footwork",
+        "Feinting Attack",
+        "Goading Attack",
+        "Lunging Attack",
+        "Maneuvering Attack",
+        "Menacing Attack",
+        "Parry",
+        "Precision Attack",
+        "Pushing Attack",
+        "Rally",
+        "Riposte",
+        "Sweeping Attack",
+        "Trip Attack",
+        "Ambush",
+        "Bait and Switch",
+        "Brace",
+        "Commanding Presence",
+        "Grappling Strike",
+        "Quick Toss",
+        "Tactical Assessment"
+      ]
     }
   ]
 }
+

--- a/data/subclasses/cavalier.json
+++ b/data/subclasses/cavalier.json
@@ -1,0 +1,46 @@
+{
+  "name": "Cavalier",
+  "description": "Cavaliers excel at mounted combat and protecting their allies.",
+  "features_by_level": {
+    "3": [
+      {
+        "name": "Bonus Proficiency",
+        "description": "Gain proficiency in a skill of your choice or learn one language."
+      },
+      {
+        "name": "Born to the Saddle",
+        "description": "You have advantage on checks to stay mounted and mounting or dismounting costs only 5 feet of movement."
+      },
+      {
+        "name": "Unwavering Mark",
+        "description": "Mark foes you hit, imposing disadvantage on attacks that don't include you and enabling a retaliatory strike."
+      }
+    ],
+    "7": [
+      {
+        "name": "Warding Maneuver",
+        "description": "Use a reaction to add 1d8 to a nearby target's AC and grant resistance to the attack's damage."
+      }
+    ],
+    "10": [
+      {
+        "name": "Hold the Line",
+        "description": "Creatures provoke opportunity attacks when they move 5 feet while within your reach, and your hits reduce their speed to 0."
+      }
+    ],
+    "15": [
+      {
+        "name": "Ferocious Charger",
+        "description": "If you move at least 10 feet before hitting a creature, you can knock it prone."
+      }
+    ],
+    "18": [
+      {
+        "name": "Vigilant Defender",
+        "description": "Gain a special reaction each round that can be used for opportunity attacks."
+      }
+    ]
+  },
+  "choices": []
+}
+

--- a/data/subclasses/champion.json
+++ b/data/subclasses/champion.json
@@ -5,45 +5,55 @@
     "3": [
       {
         "name": "Improved Critical",
-        "description": "Description for Improved Critical."
+        "description": "Your weapon attacks score a critical hit on a roll of 19 or 20."
       }
     ],
     "7": [
       {
         "name": "Remarkable Athlete",
-        "description": "Description for Remarkable Athlete."
+        "description": "Add half your proficiency bonus to Strength, Dexterity, or Constitution checks that don't already use it, and increase your running long jump distance."
       }
     ],
     "10": [
       {
         "name": "Additional Fighting Style",
-        "description": "Description for Additional Fighting Style."
+        "description": "You can choose a second option from the Fighting Style class feature."
       }
     ],
     "15": [
       {
         "name": "Superior Critical",
-        "description": "Description for Superior Critical."
+        "description": "Your weapon attacks score a critical hit on a roll of 18-20."
       }
     ],
     "18": [
       {
         "name": "Survivor",
-        "description": "Description for Survivor."
+        "description": "At the start of each of your turns, regain hit points if you have no more than half your hit points left."
       }
     ]
   },
   "choices": [
     {
-      "level": 3,
-      "name": "Champion Feature",
-      "description": "Choose an option for the Champion subclass",
+      "level": 10,
+      "name": "Additional Fighting Style",
+      "description": "Choose an additional fighting style",
       "count": 1,
+      "type": "fighting style",
       "selection": [
-        "Champion Option 1",
-        "Champion Option 2"
-      ],
-      "type": "Champion Feature"
+        "Archery",
+        "Blind Fighting",
+        "Defense",
+        "Dueling",
+        "Great Weapon Fighting",
+        "Interception",
+        "Protection",
+        "Superior Technique",
+        "Thrown Weapon Fighting",
+        "Two-Weapon Fighting",
+        "Unarmed Fighting"
+      ]
     }
   ]
 }
+

--- a/data/subclasses/echo_knight.json
+++ b/data/subclasses/echo_knight.json
@@ -1,0 +1,42 @@
+{
+  "name": "Echo Knight",
+  "description": "Echo Knights manifest shades of themselves from unrealized timelines to aid in battle.",
+  "features_by_level": {
+    "3": [
+      {
+        "name": "Manifest Echo",
+        "description": "Use a bonus action to create a magical echo that you can move and attack from."
+      },
+      {
+        "name": "Unleash Incarnation",
+        "description": "When you take the Attack action, make an additional melee attack from your echo's position a number of times equal to your Constitution modifier per long rest."
+      }
+    ],
+    "7": [
+      {
+        "name": "Echo Avatar",
+        "description": "Project your consciousness into your echo, allowing it to scout up to 1,000 feet away."
+      }
+    ],
+    "10": [
+      {
+        "name": "Shadow Martyr",
+        "description": "Use your reaction to have your echo intercept an attack meant for another creature."
+      }
+    ],
+    "15": [
+      {
+        "name": "Reclaim Potential",
+        "description": "When your echo is destroyed, gain temporary hit points."
+      }
+    ],
+    "18": [
+      {
+        "name": "Legion of One",
+        "description": "Create two echoes at once and regain an Unleash Incarnation use if you have none when rolling initiative."
+      }
+    ]
+  },
+  "choices": []
+}
+

--- a/data/subclasses/eldritch_knight.json
+++ b/data/subclasses/eldritch_knight.json
@@ -5,49 +5,38 @@
     "3": [
       {
         "name": "Spellcasting",
-        "description": "Description for Spellcasting."
+        "description": "Augment your combat with wizard spells, focusing on abjuration and evocation."
       },
       {
         "name": "Weapon Bond",
-        "description": "Description for Weapon Bond."
+        "description": "Perform a ritual to bond with a weapon, preventing disarmament and allowing you to summon it."
       }
     ],
     "7": [
       {
         "name": "War Magic",
-        "description": "Description for War Magic."
+        "description": "After casting a cantrip, make one weapon attack as a bonus action."
       }
     ],
     "10": [
       {
         "name": "Eldritch Strike",
-        "description": "Description for Eldritch Strike."
+        "description": "When you hit a creature, it has disadvantage on the next saving throw against a spell you cast."
       }
     ],
     "15": [
       {
         "name": "Arcane Charge",
-        "description": "Description for Arcane Charge."
+        "description": "When you use Action Surge, teleport up to 30 feet before or after the additional action."
       }
     ],
     "18": [
       {
         "name": "Improved War Magic",
-        "description": "Description for Improved War Magic."
+        "description": "After casting a spell, make one weapon attack as a bonus action."
       }
     ]
   },
-  "choices": [
-    {
-      "level": 3,
-      "name": "Eldritch Knight Feature",
-      "description": "Choose an option for the Eldritch Knight subclass",
-      "count": 1,
-      "selection": [
-        "Eldritch Knight Option 1",
-        "Eldritch Knight Option 2"
-      ],
-      "type": "Eldritch Knight Feature"
-    }
-  ]
+  "choices": []
 }
+

--- a/data/subclasses/psi_warrior.json
+++ b/data/subclasses/psi_warrior.json
@@ -1,0 +1,38 @@
+{
+  "name": "Psi Warrior",
+  "description": "Psi Warriors augment their physical might with psionic energy.",
+  "features_by_level": {
+    "3": [
+      {
+        "name": "Psionic Power",
+        "description": "Harness psionic energy dice to fuel defensive fields, psionic strikes, and telekinetic movement."
+      }
+    ],
+    "7": [
+      {
+        "name": "Telekinetic Adept",
+        "description": "Use psionic energy to propel yourself or to shove foes with Telekinetic Thrust."
+      }
+    ],
+    "10": [
+      {
+        "name": "Guarded Mind",
+        "description": "Gain resistance to psychic damage and end charm or fear by expending a psionic die."
+      }
+    ],
+    "15": [
+      {
+        "name": "Bulwark of Force",
+        "description": "As a bonus action, grant half cover to yourself and nearby allies for 1 minute."
+      }
+    ],
+    "18": [
+      {
+        "name": "Telekinetic Master",
+        "description": "Cast telekinesis without components and make a weapon attack as a bonus action while maintaining it."
+      }
+    ]
+  },
+  "choices": []
+}
+

--- a/data/subclasses/purple_dragon_knight.json
+++ b/data/subclasses/purple_dragon_knight.json
@@ -1,0 +1,38 @@
+{
+  "name": "Purple Dragon Knight",
+  "description": "Purple Dragon Knights inspire greatness in others through brave deeds and leadership.",
+  "features_by_level": {
+    "3": [
+      {
+        "name": "Rallying Cry",
+        "description": "When you use Second Wind, choose up to three allies to regain hit points equal to your fighter level."
+      }
+    ],
+    "7": [
+      {
+        "name": "Royal Envoy",
+        "description": "Gain proficiency in Persuasion, and your proficiency bonus is doubled for checks using it."
+      }
+    ],
+    "10": [
+      {
+        "name": "Inspiring Surge",
+        "description": "When you use Action Surge, one ally within 60 feet can make a weapon attack with its reaction."
+      }
+    ],
+    "15": [
+      {
+        "name": "Bulwark",
+        "description": "When you use Indomitable on a mental save, an ally within 60 feet can reroll a failed save against the same effect."
+      }
+    ],
+    "18": [
+      {
+        "name": "Inspiring Surge Improvement",
+        "description": "When you use Action Surge, two allies can make attacks instead of one."
+      }
+    ]
+  },
+  "choices": []
+}
+

--- a/data/subclasses/rune_knight.json
+++ b/data/subclasses/rune_knight.json
@@ -1,0 +1,58 @@
+{
+  "name": "Rune Knight",
+  "description": "Rune Knights use the magical power of runes to enhance their martial prowess.",
+  "features_by_level": {
+    "3": [
+      {
+        "name": "Bonus Proficiencies",
+        "description": "Gain proficiency with smith's tools and learn the Giant language."
+      },
+      {
+        "name": "Rune Carver",
+        "description": "Learn two magical runes, inscribing them on gear to gain special powers."
+      },
+      {
+        "name": "Giant's Might",
+        "description": "As a bonus action, become Large, gain advantage on Strength checks and saves, and deal extra damage."
+      }
+    ],
+    "7": [
+      {
+        "name": "Runic Shield",
+        "description": "Use a reaction to force an attacker to reroll an attack against a creature within 60 feet."
+      },
+      {
+        "name": "Additional Rune Known",
+        "description": "Learn one additional rune."
+      }
+    ],
+    "10": [
+      {
+        "name": "Great Stature",
+        "description": "Grow 3d4 inches and your Giant's Might extra damage increases to 1d8."
+      },
+      {
+        "name": "Additional Rune Known",
+        "description": "Learn one additional rune."
+      }
+    ],
+    "15": [
+      {
+        "name": "Master of Runes",
+        "description": "Invoke each rune you know twice per rest instead of once."
+      },
+      {
+        "name": "Additional Rune Known",
+        "description": "Learn one additional rune."
+      }
+    ],
+    "18": [
+      {
+        "name": "Runic Juggernaut",
+        "description": "Giant's Might extra damage becomes 1d10, you can grow to Huge size, and your reach increases by 5 feet."
+      }
+    ]
+  },
+  "choices": []
+}
+

--- a/data/subclasses/samurai.json
+++ b/data/subclasses/samurai.json
@@ -1,0 +1,42 @@
+{
+  "name": "Samurai",
+  "description": "Samurai draw on an implacable fighting spirit to overcome enemies.",
+  "features_by_level": {
+    "3": [
+      {
+        "name": "Bonus Proficiency",
+        "description": "Gain proficiency in one skill or one language of your choice."
+      },
+      {
+        "name": "Fighting Spirit",
+        "description": "As a bonus action, gain advantage on weapon attacks until end of turn and temporary hit points, usable three times per long rest."
+      }
+    ],
+    "7": [
+      {
+        "name": "Elegant Courtier",
+        "description": "Add your Wisdom modifier to Persuasion checks and gain proficiency in Wisdom saves or another save."
+      }
+    ],
+    "10": [
+      {
+        "name": "Tireless Spirit",
+        "description": "Regain one use of Fighting Spirit when you roll initiative and have none."
+      }
+    ],
+    "15": [
+      {
+        "name": "Rapid Strike",
+        "description": "Forgo advantage on an attack to make an additional weapon attack against the same target."
+      }
+    ],
+    "18": [
+      {
+        "name": "Strength before Death",
+        "description": "Use your reaction to take an extra turn when reduced to 0 hit points, before falling unconscious."
+      }
+    ]
+  },
+  "choices": []
+}
+


### PR DESCRIPTION
## Summary
- expand Fighter class with full level progression and fighting style options
- add detailed Fighter subclasses including Arcane Archer, Cavalier, Echo Knight, Psi Warrior, Purple Dragon Knight, Rune Knight, Samurai
- refine Champion, Battle Master, and Eldritch Knight subclass data

## Testing
- `python -m json.tool data/subclasses/arcane_archer.json`
- `npm test` *(fails: package.json not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a4a5eccfc4832eab473e28a34e6742