### PR TITLE
feat: expand ranger class data

### DIFF
--- a/data/classes/ranger.json
+++ b/data/classes/ranger.json
@@ -1,6 +1,268 @@
 {
   "name": "Ranger",
+  "description": "A warrior of the wilderness who uses martial prowess and nature magic to hunt foes.",
+  "hit_die": "d10",
+  "hp_at_1st_level": "10 + your Constitution modifier",
+  "hp_at_higher_levels": "1d10 (or 6) + your Constitution modifier per Ranger level after 1st",
+  "saving_throws": ["Strength", "Dexterity"],
+  "skill_proficiencies": {
+    "choose": 3,
+    "options": [
+      "Animal Handling",
+      "Athletics",
+      "Insight",
+      "Investigation",
+      "Nature",
+      "Perception",
+      "Stealth",
+      "Survival"
+    ]
+  },
+  "weapon_proficiencies": ["simple weapons", "martial weapons"],
+  "armor_proficiencies": ["light armor", "medium armor", "shields"],
+  "starting_equipment": {
+    "choices": [
+      ["Scale mail", "Leather armor"],
+      ["Two shortswords", "Two simple melee weapons"],
+      ["Dungeoneer's pack", "Explorer's pack"]
+    ],
+    "fixed": ["Longbow", "Quiver of 20 arrows"],
+    "gold_alternative": "5d4 × 10 gp"
+  },
+  "multiclassing": {
+    "prerequisites": {"Dexterity": 13, "Wisdom": 13},
+    "proficiencies": {
+      "skills": {
+        "choose": 1,
+        "options": [
+          "Animal Handling",
+          "Athletics",
+          "Insight",
+          "Investigation",
+          "Nature",
+          "Perception",
+          "Stealth",
+          "Survival"
+        ]
+      },
+      "weapons": ["simple weapons", "martial weapons"],
+      "armor": ["light armor", "medium armor", "shields"]
+    }
+  },
+  "features_by_level": {
+    "1": [
+      {
+        "name": "Favored Enemy",
+        "description": "Choose a type of enemy to study; gain advantage on tracking and recalling information about it and learn a language it speaks."
+      },
+      {
+        "name": "Favored Foe",
+        "description": "(Optional) Mark a target you hit to deal an extra 1d4 damage once per turn for up to 1 minute, a number of times equal to your proficiency bonus."
+      },
+      {
+        "name": "Natural Explorer",
+        "description": "Choose a favored terrain; you and your group gain bonuses while traveling and for related checks there."
+      },
+      {
+        "name": "Deft Explorer",
+        "description": "(Optional) Gain the Canny benefit: expertise in one skill and two extra languages, with more benefits at higher levels."
+      }
+    ],
+    "2": [
+      {
+        "name": "Fighting Style",
+        "description": "Adopt a particular style of fighting such as Archery or Two-Weapon Fighting."
+      },
+      {
+        "name": "Spellcasting",
+        "description": "Use Wisdom to cast ranger spells; you know two 1st-level spells and gain more as you level."
+      },
+      {
+        "name": "Spellcasting Focus",
+        "description": "(Optional) You can use a druidic focus as a spellcasting focus for your ranger spells."
+      }
+    ],
+    "3": [
+      {
+        "name": "Ranger Archetype",
+        "description": "Choose a ranger archetype that grants features at 3rd, 7th, 11th, and 15th levels."
+      },
+      {
+        "name": "Primeval Awareness",
+        "description": "Expend a spell slot to sense if certain creature types are nearby for 1 minute per slot level."
+      },
+      {
+        "name": "Primal Awareness",
+        "description": "(Optional) Learn themed spells like speak with animals and cast each once per long rest without using a slot."
+      }
+    ],
+    "4": [
+      {
+        "name": "Ability Score Improvement",
+        "description": "Increase one ability score by 2 or two scores by 1, or take a feat if allowed."
+      },
+      {
+        "name": "Martial Versatility",
+        "description": "(Optional) Whenever you gain an Ability Score Improvement, you can replace a fighting style you know."
+      }
+    ],
+    "5": [
+      {
+        "name": "Extra Attack",
+        "description": "You can attack twice, instead of once, whenever you take the Attack action on your turn."
+      }
+    ],
+    "6": [
+      {
+        "name": "Favored Enemy and Natural Explorer Improvement",
+        "description": "Choose an additional favored enemy and favored terrain, gaining the associated benefits."
+      },
+      {
+        "name": "Deft Explorer: Roving",
+        "description": "(Optional) Your speed increases by 5 feet, and you gain climbing and swimming speeds equal to your walking speed."
+      }
+    ],
+    "7": [
+      {
+        "name": "Ranger Archetype Feature",
+        "description": "Gain a feature from your chosen ranger archetype."
+      }
+    ],
+    "8": [
+      {
+        "name": "Ability Score Improvement",
+        "description": "Increase one ability score by 2 or two scores by 1, or take a feat if allowed."
+      },
+      {
+        "name": "Land's Stride",
+        "description": "Move through nonmagical difficult terrain without extra movement and gain advantages against plants that impede movement."
+      }
+    ],
+    "10": [
+      {
+        "name": "Hide in Plain Sight",
+        "description": "Spend 1 minute crafting camouflage to gain +10 to Stealth while motionless and not taking actions."
+      },
+      {
+        "name": "Nature's Veil",
+        "description": "(Optional) As a bonus action, become invisible until the start of your next turn, usable PB times per long rest."
+      },
+      {
+        "name": "Natural Explorer Improvement",
+        "description": "Choose another favored terrain type."
+      },
+      {
+        "name": "Deft Explorer: Tireless",
+        "description": "(Optional) As an action, gain temporary hit points and reduce exhaustion by 1 after a short rest."
+      }
+    ],
+    "11": [
+      {
+        "name": "Ranger Archetype Feature",
+        "description": "Gain a feature from your chosen ranger archetype."
+      }
+    ],
+    "12": [
+      {
+        "name": "Ability Score Improvement",
+        "description": "Increase one ability score by 2 or two scores by 1, or take a feat if allowed."
+      }
+    ],
+    "14": [
+      {
+        "name": "Vanish",
+        "description": "Use the Hide action as a bonus action, and you can't be tracked by nonmagical means."
+      },
+      {
+        "name": "Favored Enemy Improvement",
+        "description": "Choose one additional favored enemy and learn its language."
+      }
+    ],
+    "15": [
+      {
+        "name": "Ranger Archetype Feature",
+        "description": "Gain a feature from your chosen ranger archetype."
+      }
+    ],
+    "16": [
+      {
+        "name": "Ability Score Improvement",
+        "description": "Increase one ability score by 2 or two scores by 1, or take a feat if allowed."
+      }
+    ],
+    "18": [
+      {
+        "name": "Feral Senses",
+        "description": "You are aware of the location of any invisible creature within 30 feet of you, and you don't suffer disadvantage when attacking unseen creatures."
+      }
+    ],
+    "19": [
+      {
+        "name": "Ability Score Improvement",
+        "description": "Increase one ability score by 2 or two scores by 1, or take a feat if allowed."
+      }
+    ],
+    "20": [
+      {
+        "name": "Foe Slayer",
+        "description": "Once on each of your turns, add your Wisdom modifier to the attack or damage roll against a favored enemy."
+      }
+    ]
+  },
   "subclasses": [
+    {
+      "name": "Beast Master",
+      "features": [
+        "Ranger's Companion",
+        "Primal Companion",
+        "Exceptional Training",
+        "Bestial Fury",
+        "Share Spells"
+      ]
+    },
+    {
+      "name": "Drakewarden",
+      "features": [
+        "Draconic Gift",
+        "Drake Companion",
+        "Bond of Fang and Scale",
+        "Drake's Breath",
+        "Perfected Bond"
+      ]
+    },
+    {
+      "name": "Fey Wanderer",
+      "features": [
+        "Dreadful Strikes",
+        "Fey Wanderer Magic",
+        "Otherworldly Glamour",
+        "Beguiling Twist",
+        "Fey Reinforcements",
+        "Misty Wanderer"
+      ]
+    },
+    {
+      "name": "Gloom Stalker",
+      "features": [
+        "Gloom Stalker Magic",
+        "Dread Ambusher",
+        "Umbral Sight",
+        "Iron Mind",
+        "Stalker's Flurry",
+        "Shadowy Dodge"
+      ]
+    },
+    {
+      "name": "Horizon Walker",
+      "features": [
+        "Horizon Walker Magic",
+        "Detect Portal",
+        "Planar Warrior",
+        "Ethereal Step",
+        "Distant Strike",
+        "Spectral Defense"
+      ]
+    },
     {
       "name": "Hunter",
       "features": [
@@ -11,31 +273,45 @@
       ]
     },
     {
-      "name": "Beast Master",
+      "name": "Monster Slayer",
       "features": [
-        "Ranger's Companion",
-        "Exceptional Training",
-        "Bestial Fury",
-        "Share Spells"
+        "Monster Slayer Magic",
+        "Hunter's Sense",
+        "Slayer's Prey",
+        "Supernatural Defense",
+        "Magic-User's Nemesis",
+        "Slayer's Counter"
+      ]
+    },
+    {
+      "name": "Swarmkeeper",
+      "features": [
+        "Gathered Swarm",
+        "Swarmkeeper Magic",
+        "Writhing Tide",
+        "Mighty Swarm",
+        "Swarming Dispersal"
       ]
     }
   ],
-  "description": "Description for Ranger class.",
-  "features_by_level": {
-    "1": [
-      {
-        "name": "Ranger Feature 1",
-        "description": "Description for Ranger feature at level 1."
-      }
-    ],
-    "2": [
-      {
-        "name": "Ranger Feature 2",
-        "description": "Description for Ranger feature at level 2."
-      }
-    ]
-  },
   "choices": [
+    {
+      "level": 1,
+      "name": "Skill Proficiency",
+      "description": "Choose three skills from the ranger list",
+      "count": 3,
+      "type": "skills",
+      "selection": [
+        "Animal Handling",
+        "Athletics",
+        "Insight",
+        "Investigation",
+        "Nature",
+        "Perception",
+        "Stealth",
+        "Survival"
+      ]
+    },
     {
       "level": 1,
       "name": "Favored Enemy",
@@ -45,9 +321,18 @@
       "selection": [
         "Aberrations",
         "Beasts",
+        "Celestials",
+        "Constructs",
         "Dragons",
+        "Elementals",
+        "Fey",
+        "Fiends",
+        "Giants",
         "Monstrosities",
-        "Undead"
+        "Oozes",
+        "Plants",
+        "Undead",
+        "Two Humanoid Races"
       ]
     },
     {
@@ -65,6 +350,22 @@
         "Mountain",
         "Swamp",
         "Underdark"
+      ]
+    },
+    {
+      "level": 2,
+      "name": "Fighting Style",
+      "description": "Choose a fighting style",
+      "count": 1,
+      "type": "fighting style",
+      "selection": [
+        "Archery",
+        "Blind Fighting",
+        "Defense",
+        "Druidic Warrior",
+        "Dueling",
+        "Thrown Weapon Fighting",
+        "Two-Weapon Fighting"
       ]
     },
     {

--- a/data/subclasses/beast_master.json
+++ b/data/subclasses/beast_master.json
@@ -1,43 +1,34 @@
 {
   "name": "Beast Master",
-  "description": "Beast Masters bond with an animal companion to fight alongside them.",
+  "description": "Beast Masters bond with a beast companion that fights alongside them.",
   "features_by_level": {
     "3": [
       {
         "name": "Ranger's Companion",
-        "description": "Description for Ranger's Companion."
+        "description": "Gain a beast companion that obeys your commands and acts on your initiative."
+      },
+      {
+        "name": "Primal Companion",
+        "description": "(Optional) Summon a primal beast spirit and command it using a bonus action; it can be resummoned after a long rest."
       }
     ],
     "7": [
       {
         "name": "Exceptional Training",
-        "description": "Description for Exceptional Training."
+        "description": "When the beast doesn't attack, you can command it as a bonus action to Dash, Disengage, or Help, and its attacks count as magical."
       }
     ],
     "11": [
       {
         "name": "Bestial Fury",
-        "description": "Description for Bestial Fury."
+        "description": "When you command the beast to Attack, it can make two attacks or use its Multiattack."
       }
     ],
     "15": [
       {
         "name": "Share Spells",
-        "description": "Description for Share Spells."
+        "description": "When you cast a spell targeting yourself, it also affects your beast companion within 30 feet."
       }
     ]
-  },
-  "choices": [
-    {
-      "level": 3,
-      "name": "Beast Master Feature",
-      "description": "Choose an option for the Beast Master subclass",
-      "count": 1,
-      "selection": [
-        "Beast Master Option 1",
-        "Beast Master Option 2"
-      ],
-      "type": "Beast Master Feature"
-    }
-  ]
+  }
 }

--- a/data/subclasses/drakewarden.json
+++ b/data/subclasses/drakewarden.json
@@ -1,0 +1,34 @@
+{
+  "name": "Drakewarden",
+  "description": "Your bond with a draconic spirit manifests as a loyal drake companion.",
+  "features_by_level": {
+    "3": [
+      {
+        "name": "Draconic Gift",
+        "description": "Learn the thaumaturgy cantrip and speak, read, and write Draconic or another language of your choice."
+      },
+      {
+        "name": "Drake Companion",
+        "description": "As an action, summon a drake spirit that fights alongside you and can be commanded with a bonus action."
+      }
+    ],
+    "7": [
+      {
+        "name": "Bond of Fang and Scale",
+        "description": "Your drake grows wings and grants you resistance to its damage type; its Bite deals extra damage and it can serve as a mount."
+      }
+    ],
+    "11": [
+      {
+        "name": "Drake's Breath",
+        "description": "As an action, you or your drake exhale a 30-foot cone dealing 8d6 damage of a chosen type, once per long rest or by expending a spell slot."
+      }
+    ],
+    "15": [
+      {
+        "name": "Perfected Bond",
+        "description": "Your drake grows to Large, its Bite gains extra damage, and you can react to grant resistance to damage to you or the drake."
+      }
+    ]
+  }
+}

--- a/data/subclasses/fey_wanderer.json
+++ b/data/subclasses/fey_wanderer.json
@@ -1,0 +1,48 @@
+{
+  "name": "Fey Wanderer",
+  "description": "Blessed by fey magic, you stride between the mortal world and the Feywild.",
+  "features_by_level": {
+    "3": [
+      {
+        "name": "Dreadful Strikes",
+        "description": "Once per turn, deal an extra 1d4 psychic damage when you hit with a weapon."
+      },
+      {
+        "name": "Fey Wanderer Magic",
+        "description": "Gain additional spells such as charm person, misty step, and more at higher levels."
+      },
+      {
+        "name": "Otherworldly Glamour",
+        "description": "Add your Wisdom modifier to Charisma checks and gain proficiency in Deception, Performance, or Persuasion."
+      }
+    ],
+    "7": [
+      {
+        "name": "Beguiling Twist",
+        "description": "When you or an ally succeeds on a save against being charmed or frightened, you can force another creature to make a Wisdom save or be charmed or frightened."
+      }
+    ],
+    "11": [
+      {
+        "name": "Fey Reinforcements",
+        "description": "You can cast summon fey without material components and once per long rest without expending a spell slot, optionally without concentration."
+      }
+    ],
+    "15": [
+      {
+        "name": "Misty Wanderer",
+        "description": "Cast misty step a number of times equal to your Wisdom modifier each long rest and bring a willing creature with you."
+      }
+    ]
+  },
+  "choices": [
+    {
+      "level": 3,
+      "name": "Otherworldly Glamour Skill",
+      "description": "Gain proficiency in one skill",
+      "count": 1,
+      "type": "skills",
+      "selection": ["Deception", "Performance", "Persuasion"]
+    }
+  ]
+}

--- a/data/subclasses/gloom_stalker.json
+++ b/data/subclasses/gloom_stalker.json
@@ -1,0 +1,38 @@
+{
+  "name": "Gloom Stalker",
+  "description": "Masters of the dark, Gloom Stalkers ambush foes from the shadows.",
+  "features_by_level": {
+    "3": [
+      {
+        "name": "Gloom Stalker Magic",
+        "description": "Gain additional spells such as disguise self and rope trick at higher levels."
+      },
+      {
+        "name": "Dread Ambusher",
+        "description": "Gain bonus to initiative, extra speed on the first turn, and an extra attack that deals +1d8 damage."
+      },
+      {
+        "name": "Umbral Sight",
+        "description": "Gain darkvision or extend it and become invisible to creatures relying on darkvision while in darkness."
+      }
+    ],
+    "7": [
+      {
+        "name": "Iron Mind",
+        "description": "Gain proficiency in Wisdom saving throws, or in Intelligence or Charisma if already proficient."
+      }
+    ],
+    "11": [
+      {
+        "name": "Stalker's Flurry",
+        "description": "Once per turn when you miss a weapon attack, make another attack."
+      }
+    ],
+    "15": [
+      {
+        "name": "Shadowy Dodge",
+        "description": "Use your reaction to impose disadvantage on an attack against you if the attacker doesn't have advantage."
+      }
+    ]
+  }
+}

--- a/data/subclasses/horizon_walker.json
+++ b/data/subclasses/horizon_walker.json
@@ -1,0 +1,38 @@
+{
+  "name": "Horizon Walker",
+  "description": "Horizon Walkers guard the world against extraplanar threats.",
+  "features_by_level": {
+    "3": [
+      {
+        "name": "Horizon Walker Magic",
+        "description": "Gain additional spells such as protection from evil and good and misty step at higher levels."
+      },
+      {
+        "name": "Detect Portal",
+        "description": "As an action, magically sense the distance and direction to the nearest planar portal within 1 mile."
+      },
+      {
+        "name": "Planar Warrior",
+        "description": "As a bonus action, choose a creature; the next time you hit it this turn, all damage becomes force and deals +1d8 force damage."
+      }
+    ],
+    "7": [
+      {
+        "name": "Ethereal Step",
+        "description": "As a bonus action, cast etherealness without a spell slot, lasting until the end of the current turn, once per rest."
+      }
+    ],
+    "11": [
+      {
+        "name": "Distant Strike",
+        "description": "Teleport up to 10 feet before each attack, and if you attack two different creatures, you can make a third attack."
+      }
+    ],
+    "15": [
+      {
+        "name": "Spectral Defense",
+        "description": "When you take damage, use your reaction to gain resistance to that attack's damage."
+      }
+    ]
+  }
+}

--- a/data/subclasses/hunter.json
+++ b/data/subclasses/hunter.json
@@ -1,43 +1,64 @@
 {
   "name": "Hunter",
-  "description": "Hunters seek to master any combat style that nature provides.",
+  "description": "Hunters adapt their tactics to fight the threats of the wilds.",
   "features_by_level": {
     "3": [
       {
         "name": "Hunter's Prey",
-        "description": "Description for Hunter's Prey."
+        "description": "Choose a tactic to focus your attacks against certain foes."
       }
     ],
     "7": [
       {
         "name": "Defensive Tactics",
-        "description": "Description for Defensive Tactics."
+        "description": "Select a defensive technique to hinder enemy assaults."
       }
     ],
     "11": [
       {
         "name": "Multiattack",
-        "description": "Description for Multiattack."
+        "description": "Choose how you engage multiple foes at once."
       }
     ],
     "15": [
       {
         "name": "Superior Hunter's Defense",
-        "description": "Description for Superior Hunter's Defense."
+        "description": "Select a powerful defensive ability to protect yourself."
       }
     ]
   },
   "choices": [
     {
       "level": 3,
-      "name": "Hunter Feature",
-      "description": "Choose an option for the Hunter subclass",
+      "name": "Hunter's Prey",
+      "description": "Choose a Hunter's Prey option",
       "count": 1,
-      "selection": [
-        "Hunter Option 1",
-        "Hunter Option 2"
-      ],
-      "type": "Hunter Feature"
+      "type": "Hunter's Prey",
+      "selection": ["Colossus Slayer", "Giant Killer", "Horde Breaker"]
+    },
+    {
+      "level": 7,
+      "name": "Defensive Tactics",
+      "description": "Choose a Defensive Tactics option",
+      "count": 1,
+      "type": "Defensive Tactics",
+      "selection": ["Escape the Horde", "Multiattack Defense", "Steel Will"]
+    },
+    {
+      "level": 11,
+      "name": "Multiattack",
+      "description": "Choose a Multiattack option",
+      "count": 1,
+      "type": "Multiattack",
+      "selection": ["Volley", "Whirlwind Attack"]
+    },
+    {
+      "level": 15,
+      "name": "Superior Hunter's Defense",
+      "description": "Choose a Superior Hunter's Defense option",
+      "count": 1,
+      "type": "Superior Hunter's Defense",
+      "selection": ["Evasion", "Stand Against the Tide", "Uncanny Dodge"]
     }
   ]
 }

--- a/data/subclasses/monster_slayer.json
+++ b/data/subclasses/monster_slayer.json
@@ -1,0 +1,38 @@
+{
+  "name": "Monster Slayer",
+  "description": "Monster Slayers hunt down creatures of supernatural evil.",
+  "features_by_level": {
+    "3": [
+      {
+        "name": "Monster Slayer Magic",
+        "description": "Gain additional spells such as protection from evil and good and zone of truth at higher levels."
+      },
+      {
+        "name": "Hunter's Sense",
+        "description": "As an action, learn a creature's damage immunities, resistances, and vulnerabilities."
+      },
+      {
+        "name": "Slayer's Prey",
+        "description": "As a bonus action, mark a creature to deal an extra 1d6 damage to it once per turn."
+      }
+    ],
+    "7": [
+      {
+        "name": "Supernatural Defense",
+        "description": "Add 1d6 to saving throws or checks to escape a grapple imposed by your Slayer's Prey target."
+      }
+    ],
+    "11": [
+      {
+        "name": "Magic-User's Nemesis",
+        "description": "As a reaction, force a creature casting a spell or teleporting to make a Wisdom save or have the effect fail."
+      }
+    ],
+    "15": [
+      {
+        "name": "Slayer's Counter",
+        "description": "When your Slayer's Prey forces you to make a saving throw, make a weapon attack; on hit, the save automatically succeeds."
+      }
+    ]
+  }
+}

--- a/data/subclasses/swarmkeeper.json
+++ b/data/subclasses/swarmkeeper.json
@@ -1,0 +1,34 @@
+{
+  "name": "Swarmkeeper",
+  "description": "Swarmkeepers host a swarm of nature spirits that can aid them in battle.",
+  "features_by_level": {
+    "3": [
+      {
+        "name": "Gathered Swarm",
+        "description": "Once per turn after you hit, your swarm can deal 1d6 piercing damage, move the target, or move you 5 feet."
+      },
+      {
+        "name": "Swarmkeeper Magic",
+        "description": "Gain mage hand and additional spells like faerie fire and web at higher levels."
+      }
+    ],
+    "7": [
+      {
+        "name": "Writhing Tide",
+        "description": "As a bonus action, gain a flying speed of 10 feet and hover for 1 minute, a number of times per long rest equal to your proficiency bonus."
+      }
+    ],
+    "11": [
+      {
+        "name": "Mighty Swarm",
+        "description": "Your swarm's damage increases to 1d8, can knock prone on failed save, and grants half cover when moving you."
+      }
+    ],
+    "15": [
+      {
+        "name": "Swarming Dispersal",
+        "description": "As a reaction when you take damage, gain resistance and teleport up to 30 feet, a number of times per long rest equal to your proficiency bonus."
+      }
+    ]
+  }
+}


### PR DESCRIPTION
## Summary
- add detailed JSON files for drakewarden, fey wanderer, gloom stalker, horizon walker, monster slayer, and swarmkeeper ranger subclasses
- update beast master and hunter subclass files with full feature descriptions and option selections

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a4a9848280832eaa313481bce34fcb