### PR TITLE
feat: add accordion UI for feature selections

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -29,4 +29,22 @@ body {
   button:hover {
     background-color: #45a049;
   }
+
+  details.feature-block {
+    margin-bottom: 10px;
+  }
+
+  details.needs-selection {
+    border: 2px solid #e74c3c;
+    padding: 0.5em;
+  }
+
+  details.needs-selection summary {
+    color: #e74c3c;
+  }
+
+  details.needs-selection summary::after {
+    content: " *";
+    color: #e74c3c;
+  }
   

--- a/js/script.js
+++ b/js/script.js
@@ -340,6 +340,41 @@ function gatherExtraSelections(data, context, level = 1) {
 }
 
 /**
+ * Generic handler to track selections inside feature <select> elements
+ * and visually highlight incomplete features.
+ * @param {HTMLElement} container - Parent element containing feature details.
+ * @param {Function} [saveCallback] - Optional callback to persist selections.
+ */
+function initFeatureSelectionHandlers(container, saveCallback) {
+  if (!container) return;
+  const detailsBlocks = container.querySelectorAll('details');
+  detailsBlocks.forEach(det => {
+    const selects = det.querySelectorAll('select');
+    if (selects.length === 0) return;
+    const mark = () => {
+      const unfilled = Array.from(selects).some(s => !s.value);
+      det.classList.toggle('needs-selection', unfilled);
+    };
+    mark();
+    selects.forEach(sel => {
+      sel.addEventListener('change', () => {
+        if (saveCallback) saveCallback(sel);
+        mark();
+      });
+    });
+  });
+}
+
+function saveFeatureSelection(select) {
+  const feature = select.dataset.feature;
+  const index = select.dataset.index || 0;
+  if (!feature) return;
+  if (!selectedData[feature]) selectedData[feature] = [];
+  selectedData[feature][index] = select.value || undefined;
+  sessionStorage.setItem('selectedData', JSON.stringify(selectedData));
+}
+
+/**
  * Opens the extra selections popup.
  * Hides the background extra traits container and shows the modal.
  */
@@ -465,8 +500,9 @@ function renderFeatSelection(container, index) {
       )
       .map(f => `<option value="${f.name}">${f.name}</option>`)
       .join("");
-    container.innerHTML = `<select class="asi-feat" data-index="${index}"><option value="">Seleziona...</option>${options}</select>`;
-    container.querySelector(".asi-feat").addEventListener("change", e => {
+    container.innerHTML = `<details class="feature-block"><summary>Feat</summary><select class="asi-feat" data-index="${index}"><option value="">Seleziona...</option>${options}</select></details>`;
+    const featSel = container.querySelector(".asi-feat");
+    featSel.addEventListener("change", e => {
       if (!selectedData["Ability Score Improvement"]) {
         selectedData["Ability Score Improvement"] = [];
       }
@@ -477,6 +513,7 @@ function renderFeatSelection(container, index) {
       sessionStorage.setItem("selectedData", JSON.stringify(selectedData));
       updateExtraSelectionsView();
     });
+    initFeatureSelectionHandlers(container);
   });
 }
 
@@ -705,11 +742,26 @@ function displayRaceTraits() {
 
       // Traits
       if (raceData.traits && raceData.traits.length > 0) {
-        traitsHtml += `<p><strong>Tratti:</strong></p><ul>`;
-        raceData.traits.forEach(trait => {
-          traitsHtml += `<li><strong>${trait.name}:</strong> ${trait.description || ""}</li>`;
+        traitsHtml += `<h4>Tratti:</h4>`;
+        raceData.traits.forEach((trait, tIdx) => {
+          const featureKey = trait.name.replace(/"/g, '&quot;');
+          let block = `<details class="feature-block" id="race-trait-${tIdx}"><summary>${trait.name}</summary>`;
+          block += `<div class="feature-desc">${trait.description || ''}</div>`;
+          const choices = trait.choices || trait.variant_feature_choices;
+          if (choices) {
+            choices.forEach((choice, cIdx) => {
+              const options = choice.options || choice.selection || [];
+              const saved = selectedData[featureKey]?.[cIdx] || '';
+              const label = choice.name || 'Scegli';
+              const optsHtml = options
+                .map(opt => `<option value="${opt}" ${saved === opt ? 'selected' : ''}>${opt}</option>`)
+                .join('');
+              block += `<label>${label}: <select data-feature="${featureKey}" data-index="${cIdx}"><option value="">Seleziona...</option>${optsHtml}</select></label>`;
+            });
+          }
+          block += `</details>`;
+          traitsHtml += block;
         });
-        traitsHtml += `</ul>`;
       }
 
       // Tables (rawEntries)
@@ -731,6 +783,7 @@ function displayRaceTraits() {
       if (raceTraitsDiv) {
         raceTraitsDiv.innerHTML = traitsHtml;
         raceTraitsDiv.style.display = "block";  // 🔥 FORZA IL RENDERING
+        initFeatureSelectionHandlers(raceTraitsDiv, saveFeatureSelection);
         console.log("✅ Tratti della razza aggiornati con successo!");
       } else {
         console.error("❌ ERRORE: Il div dei tratti della razza non è stato trovato!");
@@ -897,16 +950,32 @@ async function renderClassFeatures() {
   const levels = Object.keys(mergedFeatures).sort((a, b) => a - b);
   levels.forEach(lvl => {
     if (parseInt(lvl) <= charLevel) {
-      html += `<h4>Livello ${lvl}</h4><ul>`;
-      mergedFeatures[lvl].forEach(f => {
-        if (typeof f === "string") {
-          html += `<li>${f}</li>`;
+      html += `<h4>Livello ${lvl}</h4>`;
+      mergedFeatures[lvl].forEach((f, idx) => {
+        if (typeof f === 'string') {
+          html += `<details class="feature-block"><summary>${f}</summary></details>`;
         } else {
-          const desc = f.description ? `: ${f.description}` : "";
-          html += `<li><strong>${f.name}</strong>${desc}</li>`;
+          const featureKey = f.name.replace(/"/g, '&quot;');
+          let block = `<details class="feature-block" id="class-feature-${lvl}-${idx}"><summary>${f.name}</summary>`;
+          if (f.description) {
+            block += `<div class="feature-desc">${f.description}</div>`;
+          }
+          const choices = f.choices || f.variant_feature_choices;
+          if (choices) {
+            choices.forEach((choice, cIdx) => {
+              const options = choice.options || choice.selection || [];
+              const saved = selectedData[featureKey]?.[cIdx] || '';
+              const label = choice.name || 'Scegli';
+              const optsHtml = options
+                .map(opt => `<option value="${opt}" ${saved === opt ? 'selected' : ''}>${opt}</option>`)
+                .join('');
+              block += `<label>${label}: <select data-feature="${featureKey}" data-index="${cIdx}"><option value="">Seleziona...</option>${optsHtml}</select></label>`;
+            });
+          }
+          block += `</details>`;
+          html += block;
         }
       });
-      html += `</ul>`;
     }
   });
 
@@ -917,6 +986,7 @@ async function renderClassFeatures() {
     html += `<p>Seleziona una sottoclasse per vedere i tratti.</p>`;
   }
   featuresDiv.innerHTML = html;
+  initFeatureSelectionHandlers(featuresDiv, saveFeatureSelection);
   return selections;
 }
 
@@ -1108,6 +1178,7 @@ export {
   handleExtraTools,
   handleExtraAncestry,
   gatherExtraSelections,
+  initFeatureSelectionHandlers,
   updateSubclasses,
   renderClassFeatures,
   openExtrasModal,

--- a/js/step4.js
+++ b/js/step4.js
@@ -1,5 +1,6 @@
 // Step 4: Background selection and feat handling
 import { loadDropdownData } from './common.js';
+import { initFeatureSelectionHandlers } from './script.js';
 
 let featPathIndex = {};
 let currentFeatData = null;
@@ -50,14 +51,21 @@ document.addEventListener("DOMContentLoaded", () => {
 
     const skillDiv = document.getElementById("backgroundSkills");
     skillDiv.innerHTML = "";
+    const skillDetails = document.createElement("details");
+    skillDetails.className = "feature-block";
+    skillDetails.innerHTML = "<summary>Abilità</summary>";
     backgroundData.skills = Array.isArray(data.skills) ? data.skills.slice() : [];
     if (backgroundData.skills.length > 0) {
-      skillDiv.innerHTML = `<p><strong>Abilità:</strong> ${backgroundData.skills.join(", ")}</p>`;
+      const p = document.createElement("p");
+      p.innerHTML = `<strong>Abilità:</strong> ${backgroundData.skills.join(", ")}`;
+      skillDetails.appendChild(p);
     }
     if (data.skillChoices) {
       const num = data.skillChoices.choose || 0;
       const opts = data.skillChoices.options || [];
-      skillDiv.innerHTML += `<p><strong>Scegli ${num} abilità:</strong></p>`;
+      const p = document.createElement("p");
+      p.innerHTML = `<strong>Scegli ${num} abilità:</strong>`;
+      skillDetails.appendChild(p);
       for (let i = 0; i < num; i++) {
         const sel = document.createElement("select");
         sel.className = "backgroundSkillChoice";
@@ -66,20 +74,29 @@ document.addEventListener("DOMContentLoaded", () => {
           const chosen = Array.from(document.querySelectorAll(".backgroundSkillChoice")).map(s => s.value).filter(Boolean);
           backgroundData.skills = (data.skills || []).concat(chosen);
         });
-        skillDiv.appendChild(sel);
+        skillDetails.appendChild(sel);
       }
     }
+    skillDiv.appendChild(skillDetails);
+    initFeatureSelectionHandlers(skillDiv);
 
     const toolDiv = document.getElementById("backgroundTools");
     toolDiv.innerHTML = "";
+    const toolDetails = document.createElement("details");
+    toolDetails.className = "feature-block";
+    toolDetails.innerHTML = "<summary>Strumenti</summary>";
     backgroundData.tools = Array.isArray(data.tools) ? data.tools.slice() : [];
     if (Array.isArray(data.tools) && data.tools.length > 0) {
-      toolDiv.innerHTML = `<p><strong>Strumenti:</strong> ${data.tools.join(", ")}</p>`;
+      const p = document.createElement("p");
+      p.innerHTML = `<strong>Strumenti:</strong> ${data.tools.join(", ")}`;
+      toolDetails.appendChild(p);
     }
     if (data.tools && data.tools.choose) {
       const num = data.tools.choose;
       const opts = data.tools.options || [];
-      toolDiv.innerHTML += `<p><strong>Scegli ${num} strumento:</strong></p>`;
+      const p = document.createElement("p");
+      p.innerHTML = `<strong>Scegli ${num} strumento:</strong>`;
+      toolDetails.appendChild(p);
       for (let i = 0; i < num; i++) {
         const sel = document.createElement("select");
         sel.className = "backgroundToolChoice";
@@ -88,13 +105,15 @@ document.addEventListener("DOMContentLoaded", () => {
           const chosen = Array.from(document.querySelectorAll(".backgroundToolChoice")).map(s => s.value).filter(Boolean);
           backgroundData.tools = chosen;
         });
-        toolDiv.appendChild(sel);
+        toolDetails.appendChild(sel);
       }
     }
     if (data.toolChoices) {
       const num = data.toolChoices.choose || 0;
       const opts = data.toolChoices.options || [];
-      toolDiv.innerHTML += `<p><strong>Scegli ${num} strumento:</strong></p>`;
+      const p = document.createElement("p");
+      p.innerHTML = `<strong>Scegli ${num} strumento:</strong>`;
+      toolDetails.appendChild(p);
       for (let i = 0; i < num; i++) {
         const sel = document.createElement("select");
         sel.className = "backgroundToolChoice";
@@ -104,19 +123,28 @@ document.addEventListener("DOMContentLoaded", () => {
           const base = Array.isArray(data.tools) ? data.tools.slice() : [];
           backgroundData.tools = base.concat(chosen);
         });
-        toolDiv.appendChild(sel);
+        toolDetails.appendChild(sel);
       }
     }
+    toolDiv.appendChild(toolDetails);
+    initFeatureSelectionHandlers(toolDiv);
 
     const langDiv = document.getElementById("backgroundLanguages");
     langDiv.innerHTML = "";
+    const langDetails = document.createElement("details");
+    langDetails.className = "feature-block";
+    langDetails.innerHTML = "<summary>Linguaggi</summary>";
     backgroundData.languages = Array.isArray(data.languages) ? data.languages.slice() : [];
     if (Array.isArray(data.languages) && data.languages.length > 0) {
-      langDiv.innerHTML = `<p><strong>Linguaggi:</strong> ${data.languages.join(", ")}</p>`;
+      const p = document.createElement("p");
+      p.innerHTML = `<strong>Linguaggi:</strong> ${data.languages.join(", ")}`;
+      langDetails.appendChild(p);
     } else if (data.languages && data.languages.choose) {
       const num = data.languages.choose;
       const opts = data.languages.options || [];
-      langDiv.innerHTML = `<p><strong>Scegli ${num} linguaggi:</strong></p>`;
+      const p = document.createElement("p");
+      p.innerHTML = `<strong>Scegli ${num} linguaggi:</strong>`;
+      langDetails.appendChild(p);
       for (let i = 0; i < num; i++) {
         const sel = document.createElement("select");
         sel.className = "backgroundLanguageChoice";
@@ -125,14 +153,19 @@ document.addEventListener("DOMContentLoaded", () => {
           const chosen = Array.from(document.querySelectorAll(".backgroundLanguageChoice")).map(s => s.value).filter(Boolean);
           backgroundData.languages = chosen;
         });
-        langDiv.appendChild(sel);
+        langDetails.appendChild(sel);
       }
     }
+    langDiv.appendChild(langDetails);
+    initFeatureSelectionHandlers(langDiv);
 
     const featDiv = document.getElementById("backgroundFeat");
     featDiv.innerHTML = "";
     backgroundData.feat = "";
     currentFeatData = null;
+    const featDetails = document.createElement("details");
+    featDetails.className = "feature-block";
+    featDetails.innerHTML = "<summary>Talento</summary>";
     if (Array.isArray(data.featOptions) && data.featOptions.length > 0) {
       const label = document.createElement("label");
       label.htmlFor = "backgroundFeatSelect";
@@ -177,10 +210,12 @@ document.addEventListener("DOMContentLoaded", () => {
             applyFeatAbilityChoices();
           });
       });
-      featDiv.appendChild(label);
-      featDiv.appendChild(select);
-      featDiv.appendChild(abilDiv);
+      featDetails.appendChild(label);
+      featDetails.appendChild(select);
+      featDetails.appendChild(abilDiv);
     }
+    featDiv.appendChild(featDetails);
+    initFeatureSelectionHandlers(featDiv);
   });
 });
 


### PR DESCRIPTION
## Summary
- render class and race features in <details> accordions with inline choice tracking
- wrap background skill/tool/language/feat sections in accordions and highlight unfilled selections
- style details that require input to flag missing choices

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a4b67f98dc832e93ac9a0a0a1aa185