### PR TITLE
Translate equipment and spell data to English

### DIFF
--- a/data/equipment.json
+++ b/data/equipment.json
@@ -1,81 +1,128 @@
 {
   "standard": [
-    "Zaino",
-    "Torce (10)",
-    "Razioni (10 giorni)",
-    "Corda (50 piedi)",
-    "Borraccia",
-    "Acciarino e pietra focaia"
+    "Backpack",
+    "Torches (10)",
+    "Rations (10 days)",
+    "Rope (50 feet)",
+    "Waterskin",
+    "Tinderbox"
   ],
   "classes": {
     "Fighter": {
-      "fixed": ["Scudo"],
+      "fixed": [
+        "Shield"
+      ],
       "choices": [
         {
-          "label": "Armatura",
+          "label": "Armor",
           "type": "radio",
           "options": [
-            { "value": "Cotta di maglia", "label": "Cotta di maglia" },
-            { "value": "Armatura di cuoio borchiato e arco lungo", "label": "Armatura di cuoio borchiato e arco lungo" }
+            {
+              "value": "Chain Mail",
+              "label": "Chain Mail"
+            },
+            {
+              "value": "Studded leather armor and longbow",
+              "label": "Studded leather armor and longbow"
+            }
           ]
         },
         {
-          "label": "Arma",
+          "label": "Weapon",
           "type": "radio",
           "options": [
-            { "value": "Arma marziale e scudo", "label": "Arma marziale e scudo" },
-            { "value": "Due armi marziali", "label": "Due armi marziali" }
+            {
+              "value": "Martial weapon and shield",
+              "label": "Martial weapon and shield"
+            },
+            {
+              "value": "Two martial weapons",
+              "label": "Two martial weapons"
+            }
           ]
         }
       ]
     },
     "Wizard": {
-      "fixed": ["Libro degli incantesimi"],
+      "fixed": [
+        "Spellbook"
+      ],
       "choices": [
         {
-          "label": "Arma",
+          "label": "Weapon",
           "type": "radio",
           "options": [
-            { "value": "Bastone ferrato", "label": "Bastone ferrato" },
-            { "value": "Pugnale", "label": "Pugnale" }
+            {
+              "value": "Quarterstaff",
+              "label": "Quarterstaff"
+            },
+            {
+              "value": "Dagger",
+              "label": "Dagger"
+            }
           ]
         },
         {
-          "label": "Focus arcano",
+          "label": "Arcane focus",
           "type": "radio",
           "options": [
-            { "value": "Borsa delle componenti", "label": "Borsa delle componenti" },
-            { "value": "Focus arcano", "label": "Focus arcano" }
+            {
+              "value": "Component pouch",
+              "label": "Component pouch"
+            },
+            {
+              "value": "Arcane focus",
+              "label": "Arcane focus"
+            }
           ]
         }
       ]
     },
     "Druid": {
-      "fixed": ["Armatura di cuoio", "Pacchetto da esploratore", "Focus druidico"],
+      "fixed": [
+        "Leather armor",
+        "Explorer's Pack",
+        "Druidic focus"
+      ],
       "choices": [
         {
-          "label": "Scudo o Arma",
+          "label": "Shield or Weapon",
           "type": "radio",
           "options": [
-            { "value": "Scudo di legno", "label": "Scudo di legno" },
-            { "value": "Arma semplice", "label": "Arma semplice" }
+            {
+              "value": "Wooden shield",
+              "label": "Wooden shield"
+            },
+            {
+              "value": "Simple weapon",
+              "label": "Simple weapon"
+            }
           ]
         },
         {
-          "label": "Arma secondaria",
+          "label": "Secondary weapon",
           "type": "radio",
           "options": [
-            { "value": "Scimitarra", "label": "Scimitarra" },
-            { "value": "Arma semplice da mischia", "label": "Arma semplice da mischia" }
+            {
+              "value": "Scimitar",
+              "label": "Scimitar"
+            },
+            {
+              "value": "Simple melee weapon",
+              "label": "Simple melee weapon"
+            }
           ]
         }
       ],
-      "goldAlternative": "2d4 × 10 gp"
+      "goldAlternative": "2d4 \u00d7 10 gp"
     }
   },
   "upgrades": {
     "minLevel": 11,
-    "armor": ["Mezza armatura di piastre", "Armatura a piastre"],
-    "weapon": "Arma incantata"
+    "armor": [
+      "Half plate armor",
+      "Plate armor"
+    ],
+    "weapon": "Enchanted weapon"
   }
 }

--- a/data/spells.json
+++ b/data/spells.json
@@ -2,2184 +2,2184 @@
   {
     "name": "False Life",
     "level": 1,
-    "school": "Necromanzia",
+    "school": "Necromancy",
     "spell_list": ["Arteficer", "Wizard", "Sorcerer"],
     "ritual": false
   },
   {
     "name": "Feather Fall",
     "level": 1,
-    "school": "Trasmutazione",
+    "school": "Transmutation",
     "spell_list": ["Arteficer", "Bard", "Wizard", "Sorcerer"],
     "ritual": false
   },
   {
     "name": "Find Familiar",
     "level": 1,
-    "school": "Evocazione",
+    "school": "Conjuration",
     "spell_list": ["Wizard"],
     "ritual": true
   },
   {
     "name": "Floating Disk",
     "level": 1,
-    "school": "Evocazione",
+    "school": "Conjuration",
     "spell_list": ["Wizard"],
     "ritual": true
   },
   {
     "name": "Fog Cloud",
     "level": 1,
-    "school": "Evocazione",
+    "school": "Conjuration",
     "spell_list": ["Druid", "Wizard", "Ranger", "Sorcerer"],
     "ritual": false
   },
   {
     "name": "Gift of Alacrity",
     "level": 1,
-    "school": "Divinazione",
+    "school": "Divination",
     "spell_list": ["Wizard"],
     "ritual": false
   },
   {
     "name": "Goodberry",
     "level": 1,
-    "school": "Evocazione",
+    "school": "Conjuration",
     "spell_list": ["Druid", "Ranger"],
     "ritual": false
   },
   {
     "name": "Grease",
     "level": 1,
-    "school": "Evocazione",
+    "school": "Conjuration",
     "spell_list": ["Arteficer", "Wizard", "Sorcerer"],
     "ritual": false
   },
   {
     "name": "Guiding Bolt",
     "level": 1,
-    "school": "Invocazione",
+    "school": "Evocation",
     "spell_list": ["Cleric"],
     "ritual": false
   },
   {
     "name": "Hail of Thorns",
     "level": 1,
-    "school": "Evocazione",
+    "school": "Conjuration",
     "spell_list": ["Ranger"],
     "ritual": false
   },
   {
     "name": "Healing Word",
     "level": 1,
-    "school": "Invocazione",
+    "school": "Evocation",
     "spell_list": ["Bard", "Cleric", "Druid"],
     "ritual": false
   },
   {
     "name": "Hellish Rebuke",
     "level": 1,
-    "school": "Invocazione",
+    "school": "Evocation",
     "spell_list": ["Warlock"],
     "ritual": false
   },
   {
     "name": "Heroism",
     "level": 1,
-    "school": "Ammaliamento",
+    "school": "Enchantment",
     "spell_list": ["Bard", "Paladin"],
     "ritual": false
   },
   {
     "name": "Hex",
     "level": 1,
-    "school": "Ammaliamento",
+    "school": "Enchantment",
     "spell_list": ["Warlock"],
     "ritual": false
   },
   {
     "name": "Hideous Laughter",
     "level": 1,
-    "school": "Ammaliamento",
+    "school": "Enchantment",
     "spell_list": ["Bard", "Wizard"],
     "ritual": false
   },
   {
     "name": "Hunter's Mark",
     "level": 1,
-    "school": "Divinazione",
+    "school": "Divination",
     "spell_list": ["Ranger"],
     "ritual": false
   },
   {
     "name": "Ice Knife",
     "level": 1,
-    "school": "Evocazione",
+    "school": "Conjuration",
     "spell_list": ["Druid", "Wizard", "Sorcerer"],
     "ritual": false
   },
   {
     "name": "Identify",
     "level": 1,
-    "school": "Divinazione",
+    "school": "Divination",
     "spell_list": ["Arteficer", "Bard", "Wizard"],
     "ritual": true
   },
   {
     "name": "Illusory Script",
     "level": 1,
-    "school": "Illusione",
+    "school": "Illusion",
     "spell_list": ["Wizard", "Warlock"],
     "ritual": true
   },
   {
     "name": "Inflict Wounds",
     "level": 1,
-    "school": "Necromanzia",
+    "school": "Necromancy",
     "spell_list": ["Cleric", "Warlock"],
     "ritual": false
   },
   {
     "name": "Jump",
     "level": 1,
-    "school": "Trasmutazione",
+    "school": "Transmutation",
     "spell_list": ["Arteficer", "Bard", "Druid", "Wizard", "Ranger", "Sorcerer"],
     "ritual": false
   },
   {
     "name": "Longstrider",
     "level": 1,
-    "school": "Trasmutazione",
+    "school": "Transmutation",
     "spell_list": ["Arteficer", "Bard", "Druid", "Ranger"],
     "ritual": false
   },
   {
     "name": "Mage Armor",
     "level": 1,
-    "school": "Abiurazione",
+    "school": "Abjuration",
     "spell_list": ["Wizard", "Sorcerer"],
     "ritual": false
   },
   {
     "name": "Magic Missile",
     "level": 1,
-    "school": "Invocazione",
+    "school": "Evocation",
     "spell_list": ["Wizard", "Sorcerer"],
     "ritual": false
   },
   {
     "name": "Magnify Gravity",
     "level": 1,
-    "school": "Trasmutazione",
+    "school": "Transmutation",
     "spell_list": ["Wizard"],
     "ritual": false
   },
   {
     "name": "Protection from Evil and Good",
     "level": 1,
-    "school": "Abiurazione",
+    "school": "Abjuration",
     "spell_list": ["Cleric", "Druid", "Wizard", "Paladin", "Warlock"],
     "ritual": false
   },
   {
     "name": "Purify Food and Drink",
     "level": 1,
-    "school": "Abiurazione",
+    "school": "Abjuration",
     "spell_list": ["Arteficer", "Cleric", "Druid", "Paladin"],
     "ritual": true
   },
   {
     "name": "Ray of Sickness",
     "level": 1,
-    "school": "Necromanzia",
+    "school": "Necromancy",
     "spell_list": ["Wizard", "Sorcerer"],
     "ritual": false
   },
   {
     "name": "Sanctuary",
     "level": 1,
-    "school": "Abiurazione",
+    "school": "Abjuration",
     "spell_list": ["Arteficer", "Cleric"],
     "ritual": false
   },
   {
     "name": "Searing Smite",
     "level": 1,
-    "school": "Invocazione",
+    "school": "Evocation",
     "spell_list": ["Paladin", "Ranger"],
     "ritual": false
   },
   {
     "name": "Shield",
     "level": 1,
-    "school": "Abiurazione",
+    "school": "Abjuration",
     "spell_list": ["Wizard", "Sorcerer"],
     "ritual": false
   },
   {
     "name": "Shield of Faith",
     "level": 1,
-    "school": "Abiurazione",
+    "school": "Abjuration",
     "spell_list": ["Cleric", "Paladin"],
     "ritual": false
   },
   {
     "name": "Silent Image",
     "level": 1,
-    "school": "Illusione",
+    "school": "Illusion",
     "spell_list": ["Bard", "Wizard", "Sorcerer"],
     "ritual": false
   },
   {
     "name": "Sleep",
     "level": 1,
-    "school": "Ammaliamento",
+    "school": "Enchantment",
     "spell_list": ["Bard", "Wizard", "Sorcerer"],
     "ritual": false
   },
   {
     "name": "Snare",
     "level": 1,
-    "school": "Abiurazione",
+    "school": "Abjuration",
     "spell_list": ["Arteficer", "Druid", "Wizard", "Ranger"],
     "ritual": false
   },
   {
     "name": "Speak with Animals",
     "level": 1,
-    "school": "Divinazione",
+    "school": "Divination",
     "spell_list": ["Bard", "Druid", "Ranger"],
     "ritual": true
   },
   {
     "name": "Thunderous Smite",
     "level": 1,
-    "school": "Invocazione",
+    "school": "Evocation",
     "spell_list": ["Paladin"],
     "ritual": false
   },
   {
     "name": "Ray of Frost",
     "level": 0,
-    "school": "Invocazione",
+    "school": "Evocation",
     "spell_list": ["Arteficer", "Wizard", "Sorcerer"],
     "ritual": false
   },
   {
     "name": "Resistance",
     "level": 0,
-    "school": "Abiurazione",
+    "school": "Abjuration",
     "spell_list": ["Arteficer", "Cleric", "Druid"],
     "ritual": false
   },
   {
     "name": "Sacred Flame",
     "level": 0,
-    "school": "Invocazione",
+    "school": "Evocation",
     "spell_list": ["Cleric"],
     "ritual": false
   },
   {
     "name": "Shape Water",
     "level": 0,
-    "school": "Trasmutazione",
+    "school": "Transmutation",
     "spell_list": ["Druid", "Wizard", "Sorcerer"],
     "ritual": false
   },
   {
     "name": "Shillelagh",
     "level": 0,
-    "school": "Trasmutazione",
+    "school": "Transmutation",
     "spell_list": ["Druid"],
     "ritual": false
   },
   {
     "name": "Shocking Grasp",
     "level": 0,
-    "school": "Invocazione",
+    "school": "Evocation",
     "spell_list": ["Arteficer", "Wizard", "Sorcerer"],
     "ritual": false
   },
   {
     "name": "Spare the Dying",
     "level": 0,
-    "school": "Necromanzia",
+    "school": "Necromancy",
     "spell_list": ["Arteficer", "Cleric"],
     "ritual": false
   },
   {
     "name": "Sword Burst",
     "level": 0,
-    "school": "Evocazione",
+    "school": "Conjuration",
     "spell_list": ["Arteficer", "Wizard", "Sorcerer", "Warlock"],
     "ritual": false
   },
   {
     "name": "Thaumaturgy",
     "level": 0,
-    "school": "Trasmutazione",
+    "school": "Transmutation",
     "spell_list": ["Cleric"],
     "ritual": false
   },
   {
     "name": "Thorn Whip",
     "level": 0,
-    "school": "Trasmutazione",
+    "school": "Transmutation",
     "spell_list": ["Arteficer", "Druid"],
     "ritual": false
   },
   {
     "name": "Thunderclap",
     "level": 0,
-    "school": "Invocazione",
+    "school": "Evocation",
     "spell_list": ["Arteficer", "Bard", "Druid", "Wizard", "Sorcerer", "Warlock"],
     "ritual": false
   },
   {
     "name": "Toll the Dead",
     "level": 0,
-    "school": "Necromanzia",
+    "school": "Necromancy",
     "spell_list": ["Cleric", "Wizard", "Warlock"],
     "ritual": false
   },
   {
     "name": "True Strike",
     "level": 0,
-    "school": "Divinazione",
+    "school": "Divination",
     "spell_list": ["Bard", "Wizard", "Sorcerer"],
     "ritual": false
   },
   {
     "name": "Vicious Mockery",
     "level": 0,
-    "school": "Abiurazione",
+    "school": "Abjuration",
     "spell_list": ["Bard"],
     "ritual": false
   },
   {
     "name": "Word of Radiance",
     "level": 0,
-    "school": "Invocazione",
+    "school": "Evocation",
     "spell_list": ["Cleric"],
     "ritual": false
   },
   {
     "name": "Absorb Elements",
     "level": 1,
-    "school": "Abiurazione",
+    "school": "Abjuration",
     "spell_list": ["Arteficer", "Druid", "Wizard", "Ranger", "Sorcerer"],
     "ritual": false
   },
   {
     "name": "Alarm",
     "level": 1,
-    "school": "Abiurazione",
+    "school": "Abjuration",
     "spell_list": ["Arteficer", "Wizard", "Ranger"],
     "ritual": false
   },
   {
     "name": "Animal Friendship",
     "level": 1,
-    "school": "Ammaliamento",
+    "school": "Enchantment",
     "spell_list": ["Bard", "Druid", "Ranger"],
     "ritual": false
   },
   {
     "name": "Armor of Agathys",
     "level": 1,
-    "school": "Abiurazione",
+    "school": "Abjuration",
     "spell_list": ["Warlock"],
     "ritual": false
   },
   {
     "name": "Arms of Hadar",
     "level": 1,
-    "school": "Evocazione",
+    "school": "Conjuration",
     "spell_list": ["Warlock"],
     "ritual": false
   },
   {
     "name": "Bane",
     "level": 1,
-    "school": "Abiurazione",
+    "school": "Abjuration",
     "spell_list": ["Druid", "Ranger", "Sorcerer"],
     "ritual": false
   },
   {
     "name": "Beast Bond",
     "level": 1,
-    "school": "Divinazione",
+    "school": "Divination",
     "spell_list": ["Druid", "Ranger"],
     "ritual": false
   },
   {
     "name": "Bless",
     "level": 1,
-    "school": "Ammaliamento",
+    "school": "Enchantment",
     "spell_list": ["Cleric", "Paladin"],
     "ritual": false
   },
   {
     "name": "Burning Hands",
     "level": 1,
-    "school": "Invocazione",
+    "school": "Evocation",
     "spell_list": ["Wizard", "Sorcerer"],
     "ritual": false
   },
   {
     "name": "Catapult",
     "level": 1,
-    "school": "Trasmutazione",
+    "school": "Transmutation",
     "spell_list": ["Arteficer", "Wizard", "Sorcerer"],
     "ritual": false
   },
   {
     "name": "Cause Fear",
     "level": 1,
-    "school": "Necromanzia",
+    "school": "Necromancy",
     "spell_list": ["Wizard", "Warlock"],
     "ritual": false
   },
   {
     "name": "Caustic Brew",
     "level": 1,
-    "school": "Invocazione",
+    "school": "Evocation",
     "spell_list": ["Arteficer", "Wizard", "Sorcerer"],
     "ritual": false
   },
   {
     "name": "Ceremony",
     "level": 1,
-    "school": "Abiurazione",
+    "school": "Abjuration",
     "spell_list": ["Cleric", "Paladin"],
     "ritual": true
   },
   {
     "name": "Chaos Bolt",
     "level": 1,
-    "school": "Invocazione",
+    "school": "Evocation",
     "spell_list": ["Sorcerer"],
     "ritual": false
   },
   {
     "name": "Charm Person",
     "level": 1,
-    "school": "Ammaliamento",
+    "school": "Enchantment",
     "spell_list": ["Bard", "Druid", "Wizard", "Sorcerer", "Warlock"],
     "ritual": false
   },
   {
     "name": "Chromatic Orb",
     "level": 1,
-    "school": "Invocazione",
+    "school": "Evocation",
     "spell_list": ["Wizard", "Sorcerer"],
     "ritual": false
   },
   {
     "name": "Color Spray",
     "level": 1,
-    "school": "Illusione",
+    "school": "Illusion",
     "spell_list": ["Bard", "Wizard", "Sorcerer"],
     "ritual": false
   },
   {
     "name": "Command",
     "level": 1,
-    "school": "Ammaliamento",
+    "school": "Enchantment",
     "spell_list": ["Bard", "Cleric", "Paladin"],
     "ritual": false
   },
   {
     "name": "Compelled Duel",
     "level": 1,
-    "school": "Ammaliamento",
+    "school": "Enchantment",
     "spell_list": ["Paladin"],
     "ritual": false
   },
   {
     "name": "Comprehend Languages",
     "level": 1,
-    "school": "Divinazione",
+    "school": "Divination",
     "spell_list": ["Bard", "Wizard", "Sorcerer", "Warlock"],
     "ritual": true
   },
   {
     "name": "Create or Destroy Water",
     "level": 1,
-    "school": "Trasmutazione",
+    "school": "Transmutation",
     "spell_list": ["Cleric", "Druid"],
     "ritual": false
   },
   {
     "name": "Cure Wounds",
     "level": 1,
-    "school": "Invocazione",
+    "school": "Evocation",
     "spell_list": ["Arteficer", "Bard", "Cleric", "Druid", "Paladin"],
     "ritual": false
   },
   {
     "name": "Detect Evil and Good",
     "level": 1,
-    "school": "Divinazione",
+    "school": "Divination",
     "spell_list": ["Cleric", "Paladin"],
     "ritual": false
   },
   {
     "name": "Detect Magic",
     "level": 1,
-    "school": "Divinazione",
+    "school": "Divination",
     "spell_list": ["Arteficer", "Bard", "Cleric", "Druid", "Wizard", "Paladin", "Ranger", "Sorcerer"],
     "ritual": true
   },
   {
     "name": "Detect Poison and Disease",
     "level": 1,
-    "school": "Divinazione",
+    "school": "Divination",
     "spell_list": ["Cleric", "Druid", "Paladin", "Ranger"],
     "ritual": true
   },
   {
     "name": "Disguise Self",
     "level": 1,
-    "school": "Illusione",
+    "school": "Illusion",
     "spell_list": ["Arteficer", "Bard", "Wizard", "Sorcerer"],
     "ritual": false
   },
   {
     "name": "Dissonant Whispers",
     "level": 1,
-    "school": "Ammaliamento",
+    "school": "Enchantment",
     "spell_list": ["Bard"],
     "ritual": false
   },
   {
     "name": "Divine Favor",
     "level": 1,
-    "school": "Invocazione",
+    "school": "Evocation",
     "spell_list": ["Paladin"],
     "ritual": false
   },
   {
     "name": "Earth Tremor",
     "level": 1,
-    "school": "Invocazione",
+    "school": "Evocation",
     "spell_list": ["Bard", "Wizard", "Sorcerer"],
     "ritual": false
   },
   {
     "name": "Ensnaring Strike",
     "level": 1,
-    "school": "Evocazione",
+    "school": "Conjuration",
     "spell_list": ["Ranger"],
     "ritual": false
   },
   {
     "name": "Entangle",
     "level": 1,
-    "school": "Evocazione",
+    "school": "Conjuration",
     "spell_list": ["Druid", "Ranger"],
     "ritual": false
   },
   {
     "name": "Expeditious Retreat",
     "level": 1,
-    "school": "Trasmutazione",
+    "school": "Transmutation",
     "spell_list": ["Arteficer", "Wizard", "Sorcerer", "Warlock"],
     "ritual": false
   },
   {
     "name": "Faerie Fire",
     "level": 1,
-    "school": "Invocazione",
+    "school": "Evocation",
     "spell_list": ["Arteficer", "Bard", "Druid"],
     "ritual": false
   },
   {
     "name": "False Life",
     "level": 1,
-    "school": "Necromanzia",
+    "school": "Necromancy",
     "spell_list": ["Arteficer", "Wizard", "Sorcerer"],
     "ritual": false
   },
   {
     "name": "Feather Fall",
     "level": 1,
-    "school": "Trasmutazione",
+    "school": "Transmutation",
     "spell_list": ["Arteficer", "Bard", "Wizard", "Sorcerer"],
     "ritual": false
   },
   {
     "name": "Find Familiar",
     "level": 1,
-    "school": "Evocazione",
+    "school": "Conjuration",
     "spell_list": ["Wizard"],
     "ritual": true
   },
   {
     "name": "Floating Disk",
     "level": 1,
-    "school": "Evocazione",
+    "school": "Conjuration",
     "spell_list": ["Wizard"],
     "ritual": true
   },
   {
     "name": "Fog Cloud",
     "level": 1,
-    "school": "Evocazione",
+    "school": "Conjuration",
     "spell_list": ["Druid", "Wizard", "Ranger", "Sorcerer"],
     "ritual": false
   },
   {
     "name": "Gift of Alacrity",
     "level": 1,
-    "school": "Divinazione",
+    "school": "Divination",
     "spell_list": ["Wizard"],
     "ritual": false
   },
   {
     "name": "Goodberry",
     "level": 1,
-    "school": "Evocazione",
+    "school": "Conjuration",
     "spell_list": ["Druid", "Ranger"],
     "ritual": false
   },
   {
     "name": "Grease",
     "level": 1,
-    "school": "Evocazione",
+    "school": "Conjuration",
     "spell_list": ["Arteficer", "Wizard", "Sorcerer"],
     "ritual": false
   },
   {
     "name": "Guiding Bolt",
     "level": 1,
-    "school": "Invocazione",
+    "school": "Evocation",
     "spell_list": ["Cleric"],
     "ritual": false
   },
   {
     "name": "Hail of Thorns",
     "level": 1,
-    "school": "Evocazione",
+    "school": "Conjuration",
     "spell_list": ["Ranger"],
     "ritual": false
   },
   {
     "name": "Healing Word",
     "level": 1,
-    "school": "Invocazione",
+    "school": "Evocation",
     "spell_list": ["Bard", "Cleric", "Druid"],
     "ritual": false
   },
   {
     "name": "Hellish Rebuke",
     "level": 1,
-    "school": "Invocazione",
+    "school": "Evocation",
     "spell_list": ["Warlock"],
     "ritual": false
   },
   {
     "name": "Heroism",
     "level": 1,
-    "school": "Ammaliamento",
+    "school": "Enchantment",
     "spell_list": ["Bard", "Paladin"],
     "ritual": false
   },
   {
     "name": "Hex",
     "level": 1,
-    "school": "Ammaliamento",
+    "school": "Enchantment",
     "spell_list": ["Warlock"],
     "ritual": false
   },
   {
     "name": "Hideous Laughter",
     "level": 1,
-    "school": "Ammaliamento",
+    "school": "Enchantment",
     "spell_list": ["Bard", "Wizard"],
     "ritual": false
   },
   {
     "name": "Hunter's Mark",
     "level": 1,
-    "school": "Divinazione",
+    "school": "Divination",
     "spell_list": ["Ranger"],
     "ritual": false
   },
   {
     "name": "Ice Knife",
     "level": 1,
-    "school": "Evocazione",
+    "school": "Conjuration",
     "spell_list": ["Druid", "Wizard", "Sorcerer"],
     "ritual": false
   },
   {
     "name": "Identify",
     "level": 1,
-    "school": "Divinazione",
+    "school": "Divination",
     "spell_list": ["Arteficer", "Bard", "Wizard"],
     "ritual": true
   },
   {
     "name": "Illusory Script",
     "level": 1,
-    "school": "Illusione",
+    "school": "Illusion",
     "spell_list": ["Wizard", "Warlock"],
     "ritual": true
   },
   {
     "name": "Inflict Wounds",
     "level": 1,
-    "school": "Necromanzia",
+    "school": "Necromancy",
     "spell_list": ["Cleric", "Warlock"],
     "ritual": false
   },
   {
     "name": "Jump",
     "level": 1,
-    "school": "Trasmutazione",
+    "school": "Transmutation",
     "spell_list": ["Arteficer", "Bard", "Druid", "Wizard", "Ranger", "Sorcerer"],
     "ritual": false
   },
   {
     "name": "Longstrider",
     "level": 1,
-    "school": "Trasmutazione",
+    "school": "Transmutation",
     "spell_list": ["Arteficer", "Bard", "Druid", "Ranger"],
     "ritual": false
   },
   {
     "name": "Mage Armor",
     "level": 1,
-    "school": "Abiurazione",
+    "school": "Abjuration",
     "spell_list": ["Wizard", "Sorcerer"],
     "ritual": false
   },
   {
     "name": "Magic Missile",
     "level": 1,
-    "school": "Invocazione",
+    "school": "Evocation",
     "spell_list": ["Wizard", "Sorcerer"],
     "ritual": false
   },
   {
     "name": "Magnify Gravity",
     "level": 1,
-    "school": "Trasmutazione",
+    "school": "Transmutation",
     "spell_list": ["Wizard"],
     "ritual": false
   },
   {
     "name": "Protection from Evil and Good",
     "level": 1,
-    "school": "Abiurazione",
+    "school": "Abjuration",
     "spell_list": ["Cleric", "Druid", "Wizard", "Paladin", "Warlock"],
     "ritual": false
   },
   {
     "name": "Purify Food and Drink",
     "level": 1,
-    "school": "Abiurazione",
+    "school": "Abjuration",
     "spell_list": ["Arteficer", "Cleric", "Druid", "Paladin"],
     "ritual": true
   },
   {
     "name": "Ray of Sickness",
     "level": 1,
-    "school": "Necromanzia",
+    "school": "Necromancy",
     "spell_list": ["Wizard", "Sorcerer"],
     "ritual": false
   },
   {
     "name": "Sanctuary",
     "level": 1,
-    "school": "Abiurazione",
+    "school": "Abjuration",
     "spell_list": ["Arteficer", "Cleric"],
     "ritual": false
   },
   {
     "name": "Searing Smite",
     "level": 1,
-    "school": "Invocazione",
+    "school": "Evocation",
     "spell_list": ["Paladin", "Ranger"],
     "ritual": false
   },
   {
     "name": "Shield",
     "level": 1,
-    "school": "Abiurazione",
+    "school": "Abjuration",
     "spell_list": ["Wizard", "Sorcerer"],
     "ritual": false
   },
   {
     "name": "Shield of Faith",
     "level": 1,
-    "school": "Abiurazione",
+    "school": "Abjuration",
     "spell_list": ["Cleric", "Paladin"],
     "ritual": false
   },
   {
     "name": "Silent Image",
     "level": 1,
-    "school": "Illusione",
+    "school": "Illusion",
     "spell_list": ["Bard", "Wizard", "Sorcerer"],
     "ritual": false
   },
   {
     "name": "Sleep",
     "level": 1,
-    "school": "Ammaliamento",
+    "school": "Enchantment",
     "spell_list": ["Bard", "Wizard", "Sorcerer"],
     "ritual": false
   },
   {
     "name": "Snare",
     "level": 1,
-    "school": "Abiurazione",
+    "school": "Abjuration",
     "spell_list": ["Arteficer", "Druid", "Wizard", "Ranger"],
     "ritual": false
   },
   {
     "name": "Speak with Animals",
     "level": 1,
-    "school": "Divinazione",
+    "school": "Divination",
     "spell_list": ["Bard", "Druid", "Ranger"],
     "ritual": true
   },
   {
     "name": "Thunderous Smite",
     "level": 1,
-    "school": "Invocazione",
+    "school": "Evocation",
     "spell_list": ["Paladin"],
     "ritual": false
   },
   {
     "name": "Acid Arrow",
     "level": 2,
-    "school": "Invocazione",
+    "school": "Evocation",
     "spell_list": ["Wizard"],
     "ritual": false
   },
   {
     "name": "Aid",
     "level": 2,
-    "school": "Abiurazione",
+    "school": "Abjuration",
     "spell_list": ["Arteficer", "Bard", "Cleric", "Paladin", "Ranger"],
     "ritual": false
   },
   {
     "name": "Alter Self",
     "level": 2,
-    "school": "Trasmutazione",
+    "school": "Transmutation",
     "spell_list": ["Arteficer", "Wizard", "Sorcerer"],
     "ritual": false
   },
   {
     "name": "Animal Messenger",
     "level": 2,
-    "school": "Ammaliamento",
+    "school": "Enchantment",
     "spell_list": ["Bard", "Druid", "Ranger"],
     "ritual": true
   },
   {
     "name": "Arcane Lock",
     "level": 2,
-    "school": "Abiurazione",
+    "school": "Abjuration",
     "spell_list": ["Arteficer", "Wizard"],
     "ritual": false
   },
   {
     "name": "Arcane Scorcher",
     "level": 2,
-    "school": "Invocazione",
+    "school": "Evocation",
     "spell_list": ["Wizard", "Sorcerer"],
     "ritual": false
   },
   {
     "name": "Augury",
     "level": 2,
-    "school": "Divinazione",
+    "school": "Divination",
     "spell_list": ["Cleric", "Druid"],
     "ritual": true
   },
   {
     "name": "Barkskin",
     "level": 2,
-    "school": "Trasmutazione",
+    "school": "Transmutation",
     "spell_list": ["Druid", "Ranger"],
     "ritual": false
   },
   {
     "name": "Beast Sense",
     "level": 2,
-    "school": "Divinazione",
+    "school": "Divination",
     "spell_list": ["Druid", "Ranger"],
     "ritual": true
   },
   {
     "name": "Binding Ice",
     "level": 2,
-    "school": "Evocazione",
+    "school": "Conjuration",
     "spell_list": ["Wizard", "Sorcerer"],
     "ritual": false
   },
   {
     "name": "Blindness/Deafness",
     "level": 2,
-    "school": "Necromanzia",
+    "school": "Necromancy",
     "spell_list": ["Bard", "Cleric", "Wizard", "Sorcerer"],
     "ritual": false
   },
   {
     "name": "Blur",
     "level": 2,
-    "school": "Illusione",
+    "school": "Illusion",
     "spell_list": ["Arteficer", "Wizard", "Sorcerer"],
     "ritual": false
   },
   {
     "name": "Branding Smite",
     "level": 2,
-    "school": "Invocazione",
+    "school": "Evocation",
     "spell_list": ["Paladin"],
     "ritual": false
   },
   {
     "name": "Calm Emotions",
     "level": 2,
-    "school": "Ammaliamento",
+    "school": "Enchantment",
     "spell_list": ["Bard", "Cleric"],
     "ritual": false
   },
   {
     "name": "Cloud of Daggers",
     "level": 2,
-    "school": "Evocazione",
+    "school": "Conjuration",
     "spell_list": ["Bard", "Wizard", "Sorcerer", "Warlock"],
     "ritual": false
   },
   {
     "name": "Continual Flame",
     "level": 2,
-    "school": "Invocazione",
+    "school": "Evocation",
     "spell_list": ["Arteficer", "Cleric", "Druid", "Wizard"],
     "ritual": false
   },
   {
     "name": "Cordon of Arrows",
     "level": 2,
-    "school": "Trasmutazione",
+    "school": "Transmutation",
     "spell_list": ["Ranger"],
     "ritual": false
   },
   {
     "name": "Crown of Madness",
     "level": 2,
-    "school": "Ammaliamento",
+    "school": "Enchantment",
     "spell_list": ["Bard", "Wizard", "Sorcerer", "Warlock"],
     "ritual": false
   },
   {
     "name": "Darkness",
     "level": 2,
-    "school": "Invocazione",
+    "school": "Evocation",
     "spell_list": ["Wizard", "Sorcerer", "Warlock"],
     "ritual": false
   },
   {
     "name": "Darkvision",
     "level": 2,
-    "school": "Trasmutazione",
+    "school": "Transmutation",
     "spell_list": ["Arteficer", "Druid", "Wizard", "Sorcerer"],
     "ritual": false
   },
   {
     "name": "Detect Thoughts",
     "level": 2,
-    "school": "Divinazione",
+    "school": "Divination",
     "spell_list": ["Wizard"],
     "ritual": false
   },
   {
     "name": "Dragon's Breath",
     "level": 2,
-    "school": "Trasmutazione",
+    "school": "Transmutation",
     "spell_list": ["Wizard", "Sorcerer"],
     "ritual": false
   },
   {
     "name": "Dust Devil",
     "level": 2,
-    "school": "Evocazione",
+    "school": "Conjuration",
     "spell_list": ["Druid", "Wizard"],
     "ritual": false
   },
   {
     "name": "Earthbind",
     "level": 2,
-    "school": "Trasmutazione",
+    "school": "Transmutation",
     "spell_list": ["Druid", "Wizard", "Sorcerer", "Warlock"],
     "ritual": false
   },
   {
     "name": "Enhance Ability",
     "level": 2,
-    "school": "Trasmutazione",
+    "school": "Transmutation",
     "spell_list": ["Arteficer", "Bard", "Cleric", "Druid", "Wizard", "Ranger", "Sorcerer"],
     "ritual": false
   },
   {
     "name": "Enlarge/Reduce",
     "level": 2,
-    "school": "Trasmutazione",
+    "school": "Transmutation",
     "spell_list": ["Arteficer", "Bard", "Druid", "Wizard", "Sorcerer"],
     "ritual": false
   },
   {
     "name": "Find Steed",
     "level": 2,
-    "school": "Evocazione",
+    "school": "Conjuration",
     "spell_list": ["Paladin"],
     "ritual": false
   },
   {
     "name": "Flame Blade",
     "level": 2,
-    "school": "Invocazione",
+    "school": "Evocation",
     "spell_list": ["Cleric", "Druid", "Sorcerer"],
     "ritual": false
   },
   {
     "name": "Flaming Sphere",
     "level": 2,
-    "school": "Evocazione",
+    "school": "Conjuration",
     "spell_list": ["Druid", "Wizard", "Sorcerer"],
     "ritual": false
   },
   {
     "name": "Gentle Repose",
     "level": 2,
-    "school": "Necromanzia",
+    "school": "Necromancy",
     "spell_list": ["Cleric", "Wizard", "Paladin"],
     "ritual": true
   },
   {
     "name": "Gust of Wind",
     "level": 2,
-    "school": "Invocazione",
+    "school": "Evocation",
     "spell_list": ["Druid", "Wizard", "Ranger", "Sorcerer"],
     "ritual": false
   },
   {
     "name": "Hold Person",
     "level": 2,
-    "school": "Ammaliamento",
+    "school": "Enchantment",
     "spell_list": ["Bard", "Cleric", "Druid", "Wizard", "Sorcerer", "Warlock"],
     "ritual": false
   },
   {
     "name": "Invisibility",
     "level": 2,
-    "school": "Illusione",
+    "school": "Illusion",
     "spell_list": ["Arteficer", "Bard", "Wizard", "Sorcerer", "Warlock"],
     "ritual": false
   },
   {
     "name": "Knock",
     "level": 2,
-    "school": "Trasmutazione",
+    "school": "Transmutation",
     "spell_list": ["Bard", "Wizard", "Sorcerer"],
     "ritual": false
   },
   {
     "name": "Lesser Restoration",
     "level": 2,
-    "school": "Abiurazione",
+    "school": "Abjuration",
     "spell_list": ["Arteficer", "Bard", "Cleric", "Druid", "Paladin", "Ranger"],
     "ritual": false
   },
   {
     "name": "Levitate",
     "level": 2,
-    "school": "Trasmutazione",
+    "school": "Transmutation",
     "spell_list": ["Arteficer", "Wizard", "Sorcerer"],
     "ritual": false
   },
   {
     "name": "Locate Animals or Plants",
     "level": 2,
-    "school": "Divinazione",
+    "school": "Divination",
     "spell_list": ["Bard", "Druid", "Ranger"],
     "ritual": true
   },
   {
     "name": "Locate Object",
     "level": 2,
-    "school": "Divinazione",
+    "school": "Divination",
     "spell_list": ["Bard", "Cleric"],
     "ritual": false
   },
   {
     "name": "Magic Mouth",
     "level": 2,
-    "school": "Illusione",
+    "school": "Illusion",
     "spell_list": ["Arteficer", "Bard", "Wizard"],
     "ritual": true
   },
   {
     "name": "Magic Weapon",
     "level": 2,
-    "school": "Trasmutazione",
+    "school": "Transmutation",
     "spell_list": ["Arteficer", "Wizard", "Paladin", "Ranger", "Sorcerer"],
     "ritual": false
   },
   {
     "name": "Mirror Image",
     "level": 2,
-    "school": "Illusione",
+    "school": "Illusion",
     "spell_list": ["Bard", "Wizard", "Sorcerer", "Warlock"],
     "ritual": false
   },
   {
     "name": "Misty Step",
     "level": 2,
-    "school": "Evocazione",
+    "school": "Conjuration",
     "spell_list": ["Wizard", "Sorcerer", "Warlock"],
     "ritual": false
   },
   {
     "name": "Moonbeam",
     "level": 2,
-    "school": "Invocazione",
+    "school": "Evocation",
     "spell_list": ["Druid"],
     "ritual": false
   },
   {
     "name": "Pass Without Trace",
     "level": 2,
-    "school": "Abiurazione",
+    "school": "Abjuration",
     "spell_list": ["Druid", "Ranger"],
     "ritual": false
   },
   {
     "name": "Phantasmal Force",
     "level": 2,
-    "school": "Illusione",
+    "school": "Illusion",
     "spell_list": ["Bard", "Wizard", "Sorcerer"],
     "ritual": false
   },
   {
     "name": "Prayer of Healing",
     "level": 2,
-    "school": "Invocazione",
+    "school": "Evocation",
     "spell_list": ["Cleric", "Paladin"],
     "ritual": false
   },
   {
     "name": "Protection from Poison",
     "level": 2,
-    "school": "Abiurazione",
+    "school": "Abjuration",
     "spell_list": ["Arteficer", "Cleric", "Druid", "Paladin", "Ranger"],
     "ritual": false
   },
   {
     "name": "See Invisibility",
     "level": 2,
-    "school": "Divinazione",
+    "school": "Divination",
     "spell_list": ["Arteficer", "Bard", "Wizard", "Sorcerer"],
     "ritual": false
   },
   {
     "name": "Shatter",
     "level": 2,
-    "school": "Invocazione",
+    "school": "Evocation",
     "spell_list": ["Bard", "Wizard", "Sorcerer", "Warlock"],
     "ritual": false
   },
   {
     "name": "Silence",
     "level": 2,
-    "school": "Illusione",
+    "school": "Illusion",
     "spell_list": ["Bard", "Cleric", "Ranger"],
     "ritual": true
   },
   {
     "name": "Skywrite",
     "level": 2,
-    "school": "Trasmutazione",
+    "school": "Transmutation",
     "spell_list": ["Arteficer", "Bard", "Druid", "Wizard"],
     "ritual": true
   },
   {
     "name": "Spider Climb",
     "level": 2,
-    "school": "Trasmutazione",
+    "school": "Transmutation",
     "spell_list": ["Arteficer", "Wizard", "Sorcerer", "Warlock"],
     "ritual": false
   },
   {
     "name": "Spike Growth",
     "level": 2,
-    "school": "Trasmutazione",
+    "school": "Transmutation",
     "spell_list": ["Druid", "Ranger"],
     "ritual": false
   },
   {
     "name": "Spiritual Weapon",
     "level": 2,
-    "school": "Invocazione",
+    "school": "Evocation",
     "spell_list": ["Cleric"],
     "ritual": false
   },
   {
     "name": "Suggestion",
     "level": 2,
-    "school": "Ammaliamento",
+    "school": "Enchantment",
     "spell_list": ["Bard", "Wizard", "Sorcerer", "Warlock"],
     "ritual": false
   },
   {
     "name": "Summon Beast",
     "level": 2,
-    "school": "Evocazione",
+    "school": "Conjuration",
     "spell_list": ["Druid", "Ranger"],
     "ritual": false
   },
   {
     "name": "Warding Bond",
     "level": 2,
-    "school": "Abiurazione",
+    "school": "Abjuration",
     "spell_list": ["Druid", "Paladin"],
     "ritual": false
   },
   {
     "name": "Web",
     "level": 2,
-    "school": "Evocazione",
+    "school": "Conjuration",
     "spell_list": ["Arteficer", "Wizard", "Sorcerer"],
     "ritual": false
   },
   {
     "name": "Zone of Truth",
     "level": 2,
-    "school": "Ammaliamento",
+    "school": "Enchantment",
     "spell_list": ["Bard", "Cleric", "Paladin"],
     "ritual": false
   },
   {
     "name": "Animate Dead",
     "level": 3,
-    "school": "Necromanzia",
+    "school": "Necromancy",
     "spell_list": ["Cleric", "Wizard"],
     "ritual": false
   },
   {
     "name": "Aura of Vitality",
     "level": 3,
-    "school": "Abiurazione",
+    "school": "Abjuration",
     "spell_list": ["Cleric", "Druid", "Paladin"],
     "ritual": false
   },
   {
     "name": "Beacon of Hope",
     "level": 3,
-    "school": "Abiurazione",
+    "school": "Abjuration",
     "spell_list": ["Cleric"],
     "ritual": false
   },
   {
     "name": "Bestow Curse",
     "level": 3,
-    "school": "Necromanzia",
+    "school": "Necromancy",
     "spell_list": ["Bard", "Cleric", "Wizard"],
     "ritual": false
   },
   {
     "name": "Blinding Smite",
     "level": 3,
-    "school": "Invocazione",
+    "school": "Evocation",
     "spell_list": ["Paladin"],
     "ritual": false
   },
   {
     "name": "Blink",
     "level": 3,
-    "school": "Trasmutazione",
+    "school": "Transmutation",
     "spell_list": ["Arteficer", "Wizard", "Sorcerer"],
     "ritual": false
   },
   {
     "name": "Call Lightning",
     "level": 3,
-    "school": "Evocazione",
+    "school": "Conjuration",
     "spell_list": ["Druid"],
     "ritual": false
   },
   {
     "name": "Catnap",
     "level": 3,
-    "school": "Ammaliamento",
+    "school": "Enchantment",
     "spell_list": ["Arteficer", "Bard", "Wizard", "Sorcerer"],
     "ritual": false
   },
   {
     "name": "Clairvoyance",
     "level": 3,
-    "school": "Divinazione",
+    "school": "Divination",
     "spell_list": ["Bard", "Cleric", "Wizard", "Sorcerer"],
     "ritual": false
   },
   {
     "name": "Conjure Animals",
     "level": 3,
-    "school": "Evocazione",
+    "school": "Conjuration",
     "spell_list": ["Druid", "Ranger"],
     "ritual": false
   },
   {
     "name": "Conjure Barrage",
     "level": 3,
-    "school": "Evocazione",
+    "school": "Conjuration",
     "spell_list": ["Ranger"],
     "ritual": false
   },
   {
     "name": "Counterspell",
     "level": 3,
-    "school": "Abiurazione",
+    "school": "Abjuration",
     "spell_list": ["Wizard", "Sorcerer", "Warlock"],
     "ritual": false
   },
   {
     "name": "Create Food and Water",
     "level": 3,
-    "school": "Evocazione",
+    "school": "Conjuration",
     "spell_list": ["Arteficer", "Cleric", "Paladin"],
     "ritual": false
   },
   {
     "name": "Crusader's Mantle",
     "level": 3,
-    "school": "Invocazione",
+    "school": "Evocation",
     "spell_list": ["Paladin"],
     "ritual": false
   },
   {
     "name": "Daylight",
     "level": 3,
-    "school": "Invocazione",
+    "school": "Evocation",
     "spell_list": ["Cleric", "Druid", "Ranger", "Sorcerer"],
     "ritual": false
   },
   {
     "name": "Dispel Magic",
     "level": 3,
-    "school": "Abiurazione",
+    "school": "Abjuration",
     "spell_list": ["Arteficer", "Bard", "Cleric", "Druid", "Wizard", "Paladin", "Sorcerer", "Warlock"],
     "ritual": false
   },
   {
     "name": "Elemental Weapon",
     "level": 3,
-    "school": "Trasmutazione",
+    "school": "Transmutation",
     "spell_list": ["Arteficer", "Druid", "Paladin", "Ranger"],
     "ritual": false
   },
   {
     "name": "Enemies Abound",
     "level": 3,
-    "school": "Ammaliamento",
+    "school": "Enchantment",
     "spell_list": ["Bard", "Wizard", "Sorcerer", "Warlock"],
     "ritual": false
   },
   {
     "name": "Erupting Earth",
     "level": 3,
-    "school": "Trasmutazione",
+    "school": "Transmutation",
     "spell_list": ["Druid", "Wizard", "Sorcerer"],
     "ritual": false
   },
   {
     "name": "Fear",
     "level": 3,
-    "school": "Illusione",
+    "school": "Illusion",
     "spell_list": ["Wizard", "Sorcerer", "Warlock"],
     "ritual": false
   },
   {
     "name": "Feign Death",
     "level": 3,
-    "school": "Necromanzia",
+    "school": "Necromancy",
     "spell_list": ["Bard", "Cleric", "Wizard"],
     "ritual": true
   },
   {
     "name": "Fireball",
     "level": 3,
-    "school": "Invocazione",
+    "school": "Evocation",
     "spell_list": ["Wizard", "Sorcerer"],
     "ritual": false
   },
   {
     "name": "Fly",
     "level": 3,
-    "school": "Trasmutazione",
+    "school": "Transmutation",
     "spell_list": ["Arteficer", "Wizard", "Sorcerer", "Warlock"],
     "ritual": false
   },
   {
     "name": "Gaseous Form",
     "level": 3,
-    "school": "Trasmutazione",
+    "school": "Transmutation",
     "spell_list": ["Wizard", "Sorcerer", "Warlock"],
     "ritual": false
   },
   {
     "name": "Glyph of Warding",
     "level": 3,
-    "school": "Abiurazione",
+    "school": "Abjuration",
     "spell_list": ["Arteficer", "Bard", "Cleric", "Wizard"],
     "ritual": false
   },
   {
     "name": "Haste",
     "level": 3,
-    "school": "Trasmutazione",
+    "school": "Transmutation",
     "spell_list": ["Arteficer", "Wizard", "Sorcerer"],
     "ritual": false
   },
   {
     "name": "Hunger of Hadar",
     "level": 3,
-    "school": "Evocazione",
+    "school": "Conjuration",
     "spell_list": ["Warlock"],
     "ritual": false
   },
   {
     "name": "Hypnotic Pattern",
     "level": 3,
-    "school": "Illusione",
+    "school": "Illusion",
     "spell_list": ["Bard", "Wizard", "Sorcerer", "Warlock"],
     "ritual": false
   },
   {
     "name": "Intellect Fortress",
     "level": 3,
-    "school": "Abiurazione",
+    "school": "Abjuration",
     "spell_list": ["Arteficer", "Bard", "Wizard", "Sorcerer", "Warlock"],
     "ritual": false
   },
   {
     "name": "Lightning Bolt",
     "level": 3,
-    "school": "Invocazione",
+    "school": "Evocation",
     "spell_list": ["Wizard", "Sorcerer"],
     "ritual": false
   },
   {
     "name": "Magic Circle",
     "level": 3,
-    "school": "Abiurazione",
+    "school": "Abjuration",
     "spell_list": ["Cleric", "Wizard", "Paladin", "Warlock"],
     "ritual": false
   },
   {
     "name": "Major Image",
     "level": 3,
-    "school": "Illusione",
+    "school": "Illusion",
     "spell_list": ["Bard", "Wizard", "Sorcerer", "Warlock"],
     "ritual": false
   },
   {
     "name": "Mass Healing Word",
     "level": 3,
-    "school": "Invocazione",
+    "school": "Evocation",
     "spell_list": ["Bard", "Cleric"],
     "ritual": false
   },
   {
     "name": "Meld into Stone",
     "level": 3,
-    "school": "Trasmutazione",
+    "school": "Transmutation",
     "spell_list": ["Cleric", "Druid", "Ranger"],
     "ritual": true
   },
   {
     "name": "Minute Meteors",
     "level": 3,
-    "school": "Invocazione",
+    "school": "Evocation",
     "spell_list": ["Wizard", "Sorcerer"],
     "ritual": false
   },
   {
     "name": "Nondetection",
     "level": 3,
-    "school": "Abiurazione",
+    "school": "Abjuration",
     "spell_list": ["Bard", "Wizard"],
     "ritual": false
   },
   {
     "name": "Phantom Steed",
     "level": 3,
-    "school": "Illusione",
+    "school": "Illusion",
     "spell_list": ["Wizard"],
     "ritual": true
   },
   {
     "name": "Plant Growth",
     "level": 3,
-    "school": "Trasmutazione",
+    "school": "Transmutation",
     "spell_list": ["Bard", "Druid", "Ranger"],
     "ritual": false
   },
   {
     "name": "Protection from Energy",
     "level": 3,
-    "school": "Abiurazione",
+    "school": "Abjuration",
     "spell_list": ["Arteficer", "Druid", "Wizard", "Ranger", "Sorcerer"],
     "ritual": false
   },
   {
     "name": "Remove Curse",
     "level": 3,
-    "school": "Abiurazione",
+    "school": "Abjuration",
     "spell_list": ["Cleric", "Wizard", "Paladin"],
     "ritual": false
   },
   {
     "name": "Revivify",
     "level": 3,
-    "school": "Necromanzia",
+    "school": "Necromancy",
     "spell_list": ["Arteficer", "Cleric", "Druid", "Paladin", "Ranger"],
     "ritual": false
   },
   {
     "name": "Sending",
     "level": 3,
-    "school": "Invocazione",
+    "school": "Evocation",
     "spell_list": ["Bard", "Cleric", "Wizard"],
     "ritual": false
   },
   {
     "name": "Sleet Storm",
     "level": 3,
-    "school": "Evocazione",
+    "school": "Conjuration",
     "spell_list": ["Druid", "Wizard", "Sorcerer"],
     "ritual": false
   },
   {
     "name": "Slow",
     "level": 3,
-    "school": "Trasmutazione",
+    "school": "Transmutation",
     "spell_list": ["Bard", "Wizard", "Sorcerer"],
     "ritual": false
   },
   {
     "name": "Speak with Dead",
     "level": 3,
-    "school": "Necromanzia",
+    "school": "Necromancy",
     "spell_list": ["Bard", "Cleric"],
     "ritual": false
   },
   {
     "name": "Speak with Plants",
     "level": 3,
-    "school": "Trasmutazione",
+    "school": "Transmutation",
     "spell_list": ["Bard", "Druid", "Ranger"],
     "ritual": false
   },
   {
     "name": "Spirit Guardians",
     "level": 3,
-    "school": "Evocazione",
+    "school": "Conjuration",
     "spell_list": ["Cleric"],
     "ritual": false
   },
   {
     "name": "Spirit Shroud",
     "level": 3,
-    "school": "Necromanzia",
+    "school": "Necromancy",
     "spell_list": ["Cleric", "Wizard", "Paladin", "Warlock"],
     "ritual": false
   },
   {
     "name": "Stinking Cloud",
     "level": 3,
-    "school": "Evocazione",
+    "school": "Conjuration",
     "spell_list": ["Bard", "Wizard", "Sorcerer"],
     "ritual": false
   },
   {
     "name": "Summon Fey",
     "level": 3,
-    "school": "Evocazione",
+    "school": "Conjuration",
     "spell_list": ["Druid", "Wizard", "Ranger", "Warlock"],
     "ritual": false
   },
   {
     "name": "Summon Lesser Demons",
     "level": 3,
-    "school": "Evocazione",
+    "school": "Conjuration",
     "spell_list": ["Wizard", "Warlock"],
     "ritual": false
   },
   {
     "name": "Summon Shadowspawn",
     "level": 3,
-    "school": "Evocazione",
+    "school": "Conjuration",
     "spell_list": ["Wizard", "Warlock"],
     "ritual": false
   },
   {
     "name": "Summon Undead",
     "level": 3,
-    "school": "Evocazione",
+    "school": "Conjuration",
     "spell_list": ["Wizard", "Warlock"],
     "ritual": false
   },
   {
     "name": "Thunder Step",
     "level": 3,
-    "school": "Evocazione",
+    "school": "Conjuration",
     "spell_list": ["Wizard", "Sorcerer", "Warlock"],
     "ritual": false
   },
   {
     "name": "Tidal Wave",
     "level": 3,
-    "school": "Evocazione",
+    "school": "Conjuration",
     "spell_list": ["Druid", "Wizard", "Sorcerer"],
     "ritual": false
   },
   {
     "name": "Tiny Hut",
     "level": 3,
-    "school": "Invocazione",
+    "school": "Evocation",
     "spell_list": ["Wizard"],
     "ritual": true
   },
   {
     "name": "Tongues",
     "level": 3,
-    "school": "Divinazione",
+    "school": "Divination",
     "spell_list": ["Bard", "Cleric", "Wizard", "Sorcerer", "Warlock"],
     "ritual": false
   },
   {
     "name": "Vampiric Touch",
     "level": 3,
-    "school": "Necromanzia",
+    "school": "Necromancy",
     "spell_list": ["Wizard", "Sorcerer", "Warlock"],
     "ritual": false
   },
   {
     "name": "Water Breathing",
     "level": 3,
-    "school": "Trasmutazione",
+    "school": "Transmutation",
     "spell_list": ["Arteficer", "Druid", "Wizard", "Ranger", "Sorcerer"],
     "ritual": true
   },
   {
     "name": "Water Walk",
     "level": 3,
-    "school": "Trasmutazione",
+    "school": "Transmutation",
     "spell_list": ["Arteficer", "Cleric", "Druid", "Ranger", "Sorcerer"],
     "ritual": true
   },
   {
     "name": "Wind Wall",
     "level": 3,
-    "school": "Invocazione",
+    "school": "Evocation",
     "spell_list": ["Druid", "Ranger"],
     "ritual": false
   },
   {
     "name": "Arcane Eye",
     "level": 4,
-    "school": "Divinazione",
+    "school": "Divination",
     "spell_list": ["Arteficer", "Wizard"],
     "ritual": false
   },
   {
     "name": "Aura of Life",
     "level": 4,
-    "school": "Abiurazione",
+    "school": "Abjuration",
     "spell_list": ["Cleric", "Paladin"],
     "ritual": false
   },
   {
     "name": "Aura of Purity",
     "level": 4,
-    "school": "Abiurazione",
+    "school": "Abjuration",
     "spell_list": ["Cleric", "Paladin"],
     "ritual": false
   },
   {
     "name": "Banishment",
     "level": 4,
-    "school": "Abiurazione",
+    "school": "Abjuration",
     "spell_list": ["Cleric", "Wizard", "Paladin", "Sorcerer", "Warlock"],
     "ritual": false
   },
   {
     "name": "Black Tentacles",
     "level": 4,
-    "school": "Evocazione",
+    "school": "Conjuration",
     "spell_list": ["Wizard"],
     "ritual": false
   },
   {
     "name": "Blight",
     "level": 4,
-    "school": "Necromanzia",
+    "school": "Necromancy",
     "spell_list": ["Druid", "Wizard", "Warlock"],
     "ritual": false
   },
   {
     "name": "Charm Monster",
     "level": 4,
-    "school": "Ammaliamento",
+    "school": "Enchantment",
     "spell_list": ["Bard", "Druid", "Wizard", "Sorcerer", "Warlock"],
     "ritual": false
   },
   {
     "name": "Compulsion",
     "level": 4,
-    "school": "Ammaliamento",
+    "school": "Enchantment",
     "spell_list": ["Bard"],
     "ritual": false
   },
   {
     "name": "Confusion",
     "level": 4,
-    "school": "Ammaliamento",
+    "school": "Enchantment",
     "spell_list": ["Bard", "Wizard", "Sorcerer"],
     "ritual": false
   },
   {
     "name": "Conjure Minor Elementals",
     "level": 4,
-    "school": "Evocazione",
+    "school": "Conjuration",
     "spell_list": ["Druid", "Wizard"],
     "ritual": false
   },
   {
     "name": "Conjure Woodland Beings",
     "level": 4,
-    "school": "Evocazione",
+    "school": "Conjuration",
     "spell_list": ["Druid", "Ranger"],
     "ritual": false
   },
   {
     "name": "Control Water",
     "level": 4,
-    "school": "Trasmutazione",
+    "school": "Transmutation",
     "spell_list": ["Cleric", "Druid", "Wizard"],
     "ritual": false
   },
   {
     "name": "Death Ward",
     "level": 4,
-    "school": "Abiurazione",
+    "school": "Abjuration",
     "spell_list": ["Cleric", "Paladin"],
     "ritual": false
   },
   {
     "name": "Dimension Door",
     "level": 4,
-    "school": "Evocazione",
+    "school": "Conjuration",
     "spell_list": ["Bard", "Wizard", "Sorcerer", "Warlock"],
     "ritual": false
   },
   {
     "name": "Divination",
     "level": 4,
-    "school": "Divinazione",
+    "school": "Divination",
     "spell_list": ["Cleric", "Druid", "Wizard"],
     "ritual": true
   },
   {
     "name": "Dominate Beast",
     "level": 4,
-    "school": "Ammaliamento",
+    "school": "Enchantment",
     "spell_list": ["Druid", "Ranger", "Sorcerer"],
     "ritual": false
   },
   {
     "name": "Elemental Bane",
     "level": 4,
-    "school": "Trasmutazione",
+    "school": "Transmutation",
     "spell_list": ["Arteficer", "Druid", "Wizard", "Warlock"],
     "ritual": false
   },
   {
     "name": "Fabricate",
     "level": 4,
-    "school": "Trasmutazione",
+    "school": "Transmutation",
     "spell_list": ["Arteficer", "Wizard"],
     "ritual": false
   },
   {
     "name": "Faithful Hound",
     "level": 4,
-    "school": "Evocazione",
+    "school": "Conjuration",
     "spell_list": ["Arteficer", "Wizard"],
     "ritual": false
   },
   {
     "name": "Find Greater Steed",
     "level": 4,
-    "school": "Evocazione",
+    "school": "Conjuration",
     "spell_list": ["Paladin"],
     "ritual": false
   },
   {
     "name": "Fire Shield",
     "level": 4,
-    "school": "Invocazione",
+    "school": "Evocation",
     "spell_list": ["Druid", "Wizard", "Sorcerer"],
     "ritual": false
   },
   {
     "name": "Freedom of Movement",
     "level": 4,
-    "school": "Abiurazione",
+    "school": "Abjuration",
     "spell_list": ["Arteficer", "Bard", "Cleric", "Druid", "Ranger"],
     "ritual": false
   },
   {
     "name": "Giant Insect",
     "level": 4,
-    "school": "Trasmutazione",
+    "school": "Transmutation",
     "spell_list": ["Druid"],
     "ritual": false
   },
   {
     "name": "Grasping Vine",
     "level": 4,
-    "school": "Evocazione",
+    "school": "Conjuration",
     "spell_list": ["Druid", "Ranger"],
     "ritual": false
   },
   {
     "name": "Greater Invisibility",
     "level": 4,
-    "school": "Illusione",
+    "school": "Illusion",
     "spell_list": ["Bard", "Wizard", "Sorcerer"],
     "ritual": false
   },
   {
     "name": "Guardian of Faith",
     "level": 4,
-    "school": "Evocazione",
+    "school": "Conjuration",
     "spell_list": ["Cleric"],
     "ritual": false
   },
   {
     "name": "Guardian of Nature",
     "level": 4,
-    "school": "Trasmutazione",
+    "school": "Transmutation",
     "spell_list": ["Druid", "Ranger"],
     "ritual": false
   },
   {
     "name": "Hallucinatory Terrain",
     "level": 4,
-    "school": "Illusione",
+    "school": "Illusion",
     "spell_list": ["Bard", "Druid", "Wizard", "Warlock"],
     "ritual": false
   },
   {
     "name": "Ice Storm",
     "level": 4,
-    "school": "Invocazione",
+    "school": "Evocation",
     "spell_list": ["Druid", "Sorcerer"],
     "ritual": false
   },
   {
     "name": "Locate Creature",
     "level": 4,
-    "school": "Divinazione",
+    "school": "Divination",
     "spell_list": ["Bard", "Cleric", "Druid", "Wizard", "Ranger"],
     "ritual": false
   },
   {
     "name": "Phantasmal Killer",
     "level": 4,
-    "school": "Illusione",
+    "school": "Illusion",
     "spell_list": ["Bard", "Wizard"],
     "ritual": false
   },
   {
     "name": "Polymorph",
     "level": 4,
-    "school": "Trasmutazione",
+    "school": "Transmutation",
     "spell_list": ["Bard", "Wizard", "Paladin", "Sorcerer"],
     "ritual": false
   },
   {
     "name": "Private Sanctum",
     "level": 4,
-    "school": "Evocazione",
+    "school": "Conjuration",
     "spell_list": ["Arteficer", "Wizard"],
     "ritual": false
   },
   {
     "name": "Psychic Lance",
     "level": 4,
-    "school": "Abiurazione",
+    "school": "Abjuration",
     "spell_list": ["Bard", "Wizard", "Sorcerer", "Warlock"],
     "ritual": false
   },
   {
     "name": "Resilient Sphere",
     "level": 4,
-    "school": "Invocazione",
+    "school": "Evocation",
     "spell_list": ["Arteficer", "Wizard"],
     "ritual": false
   },
   {
     "name": "Secret Chest",
     "level": 4,
-    "school": "Evocazione",
+    "school": "Conjuration",
     "spell_list": ["Arteficer", "Wizard"],
     "ritual": false
   },
   {
     "name": "Shadow of Moil",
     "level": 4,
-    "school": "Necromanzia",
+    "school": "Necromancy",
     "spell_list": ["Warlock"],
     "ritual": false
   },
   {
     "name": "Sickening Radiance",
     "level": 4,
-    "school": "Invocazione",
+    "school": "Evocation",
     "spell_list": ["Wizard", "Sorcerer", "Warlock"],
     "ritual": false
   },
   {
     "name": "Spirit of Death",
     "level": 4,
-    "school": "Necromanzia",
+    "school": "Necromancy",
     "spell_list": ["Wizard", "Sorcerer", "Warlock"],
     "ritual": false
   },
   {
     "name": "Staggering Smite",
     "level": 4,
-    "school": "Invocazione",
+    "school": "Evocation",
     "spell_list": ["Paladin"],
     "ritual": false
   },
   {
     "name": "Stone Shape",
     "level": 4,
-    "school": "Trasmutazione",
+    "school": "Transmutation",
     "spell_list": ["Arteficer", "Cleric", "Druid", "Wizard", "Sorcerer"],
     "ritual": false
   },
   {
     "name": "Stoneskin",
     "level": 4,
-    "school": "Abiurazione",
+    "school": "Abjuration",
     "spell_list": ["Arteficer", "Druid", "Wizard", "Ranger", "Sorcerer"],
     "ritual": false
   },
   {
     "name": "Storm Sphere",
     "level": 4,
-    "school": "Invocazione",
+    "school": "Evocation",
     "spell_list": ["Sorcerer"],
     "ritual": false
   },
   {
     "name": "Summon Aberration",
     "level": 4,
-    "school": "Evocazione",
+    "school": "Conjuration",
     "spell_list": ["Wizard", "Warlock"],
     "ritual": false
   },
   {
     "name": "Summon Construct",
     "level": 4,
-    "school": "Evocazione",
+    "school": "Conjuration",
     "spell_list": ["Arteficer", "Wizard"],
     "ritual": false
   },
   {
     "name": "Summon Elemental",
     "level": 4,
-    "school": "Evocazione",
+    "school": "Conjuration",
     "spell_list": ["Druid", "Wizard", "Ranger"],
     "ritual": false
   },
   {
     "name": "Summon Greater Demon",
     "level": 4,
-    "school": "Evocazione",
+    "school": "Conjuration",
     "spell_list": ["Wizard", "Warlock"],
     "ritual": false
   },
   {
     "name": "Vitriolic Sphere",
     "level": 4,
-    "school": "Invocazione",
+    "school": "Evocation",
     "spell_list": ["Wizard", "Sorcerer"],
     "ritual": false
   },
   {
     "name": "Wall of Fire",
     "level": 4,
-    "school": "Invocazione",
+    "school": "Evocation",
     "spell_list": ["Druid", "Wizard", "Sorcerer"],
     "ritual": false
   },
   {
     "name": "Watery Sphere",
     "level": 4,
-    "school": "Evocazione",
+    "school": "Conjuration",
     "spell_list": ["Druid", "Wizard", "Sorcerer"],
     "ritual": false
   },
   {
     "name": "Animate Objects",
     "level": 5,
-    "school": "Trasmutazione",
+    "school": "Transmutation",
     "spell_list": ["Arteficer", "Bard", "Wizard", "Sorcerer"],
     "ritual": false
   },
   {
     "name": "Antilife Shell",
     "level": 5,
-    "school": "Abiurazione",
+    "school": "Abjuration",
     "spell_list": ["Druid"],
     "ritual": false
   },
   {
     "name": "Arcane Hand",
     "level": 5,
-    "school": "Invocazione",
+    "school": "Evocation",
     "spell_list": ["Arteficer", "Wizard", "Sorcerer"],
     "ritual": false
   },
   {
     "name": "Awaken",
     "level": 5,
-    "school": "Trasmutazione",
+    "school": "Transmutation",
     "spell_list": ["Bard", "Druid"],
     "ritual": false
   },
   {
     "name": "Banishing Smite",
     "level": 5,
-    "school": "Abiurazione",
+    "school": "Abjuration",
     "spell_list": ["Paladin"],
     "ritual": false
   },
   {
     "name": "Circle of Power",
     "level": 5,
-    "school": "Abiurazione",
+    "school": "Abjuration",
     "spell_list": ["Paladin"],
     "ritual": false
   },
   {
     "name": "Cloudkill",
     "level": 5,
-    "school": "Evocazione",
+    "school": "Conjuration",
     "spell_list": ["Wizard"],
     "ritual": false
   },
   {
     "name": "Commune",
     "level": 5,
-    "school": "Divinazione",
+    "school": "Divination",
     "spell_list": ["Cleric"],
     "ritual": true
   },
   {
     "name": "Commune with Nature",
     "level": 5,
-    "school": "Divinazione",
+    "school": "Divination",
     "spell_list": ["Druid", "Ranger"],
     "ritual": true
   },
   {
     "name": "Cone of Cold",
     "level": 5,
-    "school": "Invocazione",
+    "school": "Evocation",
     "spell_list": ["Druid", "Wizard", "Sorcerer"],
     "ritual": false
   },
   {
     "name": "Conjure Elemental",
     "level": 5,
-    "school": "Evocazione",
+    "school": "Conjuration",
     "spell_list": ["Druid", "Wizard"],
     "ritual": false
   },
   {
     "name": "Conjure Volley",
     "level": 5,
-    "school": "Evocazione",
+    "school": "Conjuration",
     "spell_list": ["Ranger"],
     "ritual": false
   },
   {
     "name": "Contact Other Plane",
     "level": 5,
-    "school": "Divinazione",
+    "school": "Divination",
     "spell_list": ["Wizard", "Warlock"],
     "ritual": true
   },
   {
     "name": "Contagion",
     "level": 5,
-    "school": "Necromanzia",
+    "school": "Necromancy",
     "spell_list": ["Cleric", "Druid"],
     "ritual": false
   },
   {
     "name": "Control Winds",
     "level": 5,
-    "school": "Trasmutazione",
+    "school": "Transmutation",
     "spell_list": ["Druid", "Wizard", "Sorcerer"],
     "ritual": false
   },
   {
     "name": "Creation",
     "level": 5,
-    "school": "Illusione",
+    "school": "Illusion",
     "spell_list": ["Arteficer", "Wizard", "Sorcerer"],
     "ritual": false
   },
   {
     "name": "Danse Macabre",
     "level": 5,
-    "school": "Necromanzia",
+    "school": "Necromancy",
     "spell_list": ["Warlock"],
     "ritual": false
   },
   {
     "name": "Dawn",
     "level": 5,
-    "school": "Invocazione",
+    "school": "Evocation",
     "spell_list": ["Cleric", "Wizard"],
     "ritual": false
   },
   {
     "name": "Destructive Wave",
     "level": 5,
-    "school": "Invocazione",
+    "school": "Evocation",
     "spell_list": ["Paladin"],
     "ritual": false
   },
   {
     "name": "Dispel Evil and Good",
     "level": 5,
-    "school": "Abiurazione",
+    "school": "Abjuration",
     "spell_list": ["Cleric", "Paladin"],
     "ritual": false
   },
@@ -2187,1008 +2187,1008 @@
   {
     "name": "Dominate Person",
     "level": 5,
-    "school": "Ammaliamento",
+    "school": "Enchantment",
     "spell_list": ["Bard", "Wizard", "Sorcerer"],
     "ritual": false
   },
   {
     "name": "Dream",
     "level": 5,
-    "school": "Illusione",
+    "school": "Illusion",
     "spell_list": ["Bard", "Wizard", "Warlock"],
     "ritual": false
   },
   {
     "name": "Enervation",
     "level": 5,
-    "school": "Necromanzia",
+    "school": "Necromancy",
     "spell_list": ["Wizard", "Sorcerer", "Warlock"],
     "ritual": false
   },
   {
     "name": "Far Step",
     "level": 5,
-    "school": "Evocazione",
+    "school": "Conjuration",
     "spell_list": ["Wizard", "Sorcerer", "Warlock"],
     "ritual": false
   },
   {
     "name": "Flame Strike",
     "level": 5,
-    "school": "Invocazione",
+    "school": "Evocation",
     "spell_list": ["Cleric"],
     "ritual": false
   },
   {
     "name": "Geas",
     "level": 5,
-    "school": "Ammaliamento",
+    "school": "Enchantment",
     "spell_list": ["Bard", "Cleric", "Druid", "Wizard"],
     "ritual": false
   },
   {
     "name": "Greater Restoration",
     "level": 5,
-    "school": "Abiurazione",
+    "school": "Abjuration",
     "spell_list": ["Arteficer", "Bard", "Cleric", "Druid", "Ranger"],
     "ritual": false
   },
   {
     "name": "Hallow",
     "level": 5,
-    "school": "Invocazione",
+    "school": "Evocation",
     "spell_list": ["Cleric"],
     "ritual": false
   },
   {
     "name": "Hold Monster",
     "level": 5,
-    "school": "Ammaliamento",
+    "school": "Enchantment",
     "spell_list": ["Bard", "Wizard", "Sorcerer", "Warlock"],
     "ritual": false
   },
   {
     "name": "Holy Weapon",
     "level": 5,
-    "school": "Invocazione",
+    "school": "Evocation",
     "spell_list": ["Cleric", "Paladin"],
     "ritual": false
   },
   {
     "name": "Immolation",
     "level": 5,
-    "school": "Invocazione",
+    "school": "Evocation",
     "spell_list": ["Wizard", "Sorcerer"],
     "ritual": false
   },
   {
     "name": "Infernal Calling",
     "level": 5,
-    "school": "Evocazione",
+    "school": "Conjuration",
     "spell_list": ["Wizard", "Warlock"],
     "ritual": false
   },
   {
     "name": "Insect Plague",
     "level": 5,
-    "school": "Evocazione",
+    "school": "Conjuration",
     "spell_list": ["Cleric", "Druid", "Sorcerer"],
     "ritual": false
   },
   {
     "name": "Legend Lore",
     "level": 5,
-    "school": "Divinazione",
+    "school": "Divination",
     "spell_list": ["Bard", "Cleric", "Wizard"],
     "ritual": false
   },
   {
     "name": "Maelstrom",
     "level": 5,
-    "school": "Invocazione",
+    "school": "Evocation",
     "spell_list": ["Druid"],
     "ritual": false
   },
   {
     "name": "Mass Cure Wounds",
     "level": 5,
-    "school": "Invocazione",
+    "school": "Evocation",
     "spell_list": ["Bard", "Cleric", "Druid"],
     "ritual": false
   },
   {
     "name": "Mislead",
     "level": 5,
-    "school": "Illusione",
+    "school": "Illusion",
     "spell_list": ["Bard", "Wizard", "Warlock"],
     "ritual": false
   },
   {
     "name": "Modify Memory",
     "level": 5,
-    "school": "Ammaliamento",
+    "school": "Enchantment",
     "spell_list": ["Bard", "Wizard"],
     "ritual": false
   },
   {
     "name": "Negative Energy Flood",
     "level": 5,
-    "school": "Necromanzia",
+    "school": "Necromancy",
     "spell_list": ["Wizard", "Warlock"],
     "ritual": false
   },
   {
     "name": "Passwall",
     "level": 5,
-    "school": "Trasmutazione",
+    "school": "Transmutation",
     "spell_list": ["Wizard"],
     "ritual": false
   },
   {
     "name": "Planar Binding",
     "level": 5,
-    "school": "Abiurazione",
+    "school": "Abjuration",
     "spell_list": ["Bard", "Cleric", "Druid", "Wizard", "Warlock"],
     "ritual": false
   },
   {
     "name": "Raise Dead",
     "level": 5,
-    "school": "Necromanzia",
+    "school": "Necromancy",
     "spell_list": ["Bard", "Cleric", "Paladin"],
     "ritual": false
   },
   {
     "name": "Rary's Telepathic Bond",
     "level": 5,
-    "school": "Divinazione",
+    "school": "Divination",
     "spell_list": ["Bard", "Wizard"],
     "ritual": true
   },
   {
     "name": "Reincarnate",
     "level": 5,
-    "school": "Trasmutazione",
+    "school": "Transmutation",
     "spell_list": ["Druid"],
     "ritual": false
   },
   {
     "name": "Scrying",
     "level": 5,
-    "school": "Divinazione",
+    "school": "Divination",
     "spell_list": ["Bard", "Cleric", "Wizard", "Warlock"],
     "ritual": false
   },
   {
     "name": "Seeming",
     "level": 5,
-    "school": "Illusione",
+    "school": "Illusion",
     "spell_list": ["Bard", "Wizard", "Sorcerer"],
     "ritual": false
   },
   {
     "name": "Skill Empowerment",
     "level": 5,
-    "school": "Trasmutazione",
+    "school": "Transmutation",
     "spell_list": ["Arteficer", "Bard", "Wizard", "Sorcerer"],
     "ritual": false
   },
   {
     "name": "Steel Wind Strike",
     "level": 5,
-    "school": "Evocazione",
+    "school": "Conjuration",
     "spell_list": ["Wizard", "Ranger"],
     "ritual": false
   },
   {
     "name": "Summon Celestial",
     "level": 5,
-    "school": "Evocazione",
+    "school": "Conjuration",
     "spell_list": ["Cleric", "Paladin"],
     "ritual": false
   },
   {
     "name": "Summon Draconic Spirit",
     "level": 5,
-    "school": "Evocazione",
+    "school": "Conjuration",
     "spell_list": ["Druid", "Wizard", "Sorcerer"],
     "ritual": false
   },
   {
     "name": "Swift Quiver",
     "level": 5,
-    "school": "Trasmutazione",
+    "school": "Transmutation",
     "spell_list": ["Ranger"],
     "ritual": false
   },
   {
     "name": "Synaptic Static",
     "level": 5,
-    "school": "Ammaliamento",
+    "school": "Enchantment",
     "spell_list": ["Bard", "Wizard", "Sorcerer", "Warlock"],
     "ritual": false
   },
   {
     "name": "Telekinesis",
     "level": 5,
-    "school": "Trasmutazione",
+    "school": "Transmutation",
     "spell_list": ["Wizard", "Sorcerer"],
     "ritual": false
   },
   {
     "name": "Teleportation Circle",
     "level": 5,
-    "school": "Evocazione",
+    "school": "Conjuration",
     "spell_list": ["Bard", "Wizard", "Sorcerer", "Warlock"],
     "ritual": false
   },
   {
     "name": "Temporal Shunt",
     "level": 5,
-    "school": "Trasmutazione",
+    "school": "Transmutation",
     "spell_list": ["Wizard"],
     "ritual": false
   },
   {
     "name": "Arcane Gate",
     "level": 6,
-    "school": "Evocazione",
+    "school": "Conjuration",
     "spell_list": ["Wizard", "Sorcerer", "Warlock"],
     "ritual": false
   },
   {
     "name": "Arcane Transformation",
     "level": 6,
-    "school": "Trasmutazione",
+    "school": "Transmutation",
     "spell_list": ["Wizard"],
     "ritual": false
   },
   {
     "name": "Blade Barrier",
     "level": 6,
-    "school": "Invocazione",
+    "school": "Evocation",
     "spell_list": ["Cleric"],
     "ritual": false
   },
   {
     "name": "Bones of the Earth",
     "level": 6,
-    "school": "Trasmutazione",
+    "school": "Transmutation",
     "spell_list": ["Druid"],
     "ritual": false
   },
   {
     "name": "Chain Lightning",
     "level": 6,
-    "school": "Invocazione",
+    "school": "Evocation",
     "spell_list": ["Wizard", "Sorcerer"],
     "ritual": false
   },
   {
     "name": "Circle of Death",
     "level": 6,
-    "school": "Necromanzia",
+    "school": "Necromancy",
     "spell_list": ["Wizard", "Sorcerer", "Warlock"],
     "ritual": false
   },
   {
     "name": "Conjure Fey",
     "level": 6,
-    "school": "Evocazione",
+    "school": "Conjuration",
     "spell_list": ["Druid", "Warlock"],
     "ritual": false
   },
   {
     "name": "Contingency",
     "level": 6,
-    "school": "Invocazione",
+    "school": "Evocation",
     "spell_list": ["Wizard"],
     "ritual": false
   },
   {
     "name": "Create Homunculus",
     "level": 6,
-    "school": "Invocazione",
+    "school": "Evocation",
     "spell_list": ["Wizard"],
     "ritual": false
   },
   {
     "name": "Create Undead",
     "level": 6,
-    "school": "Necromanzia",
+    "school": "Necromancy",
     "spell_list": ["Cleric", "Wizard", "Warlock"],
     "ritual": false
   },
   {
     "name": "Disintegrate",
     "level": 6,
-    "school": "Trasmutazione",
+    "school": "Transmutation",
     "spell_list": ["Wizard", "Sorcerer"],
     "ritual": false
   },
   {
     "name": "Druid Grove",
     "level": 6,
-    "school": "Abiurazione",
+    "school": "Abjuration",
     "spell_list": ["Druid"],
     "ritual": false
   },
   {
     "name": "Eyebite",
     "level": 6,
-    "school": "Necromanzia",
+    "school": "Necromancy",
     "spell_list": ["Bard", "Wizard", "Sorcerer", "Warlock"],
     "ritual": false
   },
   {
     "name": "Find the Path",
     "level": 6,
-    "school": "Divinazione",
+    "school": "Divination",
     "spell_list": ["Bard", "Cleric", "Druid"],
     "ritual": false
   },
   {
     "name": "Flesh to Stone",
     "level": 6,
-    "school": "Trasmutazione",
+    "school": "Transmutation",
     "spell_list": ["Druid", "Wizard", "Sorcerer", "Warlock"],
     "ritual": false
   },
   {
     "name": "Forbiddance",
     "level": 6,
-    "school": "Abiurazione",
+    "school": "Abjuration",
     "spell_list": ["Cleric"],
     "ritual": true
   },
   {
     "name": "Freezing Sphere",
     "level": 6,
-    "school": "Invocazione",
+    "school": "Evocation",
     "spell_list": ["Wizard", "Sorcerer"],
     "ritual": false
   },
   {
     "name": "Globe of Invulnerability",
     "level": 6,
-    "school": "Abiurazione",
+    "school": "Abjuration",
     "spell_list": ["Wizard", "Sorcerer"],
     "ritual": false
   },
   {
     "name": "Gravity Fissure",
     "level": 6,
-    "school": "Invocazione",
+    "school": "Evocation",
     "spell_list": ["Wizard"],
     "ritual": false
   },
   {
     "name": "Guards and Wards",
     "level": 6,
-    "school": "Abiurazione",
+    "school": "Abjuration",
     "spell_list": ["Bard", "Wizard"],
     "ritual": false
   },
   {
     "name": "Harm",
     "level": 6,
-    "school": "Necromanzia",
+    "school": "Necromancy",
     "spell_list": ["Cleric"],
     "ritual": false
   },
   {
     "name": "Heal",
     "level": 6,
-    "school": "Invocazione",
+    "school": "Evocation",
     "spell_list": ["Cleric", "Druid"],
     "ritual": false
   },
   {
     "name": "Heroes' Feast",
     "level": 6,
-    "school": "Evocazione",
+    "school": "Conjuration",
     "spell_list": ["Bard", "Cleric", "Druid"],
     "ritual": false
   },
   {
     "name": "Instant Summons",
     "level": 6,
-    "school": "Evocazione",
+    "school": "Conjuration",
     "spell_list": ["Wizard"],
     "ritual": true
   },
   {
     "name": "Investiture of Flame",
     "level": 6,
-    "school": "Trasmutazione",
+    "school": "Transmutation",
     "spell_list": ["Druid", "Wizard", "Sorcerer", "Warlock"],
     "ritual": false
   },
   {
     "name": "Investiture of Ice",
     "level": 6,
-    "school": "Trasmutazione",
+    "school": "Transmutation",
     "spell_list": ["Druid", "Wizard", "Sorcerer", "Warlock"],
     "ritual": false
   },
   {
     "name": "Investiture of Stone",
     "level": 6,
-    "school": "Trasmutazione",
+    "school": "Transmutation",
     "spell_list": ["Druid", "Wizard", "Sorcerer", "Warlock"],
     "ritual": false
   },
   {
     "name": "Investiture of Wind",
     "level": 6,
-    "school": "Trasmutazione",
+    "school": "Transmutation",
     "spell_list": ["Druid", "Wizard", "Sorcerer", "Warlock"],
     "ritual": false
   },
   {
     "name": "Irresistible Dance",
     "level": 6,
-    "school": "Ammaliamento",
+    "school": "Enchantment",
     "spell_list": ["Bard", "Wizard"],
     "ritual": false
   },
   {
     "name": "Magic Jar",
     "level": 6,
-    "school": "Necromanzia",
+    "school": "Necromancy",
     "spell_list": ["Wizard"],
     "ritual": false
   },
   {
     "name": "Mass Suggestion",
     "level": 6,
-    "school": "Ammaliamento",
+    "school": "Enchantment",
     "spell_list": ["Bard", "Wizard", "Sorcerer", "Warlock"],
     "ritual": false
   },
   {
     "name": "Mental Prison",
     "level": 6,
-    "school": "Illusione",
+    "school": "Illusion",
     "spell_list": ["Wizard", "Sorcerer", "Warlock"],
     "ritual": false
   },
   {
     "name": "Move Earth",
     "level": 6,
-    "school": "Trasmutazione",
+    "school": "Transmutation",
     "spell_list": ["Druid", "Wizard", "Sorcerer"],
     "ritual": false
   },
   {
     "name": "Otherworldly Guise",
     "level": 6,
-    "school": "Trasmutazione",
+    "school": "Transmutation",
     "spell_list": ["Wizard", "Sorcerer", "Warlock"],
     "ritual": false
   },
   {
     "name": "Planar Ally",
     "level": 6,
-    "school": "Evocazione",
+    "school": "Conjuration",
     "spell_list": ["Cleric"],
     "ritual": false
   },
   {
     "name": "Platinum Shield",
     "level": 6,
-    "school": "Abiurazione",
+    "school": "Abjuration",
     "spell_list": ["Wizard", "Sorcerer"],
     "ritual": false
   },
   {
     "name": "Arcane Sword",
     "level": 7,
-    "school": "Invocazione",
+    "school": "Evocation",
     "spell_list": ["Bard", "Wizard"],
     "ritual": false
   },
   {
     "name": "Conjure Celestial",
     "level": 7,
-    "school": "Evocazione",
+    "school": "Conjuration",
     "spell_list": ["Cleric"],
     "ritual": false
   },
   {
     "name": "Crown of Stars",
     "level": 7,
-    "school": "Invocazione",
+    "school": "Evocation",
     "spell_list": ["Wizard", "Sorcerer", "Warlock"],
     "ritual": false
   },
   {
     "name": "Delayed Blast Fireball",
     "level": 7,
-    "school": "Invocazione",
+    "school": "Evocation",
     "spell_list": ["Wizard", "Sorcerer"],
     "ritual": false
   },
   {
     "name": "Divine Word",
     "level": 7,
-    "school": "Invocazione",
+    "school": "Evocation",
     "spell_list": ["Cleric", "Wizard"],
     "ritual": false
   },
   {
     "name": "Draconic Transformation",
     "level": 7,
-    "school": "Trasmutazione",
+    "school": "Transmutation",
     "spell_list": ["Druid", "Wizard", "Sorcerer"],
     "ritual": false
   },
   {
     "name": "Dream of the Blue Veil",
     "level": 7,
-    "school": "Evocazione",
+    "school": "Conjuration",
     "spell_list": ["Bard", "Wizard", "Sorcerer", "Warlock"],
     "ritual": false
   },
   {
     "name": "Etherealness",
     "level": 7,
-    "school": "Trasmutazione",
+    "school": "Transmutation",
     "spell_list": ["Bard", "Wizard", "Sorcerer", "Warlock"],
     "ritual": false
   },
   {
     "name": "Finger of Death",
     "level": 7,
-    "school": "Necromanzia",
+    "school": "Necromancy",
     "spell_list": ["Wizard", "Sorcerer", "Warlock"],
     "ritual": false
   },
   {
     "name": "Fire Storm",
     "level": 7,
-    "school": "Invocazione",
+    "school": "Evocation",
     "spell_list": ["Cleric", "Druid", "Sorcerer"],
     "ritual": false
   },
   {
     "name": "Forcecage",
     "level": 7,
-    "school": "Invocazione",
+    "school": "Evocation",
     "spell_list": ["Bard", "Wizard", "Warlock"],
     "ritual": false
   },
   {
     "name": "Magnificent Mansion",
     "level": 7,
-    "school": "Evocazione",
+    "school": "Conjuration",
     "spell_list": ["Bard", "Wizard"],
     "ritual": false
   },
   {
     "name": "Mirage Arcane",
     "level": 7,
-    "school": "Illusione",
+    "school": "Illusion",
     "spell_list": ["Druid", "Wizard"],
     "ritual": false
   },
   {
     "name": "Plane Shift",
     "level": 7,
-    "school": "Evocazione",
+    "school": "Conjuration",
     "spell_list": ["Cleric", "Wizard", "Sorcerer", "Warlock"],
     "ritual": false
   },
   {
     "name": "Power Word Pain",
     "level": 7,
-    "school": "Ammaliamento",
+    "school": "Enchantment",
     "spell_list": ["Wizard", "Sorcerer", "Warlock"],
     "ritual": false
   },
   {
     "name": "Prismatic Spray",
     "level": 7,
-    "school": "Invocazione",
+    "school": "Evocation",
     "spell_list": ["Bard", "Wizard", "Sorcerer"],
     "ritual": false
   },
   {
     "name": "Project Image",
     "level": 7,
-    "school": "Illusione",
+    "school": "Illusion",
     "spell_list": ["Bard", "Wizard"],
     "ritual": false
   },
   {
     "name": "Regenerate",
     "level": 7,
-    "school": "Trasmutazione",
+    "school": "Transmutation",
     "spell_list": ["Bard", "Cleric", "Druid"],
     "ritual": false
   },
   {
     "name": "Resurrection",
     "level": 7,
-    "school": "Necromanzia",
+    "school": "Necromancy",
     "spell_list": ["Bard", "Cleric"],
     "ritual": false
   },
   {
     "name": "Reverse Gravity",
     "level": 7,
-    "school": "Trasmutazione",
+    "school": "Transmutation",
     "spell_list": ["Druid", "Wizard", "Sorcerer"],
     "ritual": false
   },
   {
     "name": "Sequester",
     "level": 7,
-    "school": "Trasmutazione",
+    "school": "Transmutation",
     "spell_list": ["Wizard"],
     "ritual": false
   },
   {
     "name": "Simulacrum",
     "level": 7,
-    "school": "Illusione",
+    "school": "Illusion",
     "spell_list": ["Wizard"],
     "ritual": false
   },
   {
     "name": "Symbol",
     "level": 7,
-    "school": "Abiurazione",
+    "school": "Abjuration",
     "spell_list": ["Bard", "Cleric", "Druid", "Wizard"],
     "ritual": false
   },
   {
     "name": "Teleport",
     "level": 7,
-    "school": "Evocazione",
+    "school": "Conjuration",
     "spell_list": ["Bard", "Wizard", "Sorcerer"],
     "ritual": false
   },
   {
     "name": "Temple of the Gods",
     "level": 7,
-    "school": "Evocazione",
+    "school": "Conjuration",
     "spell_list": ["Cleric"],
     "ritual": false
   },
   {
     "name": "Tether Essence",
     "level": 7,
-    "school": "Necromanzia",
+    "school": "Necromancy",
     "spell_list": ["Wizard"],
     "ritual": false
   },
   {
     "name": "Whirlwind",
     "level": 7,
-    "school": "Invocazione",
+    "school": "Evocation",
     "spell_list": ["Druid", "Wizard", "Sorcerer"],
     "ritual": false
   },
   {
     "name": "Animal Shapes",
     "level": 8,
-    "school": "Trasmutazione",
+    "school": "Transmutation",
     "spell_list": ["Druid"],
     "ritual": false
   },
   {
     "name": "Antimagic Field",
     "level": 8,
-    "school": "Abiurazione",
+    "school": "Abjuration",
     "spell_list": ["Cleric", "Wizard"],
     "ritual": false
   },
   {
     "name": "Antipathy/Sympathy",
     "level": 8,
-    "school": "Ammaliamento",
+    "school": "Enchantment",
     "spell_list": ["Bard", "Druid", "Wizard"],
     "ritual": false
   },
   {
     "name": "Clone",
     "level": 8,
-    "school": "Necromanzia",
+    "school": "Necromancy",
     "spell_list": ["Wizard"],
     "ritual": false
   },
   {
     "name": "Control Weather",
     "level": 8,
-    "school": "Trasmutazione",
+    "school": "Transmutation",
     "spell_list": ["Cleric", "Druid", "Wizard"],
     "ritual": false
   },
   {
     "name": "Dark Star",
     "level": 8,
-    "school": "Invocazione",
+    "school": "Evocation",
     "spell_list": ["Wizard"],
     "ritual": false
   },
   {
     "name": "Demiplane",
     "level": 8,
-    "school": "Evocazione",
+    "school": "Conjuration",
     "spell_list": ["Wizard", "Sorcerer", "Warlock"],
     "ritual": false
   },
   {
     "name": "Dominate Monster",
     "level": 8,
-    "school": "Ammaliamento",
+    "school": "Enchantment",
     "spell_list": ["Bard", "Wizard", "Sorcerer", "Warlock"],
     "ritual": false
   },
   {
     "name": "Earthquake",
     "level": 8,
-    "school": "Invocazione",
+    "school": "Evocation",
     "spell_list": ["Cleric", "Druid", "Sorcerer"],
     "ritual": false
   },
   {
     "name": "Feeblemind",
     "level": 8,
-    "school": "Ammaliamento",
+    "school": "Enchantment",
     "spell_list": ["Bard", "Wizard", "Warlock"],
     "ritual": false
   },
   {
     "name": "Glibness",
     "level": 8,
-    "school": "Trasmutazione",
+    "school": "Transmutation",
     "spell_list": ["Bard", "Warlock"],
     "ritual": false
   },
   {
     "name": "Holy Aura",
     "level": 8,
-    "school": "Abiurazione",
+    "school": "Abjuration",
     "spell_list": ["Cleric"],
     "ritual": false
   },
   {
     "name": "Horrid Wilting",
     "level": 8,
-    "school": "Necromanzia",
+    "school": "Necromancy",
     "spell_list": ["Wizard", "Sorcerer"],
     "ritual": false
   },
   {
     "name": "Illusory Dragon",
     "level": 8,
-    "school": "Illusione",
+    "school": "Illusion",
     "spell_list": ["Wizard"],
     "ritual": false
   },
   {
     "name": "Incendiary Cloud",
     "level": 8,
-    "school": "Evocazione",
+    "school": "Conjuration",
     "spell_list": ["Druid", "Wizard", "Sorcerer"],
     "ritual": false
   },
   {
     "name": "Maddening Darkness",
     "level": 8,
-    "school": "Invocazione",
+    "school": "Evocation",
     "spell_list": ["Wizard", "Warlock"],
     "ritual": false
   },
   {
     "name": "Maze",
     "level": 8,
-    "school": "Evocazione",
+    "school": "Conjuration",
     "spell_list": ["Wizard"],
     "ritual": false
   },
   {
     "name": "Mighty Fortress",
     "level": 8,
-    "school": "Evocazione",
+    "school": "Conjuration",
     "spell_list": ["Wizard"],
     "ritual": false
   },
   {
     "name": "Mind Blank",
     "level": 8,
-    "school": "Abiurazione",
+    "school": "Abjuration",
     "spell_list": ["Bard", "Wizard"],
     "ritual": false
   },
   {
     "name": "Power Word Stun",
     "level": 8,
-    "school": "Ammaliamento",
+    "school": "Enchantment",
     "spell_list": ["Bard", "Wizard", "Sorcerer", "Warlock"],
     "ritual": false
   },
   {
     "name": "Reality Break",
     "level": 8,
-    "school": "Evocazione",
+    "school": "Conjuration",
     "spell_list": ["Wizard"],
     "ritual": false
   },
   {
     "name": "Sunburst",
     "level": 8,
-    "school": "Invocazione",
+    "school": "Evocation",
     "spell_list": ["Cleric", "Wizard", "Sorcerer"],
     "ritual": false
   },
   {
     "name": "Telepathy",
     "level": 8,
-    "school": "Invocazione",
+    "school": "Evocation",
     "spell_list": ["Wizard"],
     "ritual": false
   },
   {
     "name": "Tsunami",
     "level": 8,
-    "school": "Evocazione",
+    "school": "Conjuration",
     "spell_list": ["Druid"],
     "ritual": false
   },
   {
     "name": "Astral Projection",
     "level": 9,
-    "school": "Necromanzia",
+    "school": "Necromancy",
     "spell_list": ["Cleric", "Wizard", "Warlock"],
     "ritual": false
   },
   {
     "name": "Blade of Disaster",
     "level": 9,
-    "school": "Evocazione",
+    "school": "Conjuration",
     "spell_list": ["Wizard", "Sorcerer", "Warlock"],
     "ritual": false
   },
   {
     "name": "Foresight",
     "level": 9,
-    "school": "Divinazione",
+    "school": "Divination",
     "spell_list": ["Bard", "Druid", "Wizard", "Warlock"],
     "ritual": false
   },
   {
     "name": "Gate",
     "level": 9,
-    "school": "Evocazione",
+    "school": "Conjuration",
     "spell_list": ["Cleric", "Wizard", "Sorcerer", "Warlock"],
     "ritual": false
   },
   {
     "name": "Imprisonment",
     "level": 9,
-    "school": "Abiurazione",
+    "school": "Abjuration",
     "spell_list": ["Wizard", "Warlock"],
     "ritual": false
   },
   {
     "name": "Invulnerability",
     "level": 9,
-    "school": "Abiurazione",
+    "school": "Abjuration",
     "spell_list": ["Wizard"],
     "ritual": false
   },
   {
     "name": "Mass Heal",
     "level": 9,
-    "school": "Evocazione",
+    "school": "Conjuration",
     "spell_list": ["Cleric"],
     "ritual": false
   },
   {
     "name": "Mass Polymorph",
     "level": 9,
-    "school": "Trasmutazione",
+    "school": "Transmutation",
     "spell_list": ["Bard", "Wizard", "Sorcerer"],
     "ritual": false
   },
   {
     "name": "Meteor Swarm",
     "level": 9,
-    "school": "Invocazione",
+    "school": "Evocation",
     "spell_list": ["Wizard", "Sorcerer"],
     "ritual": false
   },
   {
     "name": "Power Word Heal",
     "level": 9,
-    "school": "Invocazione",
+    "school": "Evocation",
     "spell_list": ["Bard", "Cleric"],
     "ritual": false
   },
   {
     "name": "Power Word Kill",
     "level": 9,
-    "school": "Ammaliamento",
+    "school": "Enchantment",
     "spell_list": ["Bard", "Wizard", "Sorcerer", "Warlock"],
     "ritual": false
   },
   {
     "name": "Prismatic Wall",
     "level": 9,
-    "school": "Abiurazione",
+    "school": "Abjuration",
     "spell_list": ["Bard", "Wizard"],
     "ritual": false
   },
   {
     "name": "Psychic Scream",
     "level": 9,
-    "school": "Ammaliamento",
+    "school": "Enchantment",
     "spell_list": ["Bard", "Wizard", "Sorcerer", "Warlock"],
     "ritual": false
   },
   {
     "name": "Ravenous Void",
     "level": 9,
-    "school": "Evocazione",
+    "school": "Conjuration",
     "spell_list": ["Wizard"],
     "ritual": false
   },
   {
     "name": "Shapechange",
     "level": 9,
-    "school": "Trasmutazione",
+    "school": "Transmutation",
     "spell_list": ["Druid", "Wizard"],
     "ritual": false
   },
   {
     "name": "Storm of Vengeance",
     "level": 9,
-    "school": "Evocazione",
+    "school": "Conjuration",
     "spell_list": ["Druid"],
     "ritual": false
   },
   {
     "name": "Time Ravage",
     "level": 9,
-    "school": "Necromanzia",
+    "school": "Necromancy",
     "spell_list": ["Wizard"],
     "ritual": false
   },
   {
     "name": "Time Stop",
     "level": 9,
-    "school": "Trasmutazione",
+    "school": "Transmutation",
     "spell_list": ["Wizard", "Sorcerer"],
     "ritual": false
   },
   {
     "name": "True Polymorph",
     "level": 9,
-    "school": "Trasmutazione",
+    "school": "Transmutation",
     "spell_list": ["Bard", "Wizard", "Warlock"],
     "ritual": false
   },
   {
     "name": "True Resurrection",
     "level": 9,
-    "school": "Necromanzia",
+    "school": "Necromancy",
     "spell_list": ["Cleric", "Druid"],
     "ritual": false
   },
   {
     "name": "Weird",
     "level": 9,
-    "school": "Illusione",
+    "school": "Illusion",
     "spell_list": ["Wizard", "Warlock"],
     "ritual": false
   },
   {
     "name": "Wish",
     "level": 9,
-    "school": "Evocazione",
+    "school": "Conjuration",
     "spell_list": ["Wizard", "Sorcerer"],
     "ritual": false
   }

--- a/js/spellcasting.js
+++ b/js/spellcasting.js
@@ -2,10 +2,10 @@ export function loadSpells(callback) {
   fetch('data/spells.json')
     .then(response => response.json())
     .then(data => {
-      console.log('📖 Incantesimi caricati:', data);
+      console.log('📖 Spells loaded:', data);
       callback(data);
     })
-    .catch(error => console.error('❌ Errore nel caricamento degli incantesimi:', error));
+    .catch(error => console.error('❌ Error loading spells:', error));
 }
 
 export function filterSpells(spells, filterString) {
@@ -38,7 +38,7 @@ export function handleSpellcasting(data, containerId) {
     console.log(`🔍 JSON Spellcasting per ${data.name}:`, data.spellcasting);
 
     if (data.spellcasting.fixed_spell) {
-      container.innerHTML += `<p><strong>✨ Incantesimo assegnato:</strong> ${data.spellcasting.fixed_spell}</p>`;
+      container.innerHTML += `<p><strong>✨ Assigned spell:</strong> ${data.spellcasting.fixed_spell}</p>`;
     }
 
     if (data.spellcasting.spell_choices) {
@@ -47,9 +47,9 @@ export function handleSpellcasting(data, containerId) {
           .map(spell => `<option value="${spell}">${spell}</option>`)
           .join('');
         container.innerHTML += `
-          <p><strong>🔮 Scegli un incantesimo:</strong></p>
+          <p><strong>🔮 Choose a spell:</strong></p>
           <select id="spellSelection">
-            <option value="">Seleziona...</option>${options}
+            <option value="">Select...</option>${options}
           </select>`;
       } else if (data.spellcasting.spell_choices.type === 'filter') {
         const filterParts = data.spellcasting.spell_choices.filter.split('|');
@@ -65,30 +65,30 @@ export function handleSpellcasting(data, containerId) {
 
             if (filteredSpells) {
               container.innerHTML += `
-                <p><strong>🔮 Scegli un Cantrip da ${spellClass}:</strong></p>
+                <p><strong>🔮 Choose a ${spellClass} Cantrip:</strong></p>
                 <select id="spellSelection">
-                  <option value="">Seleziona...</option>${filteredSpells}
+                  <option value="">Select...</option>${filteredSpells}
                 </select>`;
             } else {
-              container.innerHTML += `<p><strong>⚠️ Nessun Cantrip disponibile per ${spellClass}.</strong></p>`;
+              container.innerHTML += `<p><strong>⚠️ No Cantrip available for ${spellClass}.</strong></p>`;
             }
           });
         } else {
-          container.innerHTML += `<p><strong>⚠️ Errore: Il filtro incantesimi non è valido per questa razza.</strong></p>`;
+          container.innerHTML += `<p><strong>⚠️ Error: Spell filter is not valid for this race.</strong></p>`;
         }
       }
     }
 
     if (data.spellcasting.ability_choices && Array.isArray(data.spellcasting.ability_choices)) {
-      console.log(`🧙‍♂️ Verifica dell'abilità di lancio per ${data.name}:`, data.spellcasting.ability_choices);
+      console.log(`🧙‍♂️ Checking casting ability for ${data.name}:`, data.spellcasting.ability_choices);
       if (data.spellcasting.ability_choices.length > 1) {
         const abilityOptions = data.spellcasting.ability_choices
           .map(a => `<option value="${a.toUpperCase()}">${a.toUpperCase()}</option>`)
           .join('');
         container.innerHTML += `
-          <p><strong>🧠 Seleziona l'abilità di lancio:</strong></p>
+          <p><strong>🧠 Select the casting ability:</strong></p>
           <select id="castingAbility">
-            <option value="">Seleziona...</option>${abilityOptions}
+            <option value="">Select...</option>${abilityOptions}
           </select>`;
       }
     }


### PR DESCRIPTION
## Summary
- translate equipment listing and class options to English
- convert spell school fields to English terms
- update spellcasting UI text to English

## Testing
- `npm test` *(fails: package.json not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a4d971e904832e99564490bfdac654