### PR TITLE
Refactor race trait display with interactive selections

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -29,4 +29,19 @@ body {
   button:hover {
     background-color: #45a049;
   }
+
+  /* Evidenzia i tratti che richiedono scelte aggiuntive */
+  details.needs-selection {
+    border: 2px solid transparent;
+    padding: 0.5em;
+    margin-bottom: 0.5em;
+  }
+
+  details.needs-selection.incomplete {
+    border-color: #e74c3c;
+  }
+
+  details.needs-selection.incomplete > summary {
+    color: #e74c3c;
+  }
   

--- a/index.html
+++ b/index.html
@@ -147,17 +147,8 @@
         <br><br>
         <div id="raceTraits"></div>
         <button id="confirmRaceSelection" class="btn btn-primary">Seleziona Razza</button>
-        <!-- Contenitore dei tratti extra, inizialmente nascosto -->
-        <div id="raceExtraTraitsContainer">
-          <h3>Tratti Extra</h3>
-          <div id="variantFeatureSelectionContainer"></div>
-          <div id="variantExtraContainer"></div>
-          <div id="ancestrySelection"></div>
-          <div id="spellSelectionContainer"></div>
-          <div id="languageSelection"></div>
-          <div id="skillSelectionContainer"></div>
-          <div id="toolSelectionContainer"></div>
-        </div>
+        <!-- Contenitore dei tratti extra (vuoto, mantenuto per compatibilità) -->
+        <div id="raceExtraTraitsContainer"></div>
       </div>
       <!-- 📜 MODALE PER TUTTE LE SCELTE EXTRA -->
       <div id="raceExtrasModal" class="modal">


### PR DESCRIPTION
## Summary
- Render racial traits as `<details>` sections with integrated choice controls for languages, skills, tools, variant features and ancestry
- Highlight unfilled trait selections and track user picks
- Add utility to gather race trait selections for final character sheet

## Testing
- ⚠️ `npm test` *(failed: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a4b68458ac832eaf14eb5de0c036f6