### PR TITLE
Rename final step module to Step 7

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -14,6 +14,7 @@ import {
 } from './script.js';
 import './step4.js';
 import './step5.js';
+import './step7.js';
 
 let classSelectionConfirmed = false;
 

--- a/js/step7.js
+++ b/js/step7.js
@@ -1,0 +1,11 @@
+document.addEventListener("DOMContentLoaded", () => {
+  const step7Container = document.getElementById("step7");
+  if (!step7Container) return;
+
+  step7Container.innerHTML = `
+    <h2>Step 7: Riepilogo ed Esportazione</h2>
+    <div id="finalRecap"></div>
+    <button id="generateJson">Genera JSON</button>
+    <!-- Puoi aggiungere qui anche il pulsante per esportare in PDF -->
+  `;
+});


### PR DESCRIPTION
## Summary
- add new `step7.js` replacing legacy Step 8 script and update heading to Step 7
- import `step7.js` in `main.js` and ensure navigation to Step 7 remains wired

## Testing
- `node --check js/step7.js`
- `node --check js/main.js`
- `node /tmp/test-export.mjs`

------
https://chatgpt.com/codex/tasks/task_e_68a4b497984c832eb7387c529d07b8b5