### PR TITLE
Add warlock class and patron subclasses

### DIFF
--- a/data/classes/warlock.json
+++ b/data/classes/warlock.json
@@ -1,5 +1,112 @@
 {
   "name": "Warlock",
+  "description": "A wielder of magic derived from a bargain with an extraplanar patron.",
+  "features_by_level": {
+    "1": [
+      {
+        "name": "Pact Magic",
+        "description": "Your patron grants you spellcasting. You know cantrips and spells and regain spell slots on a short or long rest, using Charisma as your spellcasting ability."
+      },
+      {
+        "name": "Otherworldly Patron",
+        "description": "You have struck a bargain with a patron of your choice, which grants features at 1st, 6th, 10th, and 14th level."
+      }
+    ],
+    "2": [
+      {
+        "name": "Eldritch Invocations",
+        "description": "Learn two eldritch invocations, gaining more at higher levels and replacing them when you level."
+      }
+    ],
+    "3": [
+      {
+        "name": "Pact Boon",
+        "description": "Your patron bestows a boon of your choice such as Pact of the Chain, Blade, Talisman, or Tome."
+      }
+    ],
+    "4": [
+      {
+        "name": "Ability Score Improvement",
+        "description": "Increase one ability score by 2 or two scores by 1, or take a feat if allowed."
+      },
+      {
+        "name": "Eldritch Versatility",
+        "description": "Whenever you gain an Ability Score Improvement, you can replace a cantrip, swap your Pact Boon, or exchange a Mystic Arcanum of the same level."
+      }
+    ],
+    "6": [
+      {
+        "name": "Otherworldly Patron Feature",
+        "description": "Your chosen patron grants you an additional feature."
+      }
+    ],
+    "8": [
+      {
+        "name": "Ability Score Improvement",
+        "description": "Increase one ability score by 2 or two scores by 1, or take a feat if allowed."
+      }
+    ],
+    "10": [
+      {
+        "name": "Otherworldly Patron Feature",
+        "description": "Your chosen patron grants you an additional feature."
+      }
+    ],
+    "11": [
+      {
+        "name": "Mystic Arcanum (6th level)",
+        "description": "Choose one 6th-level warlock spell to cast once without a spell slot each long rest."
+      }
+    ],
+    "12": [
+      {
+        "name": "Ability Score Improvement",
+        "description": "Increase one ability score by 2 or two scores by 1, or take a feat if allowed."
+      }
+    ],
+    "13": [
+      {
+        "name": "Mystic Arcanum (7th level)",
+        "description": "Choose one 7th-level warlock spell to cast once without a spell slot each long rest."
+      }
+    ],
+    "14": [
+      {
+        "name": "Otherworldly Patron Feature",
+        "description": "Your chosen patron grants you an additional feature."
+      }
+    ],
+    "15": [
+      {
+        "name": "Mystic Arcanum (8th level)",
+        "description": "Choose one 8th-level warlock spell to cast once without a spell slot each long rest."
+      }
+    ],
+    "16": [
+      {
+        "name": "Ability Score Improvement",
+        "description": "Increase one ability score by 2 or two scores by 1, or take a feat if allowed."
+      }
+    ],
+    "17": [
+      {
+        "name": "Mystic Arcanum (9th level)",
+        "description": "Choose one 9th-level warlock spell to cast once without a spell slot each long rest."
+      }
+    ],
+    "19": [
+      {
+        "name": "Ability Score Improvement",
+        "description": "Increase one ability score by 2 or two scores by 1, or take a feat if allowed."
+      }
+    ],
+    "20": [
+      {
+        "name": "Eldritch Master",
+        "description": "Spend 1 minute entreating your patron to regain all expended Pact Magic spell slots once per long rest."
+      }
+    ]
+  },
   "subclasses": [
     {
       "name": "The Archfey",
@@ -8,6 +115,27 @@
         "Misty Escape",
         "Beguiling Defenses",
         "Dark Delirium"
+      ]
+    },
+    {
+      "name": "The Celestial",
+      "features": [
+        "Bonus Cantrips",
+        "Healing Light",
+        "Radiant Soul",
+        "Celestial Resilience",
+        "Searing Vengeance"
+      ]
+    },
+    {
+      "name": "The Fathomless",
+      "features": [
+        "Tentacle of the Deeps",
+        "Gift of the Sea",
+        "Oceanic Soul",
+        "Guardian Coil",
+        "Grasping Tentacles",
+        "Fathomless Plunge"
       ]
     },
     {
@@ -20,6 +148,15 @@
       ]
     },
     {
+      "name": "The Genie",
+      "features": [
+        "Genie's Vessel",
+        "Elemental Gift",
+        "Sanctuary Vessel",
+        "Limited Wish"
+      ]
+    },
+    {
       "name": "The Great Old One",
       "features": [
         "Awakened Mind",
@@ -27,24 +164,56 @@
         "Thought Shield",
         "Create Thrall"
       ]
+    },
+    {
+      "name": "The Hexblade",
+      "features": [
+        "Hexblade's Curse",
+        "Hex Warrior",
+        "Accursed Specter",
+        "Armor of Hexes",
+        "Master of Hexes"
+      ]
+    },
+    {
+      "name": "The Undead",
+      "features": [
+        "Form of Dread",
+        "Grave Touched",
+        "Necrotic Husk",
+        "Spirit Projection"
+      ]
+    },
+    {
+      "name": "The Undying",
+      "features": [
+        "Among the Dead",
+        "Defy Death",
+        "Undying Nature",
+        "Indestructible Life"
+      ]
     }
   ],
-  "description": "Description for Warlock class.",
-  "features_by_level": {
-    "1": [
-      {
-        "name": "Warlock Feature 1",
-        "description": "Description for Warlock feature at level 1."
-      }
-    ],
-    "2": [
-      {
-        "name": "Warlock Feature 2",
-        "description": "Description for Warlock feature at level 2."
-      }
-    ]
-  },
   "choices": [
+    {
+      "level": 2,
+      "name": "Eldritch Invocations",
+      "description": "Learn eldritch invocations",
+      "count": 2,
+      "type": "eldritch invocation",
+      "selection": [
+        "Agonizing Blast",
+        "Armor of Shadows",
+        "Beast Speech",
+        "Devil's Sight",
+        "Eldritch Sight",
+        "Fiendish Vigor",
+        "Mask of Many Faces",
+        "Misty Visions",
+        "One with Shadows",
+        "Repelling Blast"
+      ]
+    },
     {
       "level": 3,
       "name": "Pact Boon",
@@ -54,6 +223,7 @@
       "selection": [
         "Pact of the Chain",
         "Pact of the Blade",
+        "Pact of the Talisman",
         "Pact of the Tome"
       ]
     },
@@ -70,6 +240,44 @@
       ]
     },
     {
+      "level": 5,
+      "name": "Eldritch Invocations",
+      "description": "Learn an additional eldritch invocation",
+      "count": 3,
+      "type": "eldritch invocation",
+      "selection": [
+        "Agonizing Blast",
+        "Armor of Shadows",
+        "Beast Speech",
+        "Devil's Sight",
+        "Eldritch Sight",
+        "Fiendish Vigor",
+        "Mask of Many Faces",
+        "Misty Visions",
+        "One with Shadows",
+        "Repelling Blast"
+      ]
+    },
+    {
+      "level": 7,
+      "name": "Eldritch Invocations",
+      "description": "Learn an additional eldritch invocation",
+      "count": 4,
+      "type": "eldritch invocation",
+      "selection": [
+        "Agonizing Blast",
+        "Armor of Shadows",
+        "Beast Speech",
+        "Devil's Sight",
+        "Eldritch Sight",
+        "Fiendish Vigor",
+        "Mask of Many Faces",
+        "Misty Visions",
+        "One with Shadows",
+        "Repelling Blast"
+      ]
+    },
+    {
       "level": 8,
       "name": "Ability Score Improvement",
       "description": "Increase one ability score by 2, two ability scores by 1, or take a feat if allowed.",
@@ -79,6 +287,44 @@
         "Increase one ability score by 2",
         "Increase two ability scores by 1",
         "Feat"
+      ]
+    },
+    {
+      "level": 9,
+      "name": "Eldritch Invocations",
+      "description": "Learn an additional eldritch invocation",
+      "count": 5,
+      "type": "eldritch invocation",
+      "selection": [
+        "Agonizing Blast",
+        "Armor of Shadows",
+        "Beast Speech",
+        "Devil's Sight",
+        "Eldritch Sight",
+        "Fiendish Vigor",
+        "Mask of Many Faces",
+        "Misty Visions",
+        "One with Shadows",
+        "Repelling Blast"
+      ]
+    },
+    {
+      "level": 12,
+      "name": "Eldritch Invocations",
+      "description": "Learn an additional eldritch invocation",
+      "count": 6,
+      "type": "eldritch invocation",
+      "selection": [
+        "Agonizing Blast",
+        "Armor of Shadows",
+        "Beast Speech",
+        "Devil's Sight",
+        "Eldritch Sight",
+        "Fiendish Vigor",
+        "Mask of Many Faces",
+        "Misty Visions",
+        "One with Shadows",
+        "Repelling Blast"
       ]
     },
     {
@@ -94,6 +340,25 @@
       ]
     },
     {
+      "level": 15,
+      "name": "Eldritch Invocations",
+      "description": "Learn an additional eldritch invocation",
+      "count": 7,
+      "type": "eldritch invocation",
+      "selection": [
+        "Agonizing Blast",
+        "Armor of Shadows",
+        "Beast Speech",
+        "Devil's Sight",
+        "Eldritch Sight",
+        "Fiendish Vigor",
+        "Mask of Many Faces",
+        "Misty Visions",
+        "One with Shadows",
+        "Repelling Blast"
+      ]
+    },
+    {
       "level": 16,
       "name": "Ability Score Improvement",
       "description": "Increase one ability score by 2, two ability scores by 1, or take a feat if allowed.",
@@ -103,6 +368,25 @@
         "Increase one ability score by 2",
         "Increase two ability scores by 1",
         "Feat"
+      ]
+    },
+    {
+      "level": 18,
+      "name": "Eldritch Invocations",
+      "description": "Learn an additional eldritch invocation",
+      "count": 8,
+      "type": "eldritch invocation",
+      "selection": [
+        "Agonizing Blast",
+        "Armor of Shadows",
+        "Beast Speech",
+        "Devil's Sight",
+        "Eldritch Sight",
+        "Fiendish Vigor",
+        "Mask of Many Faces",
+        "Misty Visions",
+        "One with Shadows",
+        "Repelling Blast"
       ]
     },
     {

--- a/data/subclasses/celestial.json
+++ b/data/subclasses/celestial.json
@@ -1,0 +1,47 @@
+{
+  "name": "The Celestial",
+  "description": "Your patron is a powerful being of the Upper Planes.",
+  "features_by_level": {
+    "1": [
+      {
+        "name": "Bonus Cantrips",
+        "description": "Description for Bonus Cantrips."
+      },
+      {
+        "name": "Healing Light",
+        "description": "Description for Healing Light."
+      }
+    ],
+    "6": [
+      {
+        "name": "Radiant Soul",
+        "description": "Description for Radiant Soul."
+      }
+    ],
+    "10": [
+      {
+        "name": "Celestial Resilience",
+        "description": "Description for Celestial Resilience."
+      }
+    ],
+    "14": [
+      {
+        "name": "Searing Vengeance",
+        "description": "Description for Searing Vengeance."
+      }
+    ]
+  },
+  "choices": [
+    {
+      "level": 1,
+      "name": "The Celestial Feature",
+      "description": "Choose an option for the The Celestial subclass",
+      "count": 1,
+      "selection": [
+        "The Celestial Option 1",
+        "The Celestial Option 2"
+      ],
+      "type": "The Celestial Feature"
+    }
+  ]
+}

--- a/data/subclasses/fathomless.json
+++ b/data/subclasses/fathomless.json
@@ -1,0 +1,51 @@
+{
+  "name": "The Fathomless",
+  "description": "You have plunged into a pact with the deeps.",
+  "features_by_level": {
+    "1": [
+      {
+        "name": "Tentacle of the Deeps",
+        "description": "Description for Tentacle of the Deeps."
+      },
+      {
+        "name": "Gift of the Sea",
+        "description": "Description for Gift of the Sea."
+      }
+    ],
+    "6": [
+      {
+        "name": "Oceanic Soul",
+        "description": "Description for Oceanic Soul."
+      },
+      {
+        "name": "Guardian Coil",
+        "description": "Description for Guardian Coil."
+      }
+    ],
+    "10": [
+      {
+        "name": "Grasping Tentacles",
+        "description": "Description for Grasping Tentacles."
+      }
+    ],
+    "14": [
+      {
+        "name": "Fathomless Plunge",
+        "description": "Description for Fathomless Plunge."
+      }
+    ]
+  },
+  "choices": [
+    {
+      "level": 1,
+      "name": "The Fathomless Feature",
+      "description": "Choose an option for the The Fathomless subclass",
+      "count": 1,
+      "selection": [
+        "The Fathomless Option 1",
+        "The Fathomless Option 2"
+      ],
+      "type": "The Fathomless Feature"
+    }
+  ]
+}

--- a/data/subclasses/genie.json
+++ b/data/subclasses/genie.json
@@ -1,0 +1,43 @@
+{
+  "name": "The Genie",
+  "description": "You have made a pact with a noble genie.",
+  "features_by_level": {
+    "1": [
+      {
+        "name": "Genie's Vessel",
+        "description": "Description for Genie's Vessel."
+      }
+    ],
+    "6": [
+      {
+        "name": "Elemental Gift",
+        "description": "Description for Elemental Gift."
+      }
+    ],
+    "10": [
+      {
+        "name": "Sanctuary Vessel",
+        "description": "Description for Sanctuary Vessel."
+      }
+    ],
+    "14": [
+      {
+        "name": "Limited Wish",
+        "description": "Description for Limited Wish."
+      }
+    ]
+  },
+  "choices": [
+    {
+      "level": 1,
+      "name": "The Genie Feature",
+      "description": "Choose an option for the The Genie subclass",
+      "count": 1,
+      "selection": [
+        "The Genie Option 1",
+        "The Genie Option 2"
+      ],
+      "type": "The Genie Feature"
+    }
+  ]
+}

--- a/data/subclasses/hexblade.json
+++ b/data/subclasses/hexblade.json
@@ -1,0 +1,47 @@
+{
+  "name": "The Hexblade",
+  "description": "You have made your pact with a mysterious entity from the Shadowfell.",
+  "features_by_level": {
+    "1": [
+      {
+        "name": "Hexblade's Curse",
+        "description": "Description for Hexblade's Curse."
+      },
+      {
+        "name": "Hex Warrior",
+        "description": "Description for Hex Warrior."
+      }
+    ],
+    "6": [
+      {
+        "name": "Accursed Specter",
+        "description": "Description for Accursed Specter."
+      }
+    ],
+    "10": [
+      {
+        "name": "Armor of Hexes",
+        "description": "Description for Armor of Hexes."
+      }
+    ],
+    "14": [
+      {
+        "name": "Master of Hexes",
+        "description": "Description for Master of Hexes."
+      }
+    ]
+  },
+  "choices": [
+    {
+      "level": 1,
+      "name": "The Hexblade Feature",
+      "description": "Choose an option for the The Hexblade subclass",
+      "count": 1,
+      "selection": [
+        "The Hexblade Option 1",
+        "The Hexblade Option 2"
+      ],
+      "type": "The Hexblade Feature"
+    }
+  ]
+}

--- a/data/subclasses/undead.json
+++ b/data/subclasses/undead.json
@@ -1,0 +1,43 @@
+{
+  "name": "The Undead",
+  "description": "You've made a pact with a deathless being.",
+  "features_by_level": {
+    "1": [
+      {
+        "name": "Form of Dread",
+        "description": "Description for Form of Dread."
+      }
+    ],
+    "6": [
+      {
+        "name": "Grave Touched",
+        "description": "Description for Grave Touched."
+      }
+    ],
+    "10": [
+      {
+        "name": "Necrotic Husk",
+        "description": "Description for Necrotic Husk."
+      }
+    ],
+    "14": [
+      {
+        "name": "Spirit Projection",
+        "description": "Description for Spirit Projection."
+      }
+    ]
+  },
+  "choices": [
+    {
+      "level": 1,
+      "name": "The Undead Feature",
+      "description": "Choose an option for the The Undead subclass",
+      "count": 1,
+      "selection": [
+        "The Undead Option 1",
+        "The Undead Option 2"
+      ],
+      "type": "The Undead Feature"
+    }
+  ]
+}

--- a/data/subclasses/undying.json
+++ b/data/subclasses/undying.json
@@ -1,0 +1,43 @@
+{
+  "name": "The Undying",
+  "description": "Death holds no sway over your patron.",
+  "features_by_level": {
+    "1": [
+      {
+        "name": "Among the Dead",
+        "description": "Description for Among the Dead."
+      }
+    ],
+    "6": [
+      {
+        "name": "Defy Death",
+        "description": "Description for Defy Death."
+      }
+    ],
+    "10": [
+      {
+        "name": "Undying Nature",
+        "description": "Description for Undying Nature."
+      }
+    ],
+    "14": [
+      {
+        "name": "Indestructible Life",
+        "description": "Description for Indestructible Life."
+      }
+    ]
+  },
+  "choices": [
+    {
+      "level": 1,
+      "name": "The Undying Feature",
+      "description": "Choose an option for the The Undying subclass",
+      "count": 1,
+      "selection": [
+        "The Undying Option 1",
+        "The Undying Option 2"
+      ],
+      "type": "The Undying Feature"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- flesh out Warlock class with full level progression and choices
- add Celestial, Fathomless, Genie, Hexblade, Undead, and Undying patron subclasses

## Testing
- `python -m json.tool data/classes/warlock.json`
- `python -m json.tool data/subclasses/celestial.json`
- `python -m json.tool data/subclasses/fathomless.json`
- `python -m json.tool data/subclasses/genie.json`
- `python -m json.tool data/subclasses/hexblade.json`
- `python -m json.tool data/subclasses/undead.json`
- `python -m json.tool data/subclasses/undying.json`


------
https://chatgpt.com/codex/tasks/task_e_68a4aee66730832ebe80bb17a435bdf4