### PR TITLE
Add Rogue class details and subclasses

### DIFF
--- a/data/classes/rogue.json
+++ b/data/classes/rogue.json
@@ -30,20 +30,201 @@
         "Versatile Trickster",
         "Spell Thief"
       ]
+    },
+    {
+      "name": "Inquisitive",
+      "features": [
+        "Ear for Deceit",
+        "Eye for Detail",
+        "Insightful Fighting",
+        "Steady Eye",
+        "Unerring Eye",
+        "Eye for Weakness"
+      ]
+    },
+    {
+      "name": "Mastermind",
+      "features": [
+        "Master of Intrigue",
+        "Master of Tactics",
+        "Insightful Manipulator",
+        "Misdirection",
+        "Soul of Deceit"
+      ]
+    },
+    {
+      "name": "Phantom",
+      "features": [
+        "Whispers of the Dead",
+        "Wails from the Grave",
+        "Tokens of the Departed",
+        "Ghost Walk",
+        "Death's Friend"
+      ]
+    },
+    {
+      "name": "Scout",
+      "features": [
+        "Skirmisher",
+        "Survivalist",
+        "Superior Mobility",
+        "Ambush Master",
+        "Sudden Strike"
+      ]
+    },
+    {
+      "name": "Soulknife",
+      "features": [
+        "Psionic Power",
+        "Psychic Blades",
+        "Soul Blades",
+        "Psychic Veil",
+        "Rend Mind"
+      ]
+    },
+    {
+      "name": "Swashbuckler",
+      "features": [
+        "Fancy Footwork",
+        "Rakish Audacity",
+        "Panache",
+        "Elegant Maneuver",
+        "Master Duelist"
+      ]
     }
   ],
-  "description": "Description for Rogue class.",
+  "description": "A scoundrel who uses stealth and trickery to overcome obstacles and enemies.",
   "features_by_level": {
     "1": [
       {
-        "name": "Rogue Feature 1",
-        "description": "Description for Rogue feature at level 1."
+        "name": "Expertise",
+        "description": "Choose two of your skill proficiencies, or one skill and your thieves' tools; your proficiency bonus is doubled for any ability check that uses them."
+      },
+      {
+        "name": "Sneak Attack",
+        "description": "Once per turn, deal extra damage to one creature you hit if you have advantage on the attack roll or an ally is within 5 feet of the target."
+      },
+      {
+        "name": "Thieves' Cant",
+        "description": "You know the secret rogues' language of thieves' cant and the signs used to convey hidden messages."
       }
     ],
     "2": [
       {
-        "name": "Rogue Feature 2",
-        "description": "Description for Rogue feature at level 2."
+        "name": "Cunning Action",
+        "description": "You can take a bonus action each turn to Dash, Disengage, or Hide."
+      }
+    ],
+    "3": [
+      {
+        "name": "Roguish Archetype",
+        "description": "Choose a Roguish Archetype, which grants features at 3rd, 9th, 13th, and 17th levels."
+      },
+      {
+        "name": "Steady Aim",
+        "description": "As a bonus action, give yourself advantage on your next attack roll if you haven't moved this turn; your speed becomes 0 until the end of the turn."
+      }
+    ],
+    "4": [
+      {
+        "name": "Ability Score Improvement",
+        "description": "Increase one ability score by 2, two scores by 1, or take a feat if allowed."
+      }
+    ],
+    "5": [
+      {
+        "name": "Uncanny Dodge",
+        "description": "Use your reaction to halve the damage of an attack you can see."
+      }
+    ],
+    "6": [
+      {
+        "name": "Expertise",
+        "description": "Choose two more of your proficiencies to gain expertise."
+      }
+    ],
+    "7": [
+      {
+        "name": "Evasion",
+        "description": "When subjected to an effect that allows a Dexterity save for half damage, you take no damage on a success and half on a failure."
+      }
+    ],
+    "8": [
+      {
+        "name": "Ability Score Improvement",
+        "description": "Increase one ability score by 2, two scores by 1, or take a feat if allowed."
+      }
+    ],
+    "9": [
+      {
+        "name": "Roguish Archetype Feature",
+        "description": "Gain a feature from your Roguish Archetype."
+      }
+    ],
+    "10": [
+      {
+        "name": "Ability Score Improvement",
+        "description": "Increase one ability score by 2, two scores by 1, or take a feat if allowed."
+      }
+    ],
+    "11": [
+      {
+        "name": "Reliable Talent",
+        "description": "Treat a d20 roll of 9 or lower as a 10 when making an ability check that uses your proficiency bonus."
+      }
+    ],
+    "12": [
+      {
+        "name": "Ability Score Improvement",
+        "description": "Increase one ability score by 2, two scores by 1, or take a feat if allowed."
+      }
+    ],
+    "13": [
+      {
+        "name": "Roguish Archetype Feature",
+        "description": "Gain a feature from your Roguish Archetype."
+      }
+    ],
+    "14": [
+      {
+        "name": "Blindsense",
+        "description": "If you are able to hear, you are aware of the location of any hidden or invisible creature within 10 feet of you."
+      }
+    ],
+    "15": [
+      {
+        "name": "Slippery Mind",
+        "description": "You gain proficiency in Wisdom saving throws."
+      }
+    ],
+    "16": [
+      {
+        "name": "Ability Score Improvement",
+        "description": "Increase one ability score by 2, two scores by 1, or take a feat if allowed."
+      }
+    ],
+    "17": [
+      {
+        "name": "Roguish Archetype Feature",
+        "description": "Gain a feature from your Roguish Archetype."
+      }
+    ],
+    "18": [
+      {
+        "name": "Elusive",
+        "description": "No attack roll has advantage against you while you aren't incapacitated."
+      }
+    ],
+    "19": [
+      {
+        "name": "Ability Score Improvement",
+        "description": "Increase one ability score by 2, two scores by 1, or take a feat if allowed."
+      }
+    ],
+    "20": [
+      {
+        "name": "Stroke of Luck",
+        "description": "Turn a missed attack into a hit or a failed ability check into a 20 once per rest."
       }
     ]
   },
@@ -64,6 +245,7 @@
         "Perception",
         "Performance",
         "Persuasion",
+        "Sleight of Hand",
         "Stealth"
       ]
     },
@@ -95,6 +277,7 @@
         "Perception",
         "Performance",
         "Persuasion",
+        "Sleight of Hand",
         "Stealth"
       ]
     },

--- a/data/subclasses/inquisitive.json
+++ b/data/subclasses/inquisitive.json
@@ -1,0 +1,51 @@
+{
+  "name": "Inquisitive",
+  "description": "You excel at rooting out secrets and unraveling mysteries.",
+  "features_by_level": {
+    "3": [
+      {
+        "name": "Ear for Deceit",
+        "description": "When you make an Insight check to determine if a creature is lying, treat a roll of 7 or lower as an 8."
+      },
+      {
+        "name": "Eye for Detail",
+        "description": "Use a bonus action to make a Perception check to spot a hidden creature or object or an Investigation check to uncover clues."
+      },
+      {
+        "name": "Insightful Fighting",
+        "description": "As a bonus action, make an Insight check contested by a creature's Deception; on a success you can use Sneak Attack against it without advantage for 1 minute."
+      }
+    ],
+    "9": [
+      {
+        "name": "Steady Eye",
+        "description": "You have advantage on Perception or Investigation checks if you move no more than half your speed on the same turn."
+      }
+    ],
+    "13": [
+      {
+        "name": "Unerring Eye",
+        "description": "As an action, sense illusions, shapechangers, and other magic designed to deceive within 30 feet; uses per Wisdom modifier each long rest."
+      }
+    ],
+    "17": [
+      {
+        "name": "Eye for Weakness",
+        "description": "While Insightful Fighting applies, your Sneak Attack against that creature deals an extra 3d6 damage."
+      }
+    ]
+  },
+  "choices": [
+    {
+      "level": 3,
+      "name": "Inquisitive Feature",
+      "description": "Choose an option for the Inquisitive subclass",
+      "count": 1,
+      "selection": [
+        "Inquisitive Option 1",
+        "Inquisitive Option 2"
+      ],
+      "type": "Inquisitive Feature"
+    }
+  ]
+}

--- a/data/subclasses/mastermind.json
+++ b/data/subclasses/mastermind.json
@@ -1,0 +1,47 @@
+{
+  "name": "Mastermind",
+  "description": "Your focus is on people and the influence and secrets they have.",
+  "features_by_level": {
+    "3": [
+      {
+        "name": "Master of Intrigue",
+        "description": "Gain proficiency with the disguise kit, the forgery kit, and one gaming set; learn two languages and can mimic speech patterns."
+      },
+      {
+        "name": "Master of Tactics",
+        "description": "You can use the Help action as a bonus action, and when you aid an ally attacking a creature, the target can be within 30 feet of you."
+      }
+    ],
+    "9": [
+      {
+        "name": "Insightful Manipulator",
+        "description": "After observing a creature for 1 minute outside combat, learn how it compares to you in key abilities or levels."
+      }
+    ],
+    "13": [
+      {
+        "name": "Misdirection",
+        "description": "When an attack targets you while a creature within 5 feet provides cover, you can have the attack target that creature instead."
+      }
+    ],
+    "17": [
+      {
+        "name": "Soul of Deceit",
+        "description": "Your thoughts can't be read, you can present false thoughts, and magic can't compel you to tell the truth."
+      }
+    ]
+  },
+  "choices": [
+    {
+      "level": 3,
+      "name": "Mastermind Feature",
+      "description": "Choose an option for the Mastermind subclass",
+      "count": 1,
+      "selection": [
+        "Mastermind Option 1",
+        "Mastermind Option 2"
+      ],
+      "type": "Mastermind Feature"
+    }
+  ]
+}

--- a/data/subclasses/phantom.json
+++ b/data/subclasses/phantom.json
@@ -1,0 +1,47 @@
+{
+  "name": "Phantom",
+  "description": "You draw on the power of death to guide and harm.",
+  "features_by_level": {
+    "3": [
+      {
+        "name": "Whispers of the Dead",
+        "description": "After a short or long rest, gain one skill or tool proficiency you lack, which lasts until you use this feature again."
+      },
+      {
+        "name": "Wails from the Grave",
+        "description": "After dealing Sneak Attack damage, target a second creature within 30 feet to take half the number of Sneak Attack dice as necrotic damage. Uses equal to your proficiency bonus per long rest."
+      }
+    ],
+    "9": [
+      {
+        "name": "Tokens of the Departed",
+        "description": "When a creature dies near you, capture a soul trinket that grants benefits and can be used for Wails from the Grave or to ask the spirit a question."
+      }
+    ],
+    "13": [
+      {
+        "name": "Ghost Walk",
+        "description": "As a bonus action, become spectral for 10 minutes, gaining a 10-foot fly speed and the ability to move through objects; reuse by expending a soul trinket."
+      }
+    ],
+    "17": [
+      {
+        "name": "Death's Friend",
+        "description": "Wails from the Grave damages both the first and second creature, and you gain a soul trinket at the end of a long rest if you have none."
+      }
+    ]
+  },
+  "choices": [
+    {
+      "level": 3,
+      "name": "Phantom Feature",
+      "description": "Choose an option for the Phantom subclass",
+      "count": 1,
+      "selection": [
+        "Phantom Option 1",
+        "Phantom Option 2"
+      ],
+      "type": "Phantom Feature"
+    }
+  ]
+}

--- a/data/subclasses/scout.json
+++ b/data/subclasses/scout.json
@@ -1,0 +1,47 @@
+{
+  "name": "Scout",
+  "description": "You are skilled in stealth and survival, serving as the eyes and ears of your companions.",
+  "features_by_level": {
+    "3": [
+      {
+        "name": "Skirmisher",
+        "description": "When an enemy ends its turn within 5 feet of you, you can use your reaction to move up to half your speed without provoking opportunity attacks."
+      },
+      {
+        "name": "Survivalist",
+        "description": "Gain proficiency in Nature and Survival, and your proficiency bonus is doubled for checks using them."
+      }
+    ],
+    "9": [
+      {
+        "name": "Superior Mobility",
+        "description": "Your walking speed increases by 10 feet, and this bonus applies to any climbing or swimming speed you have."
+      }
+    ],
+    "13": [
+      {
+        "name": "Ambush Master",
+        "description": "You have advantage on initiative rolls, and the first creature you hit during the first round of combat grants advantage to attacks against it until your next turn."
+      }
+    ],
+    "17": [
+      {
+        "name": "Sudden Strike",
+        "description": "When you take the Attack action, you can make one additional attack as a bonus action. Each attack can use Sneak Attack, but not against the same target more than once per turn."
+      }
+    ]
+  },
+  "choices": [
+    {
+      "level": 3,
+      "name": "Scout Feature",
+      "description": "Choose an option for the Scout subclass",
+      "count": 1,
+      "selection": [
+        "Scout Option 1",
+        "Scout Option 2"
+      ],
+      "type": "Scout Feature"
+    }
+  ]
+}

--- a/data/subclasses/soulknife.json
+++ b/data/subclasses/soulknife.json
@@ -1,0 +1,47 @@
+{
+  "name": "Soulknife",
+  "description": "You channel psionic energy to manifest blades of psychic power.",
+  "features_by_level": {
+    "3": [
+      {
+        "name": "Psionic Power",
+        "description": "You gain Psionic Energy dice (d6) equal to twice your proficiency bonus to fuel psionic abilities like Psi-Bolstered Knack and Psychic Whispers. Die size increases at higher levels."
+      },
+      {
+        "name": "Psychic Blades",
+        "description": "Whenever you take the Attack action, manifest a psychic blade (1d6 psychic damage, finesse, thrown 60 ft) and a second blade as a bonus action (1d4 damage)."
+      }
+    ],
+    "9": [
+      {
+        "name": "Soul Blades",
+        "description": "Gain Homing Strikes to add a Psionic Energy die to a missed attack and Psychic Teleportation to throw a blade and teleport to its space."
+      }
+    ],
+    "13": [
+      {
+        "name": "Psychic Veil",
+        "description": "As an action, become invisible, along with gear, for 1 hour or until you attack or force a save; you can expend a Psionic Energy die to use this feature again before finishing a long rest."
+      }
+    ],
+    "17": [
+      {
+        "name": "Rend Mind",
+        "description": "When you deal Sneak Attack damage, force a Wisdom save or the target is stunned for 1 minute. Once per long rest or by expending three Psionic Energy dice."
+      }
+    ]
+  },
+  "choices": [
+    {
+      "level": 3,
+      "name": "Soulknife Feature",
+      "description": "Choose an option for the Soulknife subclass",
+      "count": 1,
+      "selection": [
+        "Soulknife Option 1",
+        "Soulknife Option 2"
+      ],
+      "type": "Soulknife Feature"
+    }
+  ]
+}

--- a/data/subclasses/swashbuckler.json
+++ b/data/subclasses/swashbuckler.json
@@ -1,0 +1,47 @@
+{
+  "name": "Swashbuckler",
+  "description": "You rely on speed, elegance, and charm in equal measure.",
+  "features_by_level": {
+    "3": [
+      {
+        "name": "Fancy Footwork",
+        "description": "When you make a melee attack against a creature, that creature can't make opportunity attacks against you for the rest of your turn."
+      },
+      {
+        "name": "Rakish Audacity",
+        "description": "Add your Charisma modifier to initiative, and you can use Sneak Attack if you're within 5 feet of a target and no other enemies are within 5 feet of you."
+      }
+    ],
+    "9": [
+      {
+        "name": "Panache",
+        "description": "As an action, make a Persuasion check contested by a creature's Insight; on success, charm or distract the creature for 1 minute depending on its attitude toward you."
+      }
+    ],
+    "13": [
+      {
+        "name": "Elegant Maneuver",
+        "description": "Use a bonus action to gain advantage on the next Acrobatics or Athletics check you make this turn."
+      }
+    ],
+    "17": [
+      {
+        "name": "Master Duelist",
+        "description": "If you miss with an attack, you can reroll it with advantage. Once used, this feature can't be used again until a short or long rest."
+      }
+    ]
+  },
+  "choices": [
+    {
+      "level": 3,
+      "name": "Swashbuckler Feature",
+      "description": "Choose an option for the Swashbuckler subclass",
+      "count": 1,
+      "selection": [
+        "Swashbuckler Option 1",
+        "Swashbuckler Option 2"
+      ],
+      "type": "Swashbuckler Feature"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- flesh out Rogue class progression including Steady Aim and high-level features
- expand Rogue subclass list and add JSON definitions for Inquisitive, Mastermind, Phantom, Scout, Soulknife, and Swashbuckler

## Testing
- `python -m json.tool data/classes/rogue.json`
- `for f in inquisitive mastermind phantom scout soulknife swashbuckler; do python -m json.tool data/subclasses/$f.json; done`
- `npm test` (fails: ENOENT package.json)
- `python -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a4aad06ba0832e8b1e9a3ecb01b630