### PR TITLE
Fix JSON syntax in equipment data

### DIFF
--- a/data/equipment.json
+++ b/data/equipment.json
@@ -124,7 +124,7 @@
             {
               "value": "Arcane focus",
               "label": "Arcane focus"
-            }
+            },
             { "value": "Mazza", "label": "Mazza" },
             { "value": "Martello da guerra", "label": "Martello da guerra" }
           ]


### PR DESCRIPTION
## Summary
- fix comma-separated array formatting in equipment data to ensure valid JSON

## Testing
- `python - <<'PY' ...`

------
https://chatgpt.com/codex/tasks/task_e_68a4dfd1ef28832e8e8003c97d1b955a