### PR TITLE
fix: remove duplicate gatherRaceTraitSelections export

### DIFF
--- a/js/script.js
+++ b/js/script.js
@@ -242,7 +242,7 @@ function checkTraitCompletion(detailId) {
   detail.classList.toggle("incomplete", incomplete);
 }
 
-export function gatherRaceTraitSelections() {
+function gatherRaceTraitSelections() {
   const result = {};
   const lang = document.getElementById("extraLanguageDropdown")?.value;
   if (lang) result.languages = [lang];


### PR DESCRIPTION
## Summary
- avoid duplicate export errors by defining `gatherRaceTraitSelections` once and exporting at module end

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a4bffb8818832e8aa304993bf69428