### PR TITLE
Fix Ghostwise Halfling race file path

### DIFF
--- a/data/races.json
+++ b/data/races.json
@@ -40,7 +40,7 @@
         "Half-Elf (Standard)": "data/races/halfelfstandard.json",
         "Half-Elf (Wood)": "data/races/halfelfwood.json",
         "Half-Orc": "data/races/halforc.json",
-        "Halfling (Ghostwise)": "data/races/halflingghost.json",
+        "Halfling (Ghostwise)": "data/races/halflingghostwise.json",
         "Halfling (Lightfoot)": "data/races/halflinglightfoot.json",
         "Halfling (Stout)": "data/races/halflingstout.json",
         "Harengon": "data/races/harengon.json",


### PR DESCRIPTION
## Summary
- fix Ghostwise Halfling race JSON path

## Testing
- `python -m json.tool data/races.json`
- `npm test` *(fails: missing package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a4d94884bc832e9ee4f34d743da7ac