### PR TITLE
Fix race spellcasting ability parsing

### DIFF
--- a/js/raceData.js
+++ b/js/raceData.js
@@ -150,9 +150,17 @@ export function convertRaceData(rawData) {
 
     // Ability choices (store as uppercase values)
     if (sc.ability) {
-      spellcasting.ability_choices = Array.isArray(sc.ability)
-        ? sc.ability.map(a => a.toUpperCase())
-        : [sc.ability.toUpperCase()];
+      let abilities = [];
+      if (Array.isArray(sc.ability)) {
+        abilities = sc.ability;
+      } else if (typeof sc.ability === 'object' && sc.ability.choose) {
+        abilities = Array.isArray(sc.ability.choose)
+          ? sc.ability.choose
+          : [sc.ability.choose];
+      } else {
+        abilities = [sc.ability];
+      }
+      spellcasting.ability_choices = abilities.map(a => a.toString().toUpperCase());
     }
 
     // Known spells / spell choices


### PR DESCRIPTION
## Summary
- handle ability choices defined as objects when parsing race spellcasting data

## Testing
- `node --experimental-modules -e "import('./js/raceData.js').then(async m=>{const fs=await import('fs'); const raw=JSON.parse(fs.readFileSync('data/races/aarakocra.json','utf8')); console.log(m.convertRaceData(raw));}).catch(e=>console.error('err',e))"`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a4d9b352bc832e808543c4bba395de