### PR TITLE
Add equipment options for remaining classes

### DIFF
--- a/data/equipment.json
+++ b/data/equipment.json
@@ -8,44 +8,128 @@
     "Acciarino e pietra focaia"
   ],
   "classes": {
-    "Fighter": {
-      "fixed": ["Scudo"],
+    "Artificer": {
+      "fixed": ["Due pugnali"],
       "choices": [
+        {
+          "label": "Arma",
+          "type": "radio",
+          "options": [
+            { "value": "Balestra leggera e 20 quadrelli", "label": "Balestra leggera e 20 quadrelli" },
+            { "value": "Arma semplice", "label": "Arma semplice" }
+          ]
+        },
         {
           "label": "Armatura",
           "type": "radio",
           "options": [
-            { "value": "Cotta di maglia", "label": "Cotta di maglia" },
-            { "value": "Armatura di cuoio borchiato e arco lungo", "label": "Armatura di cuoio borchiato e arco lungo" }
+            { "value": "Armatura di cuoio borchiato", "label": "Armatura di cuoio borchiato" },
+            { "value": "Armatura a scaglie", "label": "Armatura a scaglie" }
           ]
         },
         {
-          "label": "Arma",
+          "label": "Strumenti",
           "type": "radio",
           "options": [
-            { "value": "Arma marziale e scudo", "label": "Arma marziale e scudo" },
-            { "value": "Due armi marziali", "label": "Due armi marziali" }
+            { "value": "Strumenti da scasso", "label": "Strumenti da scasso" },
+            { "value": "Utensili da artigiano", "label": "Utensili da artigiano" }
+          ]
+        },
+        {
+          "label": "Pacchetto",
+          "type": "radio",
+          "options": [
+            { "value": "Pacchetto da avventuriero", "label": "Pacchetto da avventuriero" },
+            { "value": "Pacchetto da esploratore", "label": "Pacchetto da esploratore" }
           ]
         }
       ]
     },
-    "Wizard": {
-      "fixed": ["Libro degli incantesimi"],
+    "Barbarian": {
+      "fixed": ["Pacchetto da esploratore", "Giavellotti (4)"],
+      "choices": [
+        {
+          "label": "Arma principale",
+          "type": "radio",
+          "options": [
+            { "value": "Ascia bipenne", "label": "Ascia bipenne" },
+            { "value": "Arma marziale da mischia", "label": "Arma marziale da mischia" }
+          ]
+        },
+        {
+          "label": "Arma secondaria",
+          "type": "radio",
+          "options": [
+            { "value": "Due asce da mano", "label": "Due asce da mano" },
+            { "value": "Arma semplice", "label": "Arma semplice" }
+          ]
+        }
+      ]
+    },
+    "Bard": {
+      "fixed": ["Armatura di cuoio", "Pugnale"],
       "choices": [
         {
           "label": "Arma",
           "type": "radio",
           "options": [
-            { "value": "Bastone ferrato", "label": "Bastone ferrato" },
-            { "value": "Pugnale", "label": "Pugnale" }
+            { "value": "Stocco", "label": "Stocco" },
+            { "value": "Spada lunga", "label": "Spada lunga" },
+            { "value": "Arma semplice", "label": "Arma semplice" }
           ]
         },
         {
-          "label": "Focus arcano",
+          "label": "Pacchetto",
           "type": "radio",
           "options": [
-            { "value": "Borsa delle componenti", "label": "Borsa delle componenti" },
-            { "value": "Focus arcano", "label": "Focus arcano" }
+            { "value": "Pacchetto da diplomatico", "label": "Pacchetto da diplomatico" },
+            { "value": "Pacchetto da intrattenitore", "label": "Pacchetto da intrattenitore" }
+          ]
+        },
+        {
+          "label": "Strumento musicale",
+          "type": "radio",
+          "options": [
+            { "value": "Liuto", "label": "Liuto" },
+            { "value": "Altro strumento musicale", "label": "Altro strumento musicale" }
+          ]
+        }
+      ]
+    },
+    "Cleric": {
+      "fixed": ["Scudo", "Simbolo sacro"],
+      "choices": [
+        {
+          "label": "Arma",
+          "type": "radio",
+          "options": [
+            { "value": "Mazza", "label": "Mazza" },
+            { "value": "Martello da guerra", "label": "Martello da guerra" }
+          ]
+        },
+        {
+          "label": "Armatura",
+          "type": "radio",
+          "options": [
+            { "value": "Armatura a scaglie", "label": "Armatura a scaglie" },
+            { "value": "Armatura di cuoio", "label": "Armatura di cuoio" },
+            { "value": "Cotta di maglia", "label": "Cotta di maglia" }
+          ]
+        },
+        {
+          "label": "Arma secondaria",
+          "type": "radio",
+          "options": [
+            { "value": "Balestra leggera e 20 quadrelli", "label": "Balestra leggera e 20 quadrelli" },
+            { "value": "Arma semplice", "label": "Arma semplice" }
+          ]
+        },
+        {
+          "label": "Pacchetto",
+          "type": "radio",
+          "options": [
+            { "value": "Pacchetto da sacerdote", "label": "Pacchetto da sacerdote" },
+            { "value": "Pacchetto da esploratore", "label": "Pacchetto da esploratore" }
           ]
         }
       ]
@@ -71,6 +155,215 @@
         }
       ],
       "goldAlternative": "2d4 × 10 gp"
+    },
+    "Fighter": {
+      "fixed": ["Scudo"],
+      "choices": [
+        {
+          "label": "Armatura",
+          "type": "radio",
+          "options": [
+            { "value": "Cotta di maglia", "label": "Cotta di maglia" },
+            { "value": "Armatura di cuoio borchiato e arco lungo", "label": "Armatura di cuoio borchiato e arco lungo" }
+          ]
+        },
+        {
+          "label": "Arma",
+          "type": "radio",
+          "options": [
+            { "value": "Arma marziale e scudo", "label": "Arma marziale e scudo" },
+            { "value": "Due armi marziali", "label": "Due armi marziali" }
+          ]
+        }
+      ]
+    },
+    "Monk": {
+      "fixed": ["Dardi (10)"],
+      "choices": [
+        {
+          "label": "Arma",
+          "type": "radio",
+          "options": [
+            { "value": "Spada corta", "label": "Spada corta" },
+            { "value": "Arma semplice", "label": "Arma semplice" }
+          ]
+        },
+        {
+          "label": "Pacchetto",
+          "type": "radio",
+          "options": [
+            { "value": "Pacchetto da avventuriero", "label": "Pacchetto da avventuriero" },
+            { "value": "Pacchetto da esploratore", "label": "Pacchetto da esploratore" }
+          ]
+        }
+      ]
+    },
+    "Paladin": {
+      "fixed": ["Cotta di maglia", "Simbolo sacro"],
+      "choices": [
+        {
+          "label": "Arma",
+          "type": "radio",
+          "options": [
+            { "value": "Arma marziale e scudo", "label": "Arma marziale e scudo" },
+            { "value": "Due armi marziali", "label": "Due armi marziali" }
+          ]
+        },
+        {
+          "label": "Arma secondaria",
+          "type": "radio",
+          "options": [
+            { "value": "Giavellotti (5)", "label": "Giavellotti (5)" },
+            { "value": "Arma semplice da mischia", "label": "Arma semplice da mischia" }
+          ]
+        },
+        {
+          "label": "Pacchetto",
+          "type": "radio",
+          "options": [
+            { "value": "Pacchetto da sacerdote", "label": "Pacchetto da sacerdote" },
+            { "value": "Pacchetto da esploratore", "label": "Pacchetto da esploratore" }
+          ]
+        }
+      ]
+    },
+    "Ranger": {
+      "fixed": ["Arco lungo e faretra (20 frecce)"],
+      "choices": [
+        {
+          "label": "Armatura",
+          "type": "radio",
+          "options": [
+            { "value": "Armatura a scaglie", "label": "Armatura a scaglie" },
+            { "value": "Armatura di cuoio", "label": "Armatura di cuoio" }
+          ]
+        },
+        {
+          "label": "Armi",
+          "type": "radio",
+          "options": [
+            { "value": "Due spade corte", "label": "Due spade corte" },
+            { "value": "Due armi semplici da mischia", "label": "Due armi semplici da mischia" }
+          ]
+        },
+        {
+          "label": "Pacchetto",
+          "type": "radio",
+          "options": [
+            { "value": "Pacchetto da avventuriero", "label": "Pacchetto da avventuriero" },
+            { "value": "Pacchetto da esploratore", "label": "Pacchetto da esploratore" }
+          ]
+        }
+      ]
+    },
+    "Rogue": {
+      "fixed": ["Armatura di cuoio", "Due pugnali", "Strumenti da scasso"],
+      "choices": [
+        {
+          "label": "Arma principale",
+          "type": "radio",
+          "options": [
+            { "value": "Stocco", "label": "Stocco" },
+            { "value": "Spada corta", "label": "Spada corta" }
+          ]
+        },
+        {
+          "label": "Arma secondaria",
+          "type": "radio",
+          "options": [
+            { "value": "Arco corto e faretra (20 frecce)", "label": "Arco corto e faretra (20 frecce)" },
+            { "value": "Spada corta", "label": "Spada corta" }
+          ]
+        },
+        {
+          "label": "Pacchetto",
+          "type": "radio",
+          "options": [
+            { "value": "Pacchetto da scassinatore", "label": "Pacchetto da scassinatore" },
+            { "value": "Pacchetto da avventuriero", "label": "Pacchetto da avventuriero" },
+            { "value": "Pacchetto da esploratore", "label": "Pacchetto da esploratore" }
+          ]
+        }
+      ]
+    },
+    "Sorcerer": {
+      "fixed": ["Due pugnali"],
+      "choices": [
+        {
+          "label": "Arma",
+          "type": "radio",
+          "options": [
+            { "value": "Balestra leggera e 20 quadrelli", "label": "Balestra leggera e 20 quadrelli" },
+            { "value": "Arma semplice", "label": "Arma semplice" }
+          ]
+        },
+        {
+          "label": "Focus arcano",
+          "type": "radio",
+          "options": [
+            { "value": "Borsa delle componenti", "label": "Borsa delle componenti" },
+            { "value": "Focus arcano", "label": "Focus arcano" }
+          ]
+        },
+        {
+          "label": "Pacchetto",
+          "type": "radio",
+          "options": [
+            { "value": "Pacchetto da avventuriero", "label": "Pacchetto da avventuriero" },
+            { "value": "Pacchetto da esploratore", "label": "Pacchetto da esploratore" }
+          ]
+        }
+      ]
+    },
+    "Warlock": {
+      "fixed": ["Armatura di cuoio", "Arma semplice", "Due pugnali"],
+      "choices": [
+        {
+          "label": "Arma aggiuntiva",
+          "type": "radio",
+          "options": [
+            { "value": "Balestra leggera e 20 quadrelli", "label": "Balestra leggera e 20 quadrelli" },
+            { "value": "Arma semplice", "label": "Arma semplice" }
+          ]
+        },
+        {
+          "label": "Focus arcano",
+          "type": "radio",
+          "options": [
+            { "value": "Borsa delle componenti", "label": "Borsa delle componenti" },
+            { "value": "Focus arcano", "label": "Focus arcano" }
+          ]
+        },
+        {
+          "label": "Pacchetto",
+          "type": "radio",
+          "options": [
+            { "value": "Pacchetto da studioso", "label": "Pacchetto da studioso" },
+            { "value": "Pacchetto da avventuriero", "label": "Pacchetto da avventuriero" }
+          ]
+        }
+      ]
+    },
+    "Wizard": {
+      "fixed": ["Libro degli incantesimi"],
+      "choices": [
+        {
+          "label": "Arma",
+          "type": "radio",
+          "options": [
+            { "value": "Bastone ferrato", "label": "Bastone ferrato" },
+            { "value": "Pugnale", "label": "Pugnale" }
+          ]
+        },
+        {
+          "label": "Focus arcano",
+          "type": "radio",
+          "options": [
+            { "value": "Borsa delle componenti", "label": "Borsa delle componenti" },
+            { "value": "Focus arcano", "label": "Focus arcano" }
+          ]
+        }
+      ]
     }
   },
   "upgrades": {


### PR DESCRIPTION
## Summary
- add class equipment presets for Artificer, Barbarian, Bard, Cleric, Monk, Paladin, Ranger, Rogue, Sorcerer, Warlock and more
- include fixed gear and radio-choice options for each class

## Testing
- `python -m json.tool data/equipment.json >/dev/null && echo OK`

------
https://chatgpt.com/codex/tasks/task_e_68a4d94a2c5c832eacda43ef39768dc8