### PR TITLE
Simplify background language options

### DIFF
--- a/data/backgrounds/acolyte.json
+++ b/data/backgrounds/acolyte.json
@@ -7,24 +7,7 @@
   "tools": [],
   "languages": {
     "choose": 2,
-    "options": [
-      "Common",
-      "Dwarvish",
-      "Elvish",
-      "Giant",
-      "Gnomish",
-      "Goblin",
-      "Halfling",
-      "Orc",
-      "Abyssal",
-      "Celestial",
-      "Draconic",
-      "Deep Speech",
-      "Infernal",
-      "Primordial",
-      "Sylvan",
-      "Undercommon"
-    ]
+    "any": true
   },
   "featOptions": [
     "Magic Initiate",

--- a/data/backgrounds/anthropologist.json
+++ b/data/backgrounds/anthropologist.json
@@ -7,24 +7,7 @@
   "tools": [],
   "languages": {
     "choose": 2,
-    "options": [
-      "Common",
-      "Dwarvish",
-      "Elvish",
-      "Giant",
-      "Gnomish",
-      "Goblin",
-      "Halfling",
-      "Orc",
-      "Abyssal",
-      "Celestial",
-      "Draconic",
-      "Deep Speech",
-      "Infernal",
-      "Primordial",
-      "Sylvan",
-      "Undercommon"
-    ]
+    "any": true
   },
   "featOptions": [
     "Actor",

--- a/data/backgrounds/archaeologist.json
+++ b/data/backgrounds/archaeologist.json
@@ -13,24 +13,7 @@
   },
   "languages": {
     "choose": 1,
-    "options": [
-      "Common",
-      "Dwarvish",
-      "Elvish",
-      "Giant",
-      "Gnomish",
-      "Goblin",
-      "Halfling",
-      "Orc",
-      "Abyssal",
-      "Celestial",
-      "Draconic",
-      "Deep Speech",
-      "Infernal",
-      "Primordial",
-      "Sylvan",
-      "Undercommon"
-    ]
+    "any": true
   },
   "featOptions": [
     "Antiquarian",

--- a/data/backgrounds/artisan.json
+++ b/data/backgrounds/artisan.json
@@ -28,24 +28,7 @@
   },
   "languages": {
     "choose": 1,
-    "options": [
-      "Common",
-      "Dwarvish",
-      "Elvish",
-      "Giant",
-      "Gnomish",
-      "Goblin",
-      "Halfling",
-      "Orc",
-      "Abyssal",
-      "Celestial",
-      "Draconic",
-      "Deep Speech",
-      "Infernal",
-      "Primordial",
-      "Sylvan",
-      "Undercommon"
-    ]
+    "any": true
   },
   "featOptions": [
     "Antiquarian",

--- a/data/backgrounds/artist.json
+++ b/data/backgrounds/artist.json
@@ -34,24 +34,7 @@
   },
   "languages": {
     "choose": 1,
-    "options": [
-      "Common",
-      "Dwarvish",
-      "Elvish",
-      "Giant",
-      "Gnomish",
-      "Goblin",
-      "Halfling",
-      "Orc",
-      "Abyssal",
-      "Celestial",
-      "Draconic",
-      "Deep Speech",
-      "Infernal",
-      "Primordial",
-      "Sylvan",
-      "Undercommon"
-    ]
+    "any": true
   },
   "featOptions": [
     "Antiquarian",

--- a/data/backgrounds/athlete.json
+++ b/data/backgrounds/athlete.json
@@ -9,24 +9,7 @@
   ],
   "languages": {
     "choose": 1,
-    "options": [
-      "Common",
-      "Dwarvish",
-      "Elvish",
-      "Giant",
-      "Gnomish",
-      "Goblin",
-      "Halfling",
-      "Orc",
-      "Abyssal",
-      "Celestial",
-      "Draconic",
-      "Deep Speech",
-      "Infernal",
-      "Primordial",
-      "Sylvan",
-      "Undercommon"
-    ]
+    "any": true
   },
   "featOptions": [
     "Athlete",

--- a/data/backgrounds/city_watch.json
+++ b/data/backgrounds/city_watch.json
@@ -7,24 +7,7 @@
   "tools": [],
   "languages": {
     "choose": 2,
-    "options": [
-      "Common",
-      "Dwarvish",
-      "Elvish",
-      "Giant",
-      "Gnomish",
-      "Goblin",
-      "Halfling",
-      "Orc",
-      "Abyssal",
-      "Celestial",
-      "Draconic",
-      "Deep Speech",
-      "Infernal",
-      "Primordial",
-      "Sylvan",
-      "Undercommon"
-    ]
+    "any": true
   },
   "featOptions": [
     "Alert",

--- a/data/backgrounds/cloistered_scholar.json
+++ b/data/backgrounds/cloistered_scholar.json
@@ -14,24 +14,7 @@
   "tools": [],
   "languages": {
     "choose": 2,
-    "options": [
-      "Common",
-      "Dwarvish",
-      "Elvish",
-      "Giant",
-      "Gnomish",
-      "Goblin",
-      "Halfling",
-      "Orc",
-      "Abyssal",
-      "Celestial",
-      "Draconic",
-      "Deep Speech",
-      "Infernal",
-      "Primordial",
-      "Sylvan",
-      "Undercommon"
-    ]
+    "any": true
   },
   "featOptions": [
     "Erudite",

--- a/data/backgrounds/courtier.json
+++ b/data/backgrounds/courtier.json
@@ -7,24 +7,7 @@
   "tools": [],
   "languages": {
     "choose": 2,
-    "options": [
-      "Common",
-      "Dwarvish",
-      "Elvish",
-      "Giant",
-      "Gnomish",
-      "Goblin",
-      "Halfling",
-      "Orc",
-      "Abyssal",
-      "Celestial",
-      "Draconic",
-      "Deep Speech",
-      "Infernal",
-      "Primordial",
-      "Sylvan",
-      "Undercommon"
-    ]
+    "any": true
   },
   "featOptions": [
     "Keen Mind",

--- a/data/backgrounds/hermit.json
+++ b/data/backgrounds/hermit.json
@@ -15,24 +15,7 @@
   ],
   "languages": {
     "choose": 1,
-    "options": [
-      "Common",
-      "Dwarvish",
-      "Elvish",
-      "Giant",
-      "Gnomish",
-      "Goblin",
-      "Halfling",
-      "Orc",
-      "Abyssal",
-      "Celestial",
-      "Draconic",
-      "Deep Speech",
-      "Infernal",
-      "Primordial",
-      "Sylvan",
-      "Undercommon"
-    ]
+    "any": true
   },
   "featOptions": [
     "Alert",

--- a/data/backgrounds/knight.json
+++ b/data/backgrounds/knight.json
@@ -9,24 +9,7 @@
   ],
   "languages": {
     "choose": 1,
-    "options": [
-      "Common",
-      "Dwarvish",
-      "Elvish",
-      "Giant",
-      "Gnomish",
-      "Goblin",
-      "Halfling",
-      "Orc",
-      "Abyssal",
-      "Celestial",
-      "Draconic",
-      "Deep Speech",
-      "Infernal",
-      "Primordial",
-      "Sylvan",
-      "Undercommon"
-    ]
+    "any": true
   },
   "featOptions": [
     "Loyal Companion",

--- a/data/backgrounds/merchant.json
+++ b/data/backgrounds/merchant.json
@@ -28,24 +28,7 @@
   },
   "languages": {
     "choose": 1,
-    "options": [
-      "Common",
-      "Dwarvish",
-      "Elvish",
-      "Giant",
-      "Gnomish",
-      "Goblin",
-      "Halfling",
-      "Orc",
-      "Abyssal",
-      "Celestial",
-      "Draconic",
-      "Deep Speech",
-      "Infernal",
-      "Primordial",
-      "Sylvan",
-      "Undercommon"
-    ]
+    "any": true
   },
   "featOptions": [
     "Linguist",

--- a/data/backgrounds/noble.json
+++ b/data/backgrounds/noble.json
@@ -9,24 +9,7 @@
   ],
   "languages": {
     "choose": 1,
-    "options": [
-      "Common",
-      "Dwarvish",
-      "Elvish",
-      "Giant",
-      "Gnomish",
-      "Goblin",
-      "Halfling",
-      "Orc",
-      "Abyssal",
-      "Celestial",
-      "Draconic",
-      "Deep Speech",
-      "Infernal",
-      "Primordial",
-      "Sylvan",
-      "Undercommon"
-    ]
+    "any": true
   },
   "featOptions": [
     "Defensive Duelist",

--- a/data/backgrounds/outlander.json
+++ b/data/backgrounds/outlander.json
@@ -22,24 +22,7 @@
   },
   "languages": {
     "choose": 1,
-    "options": [
-      "Common",
-      "Dwarvish",
-      "Elvish",
-      "Giant",
-      "Gnomish",
-      "Goblin",
-      "Halfling",
-      "Orc",
-      "Abyssal",
-      "Celestial",
-      "Draconic",
-      "Deep Speech",
-      "Infernal",
-      "Primordial",
-      "Sylvan",
-      "Undercommon"
-    ]
+    "any": true
   },
   "featOptions": [
     "Chef",

--- a/data/backgrounds/prostitute.json
+++ b/data/backgrounds/prostitute.json
@@ -32,24 +32,7 @@
   },
   "languages": {
     "choose": 1,
-    "options": [
-      "Common",
-      "Dwarvish",
-      "Elvish",
-      "Giant",
-      "Gnomish",
-      "Goblin",
-      "Halfling",
-      "Orc",
-      "Abyssal",
-      "Celestial",
-      "Draconic",
-      "Deep Speech",
-      "Infernal",
-      "Primordial",
-      "Sylvan",
-      "Undercommon"
-    ]
+    "any": true
   },
   "featOptions": [
     "Observant",

--- a/data/backgrounds/sage.json
+++ b/data/backgrounds/sage.json
@@ -15,24 +15,7 @@
   "tools": [],
   "languages": {
     "choose": 2,
-    "options": [
-      "Common",
-      "Dwarvish",
-      "Elvish",
-      "Giant",
-      "Gnomish",
-      "Goblin",
-      "Halfling",
-      "Orc",
-      "Abyssal",
-      "Celestial",
-      "Draconic",
-      "Deep Speech",
-      "Infernal",
-      "Primordial",
-      "Sylvan",
-      "Undercommon"
-    ]
+    "any": true
   },
   "featOptions": [
     "Apothecary",

--- a/data/backgrounds/servant.json
+++ b/data/backgrounds/servant.json
@@ -25,24 +25,7 @@
   },
   "languages": {
     "choose": 1,
-    "options": [
-      "Common",
-      "Dwarvish",
-      "Elvish",
-      "Giant",
-      "Gnomish",
-      "Goblin",
-      "Halfling",
-      "Orc",
-      "Abyssal",
-      "Celestial",
-      "Draconic",
-      "Deep Speech",
-      "Infernal",
-      "Primordial",
-      "Sylvan",
-      "Undercommon"
-    ]
+    "any": true
   },
   "featOptions": [
     "Keen Mind",

--- a/data/backgrounds/slave.json
+++ b/data/backgrounds/slave.json
@@ -14,24 +14,7 @@
   },
   "languages": {
     "choose": 1,
-    "options": [
-      "Common",
-      "Dwarvish",
-      "Elvish",
-      "Giant",
-      "Gnomish",
-      "Goblin",
-      "Halfling",
-      "Orc",
-      "Abyssal",
-      "Celestial",
-      "Draconic",
-      "Deep Speech",
-      "Infernal",
-      "Primordial",
-      "Sylvan",
-      "Undercommon"
-    ]
+    "any": true
   },
   "featOptions": [
     "Beast Tamer",

--- a/data/backgrounds/tribe_member.json
+++ b/data/backgrounds/tribe_member.json
@@ -38,24 +38,7 @@
   },
   "languages": {
     "choose": 1,
-    "options": [
-      "Common",
-      "Dwarvish",
-      "Elvish",
-      "Giant",
-      "Gnomish",
-      "Goblin",
-      "Halfling",
-      "Orc",
-      "Abyssal",
-      "Celestial",
-      "Draconic",
-      "Deep Speech",
-      "Infernal",
-      "Primordial",
-      "Sylvan",
-      "Undercommon"
-    ]
+    "any": true
   },
   "featOptions": [
     "Charger",

--- a/js/step4.js
+++ b/js/step4.js
@@ -1,5 +1,5 @@
 // Step 4: Background selection and feat handling
-import { loadDropdownData } from './common.js';
+import { loadDropdownData, loadLanguages } from './common.js';
 import { initFeatureSelectionHandlers } from './script.js';
 
 let featPathIndex = {};
@@ -139,25 +139,36 @@ document.addEventListener("DOMContentLoaded", () => {
       const p = document.createElement("p");
       p.innerHTML = `<strong>Linguaggi:</strong> ${data.languages.join(", ")}`;
       langDetails.appendChild(p);
+      langDiv.appendChild(langDetails);
+      initFeatureSelectionHandlers(langDiv);
     } else if (data.languages && data.languages.choose) {
       const num = data.languages.choose;
-      const opts = data.languages.options || [];
-      const p = document.createElement("p");
-      p.innerHTML = `<strong>Scegli ${num} linguaggi:</strong>`;
-      langDetails.appendChild(p);
-      for (let i = 0; i < num; i++) {
-        const sel = document.createElement("select");
-        sel.className = "backgroundLanguageChoice";
-        sel.innerHTML = `<option value="">Seleziona</option>` + opts.map(o => `<option value="${o}">${o}</option>`).join("");
-        sel.addEventListener("change", () => {
-          const chosen = Array.from(document.querySelectorAll(".backgroundLanguageChoice")).map(s => s.value).filter(Boolean);
-          backgroundData.languages = chosen;
-        });
-        langDetails.appendChild(sel);
+      const buildSelectors = opts => {
+        const p = document.createElement("p");
+        p.innerHTML = `<strong>Scegli ${num} linguaggi:</strong>`;
+        langDetails.appendChild(p);
+        for (let i = 0; i < num; i++) {
+          const sel = document.createElement("select");
+          sel.className = "backgroundLanguageChoice";
+          sel.innerHTML = `<option value="">Seleziona</option>` + opts.map(o => `<option value="${o}">${o}</option>`).join("");
+          sel.addEventListener("change", () => {
+            const chosen = Array.from(document.querySelectorAll(".backgroundLanguageChoice")).map(s => s.value).filter(Boolean);
+            backgroundData.languages = chosen;
+          });
+          langDetails.appendChild(sel);
+        }
+        langDiv.appendChild(langDetails);
+        initFeatureSelectionHandlers(langDiv);
+      };
+      if (data.languages.any) {
+        loadLanguages(buildSelectors);
+      } else {
+        buildSelectors(data.languages.options || []);
       }
+    } else {
+      langDiv.appendChild(langDetails);
+      initFeatureSelectionHandlers(langDiv);
     }
-    langDiv.appendChild(langDetails);
-    initFeatureSelectionHandlers(langDiv);
 
     const featDiv = document.getElementById("backgroundFeat");
     featDiv.innerHTML = "";


### PR DESCRIPTION
## Summary
- Replace explicit language lists in background JSON with shorthand `{ "choose": N, "any": true }`
- Load full language list from `data/languages.json` when backgrounds allow any languages

## Testing
- `node --check js/step4.js`
- `node -e "const fs=require('fs'); const files=fs.readdirSync('data/backgrounds'); const count=files.filter(f=>{const d=JSON.parse(fs.readFileSync('data/backgrounds/'+f,'utf8')); return d.languages && d.languages.options;}).length; console.log('with options:',count);"`
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a4d96a2df4832e88392019ffca61b5