### PR TITLE
Fix ReferenceError for navigation buttons in script.js

### DIFF
--- a/js/script.js
+++ b/js/script.js
@@ -292,6 +292,11 @@ let extraSelections = [];
 let currentSelectionIndex = 0;
 let extraModalContext = "";
 
+// Elements used to navigate and close the extra selections modal
+const prevTraitEl = document.getElementById("prevTrait");
+const nextTraitEl = document.getElementById("nextTrait");
+const closeModalEl = document.getElementById("closeModal");
+
 // Cached list of all languages loaded from JSON
 let availableLanguages = [];
 export function setAvailableLanguages(langs) {
@@ -755,9 +760,6 @@ function showExtraSelection() {
     }
   }
 
-  const prevTraitEl = document.getElementById("prevTrait");
-  const nextTraitEl = document.getElementById("nextTrait");
-  const closeModalEl = document.getElementById("closeModal");
   if (prevTraitEl && nextTraitEl && closeModalEl) {
     prevTraitEl.disabled = (currentSelectionIndex === 0);
     nextTraitEl.disabled = (currentSelectionIndex === extraSelections.length - 1);


### PR DESCRIPTION
## Summary
- Define modal navigation elements at the top level
- Use existing references inside `showExtraSelection` instead of redeclaring

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a4de419ba4832eaa95173454892001