### PR TITLE
Add core traits for remaining classes

### DIFF
--- a/data/classes/artificer.json
+++ b/data/classes/artificer.json
@@ -1,6 +1,44 @@
 {
   "name": "Artificer",
   "description": "Masters of invention, artificers use ingenuity to channel arcane power into wondrous items.",
+  "hit_die": "d8",
+  "hp_at_1st_level": "8 + your Constitution modifier",
+  "hp_at_higher_levels": "1d8 (or 5) + your Constitution modifier per Artificer level after 1st",
+  "saving_throws": ["Constitution", "Intelligence"],
+  "skill_proficiencies": {
+    "choose": 2,
+    "options": [
+      "Arcana",
+      "History",
+      "Investigation",
+      "Medicine",
+      "Nature",
+      "Perception",
+      "Sleight of Hand"
+    ]
+  },
+  "weapon_proficiencies": ["simple weapons", "firearms"],
+  "tool_proficiencies": ["thieves' tools", "tinker's tools", "one type of artisan's tools of your choice"],
+  "armor_proficiencies": ["light armor", "medium armor", "shields"],
+  "starting_equipment": {
+    "choices": [
+      ["Studded leather armor", "Scale mail"]
+    ],
+    "fixed": [
+      "Any two simple weapons",
+      "Light crossbow and 20 bolts",
+      "Thieves' tools",
+      "Dungeoneer's pack"
+    ],
+    "gold_alternative": "5d4 × 10 gp"
+  },
+  "multiclassing": {
+    "prerequisites": {"Intelligence": 13},
+    "proficiencies": {
+      "tools": ["thieves' tools", "tinker's tools"],
+      "armor": ["light armor", "medium armor", "shields"]
+    }
+  },
   "features_by_level": {
     "1": [
       {

--- a/data/classes/barbarian.json
+++ b/data/classes/barbarian.json
@@ -1,6 +1,38 @@
 {
   "name": "Barbarian",
   "description": "A fierce warrior of primitive background who can enter a battle rage.",
+  "hit_die": "d12",
+  "hp_at_1st_level": "12 + your Constitution modifier",
+  "hp_at_higher_levels": "1d12 (or 7) + your Constitution modifier per Barbarian level after 1st",
+  "saving_throws": ["Strength", "Constitution"],
+  "skill_proficiencies": {
+    "choose": 2,
+    "options": [
+      "Animal Handling",
+      "Athletics",
+      "Intimidation",
+      "Nature",
+      "Perception",
+      "Survival"
+    ]
+  },
+  "weapon_proficiencies": ["simple weapons", "martial weapons"],
+  "armor_proficiencies": ["light armor", "medium armor", "shields"],
+  "starting_equipment": {
+    "choices": [
+      ["Greataxe", "Any martial melee weapon"],
+      ["Two handaxes", "Any simple weapon"]
+    ],
+    "fixed": ["Explorer's pack", "Four javelins"],
+    "gold_alternative": "2d4 × 10 gp"
+  },
+  "multiclassing": {
+    "prerequisites": {"Strength": 13},
+    "proficiencies": {
+      "weapons": ["simple weapons", "martial weapons"],
+      "armor": ["shields"]
+    }
+  },
   "features_by_level": {
     "1": [
       {

--- a/data/classes/bard.json
+++ b/data/classes/bard.json
@@ -1,6 +1,53 @@
 {
   "name": "Bard",
   "description": "An inspiring magician whose power echoes music and performance.",
+  "hit_die": "d8",
+  "hp_at_1st_level": "8 + your Constitution modifier",
+  "hp_at_higher_levels": "1d8 (or 5) + your Constitution modifier per Bard level after 1st",
+  "saving_throws": ["Dexterity", "Charisma"],
+  "skill_proficiencies": {
+    "choose": 3,
+    "options": [
+      "Acrobatics",
+      "Animal Handling",
+      "Arcana",
+      "Athletics",
+      "Deception",
+      "History",
+      "Insight",
+      "Intimidation",
+      "Investigation",
+      "Medicine",
+      "Nature",
+      "Perception",
+      "Performance",
+      "Persuasion",
+      "Religion",
+      "Sleight of Hand",
+      "Stealth",
+      "Survival"
+    ]
+  },
+  "weapon_proficiencies": ["simple weapons", "hand crossbows", "longswords", "rapiers", "shortswords"],
+  "tool_proficiencies": ["three musical instruments of your choice"],
+  "armor_proficiencies": ["light armor"],
+  "starting_equipment": {
+    "choices": [
+      ["Rapier", "Longsword", "Any simple weapon"],
+      ["Diplomat's pack", "Entertainer's pack"],
+      ["Lute", "Any other musical instrument"]
+    ],
+    "fixed": ["Leather armor", "Dagger"],
+    "gold_alternative": "5d4 × 10 gp"
+  },
+  "multiclassing": {
+    "prerequisites": {"Charisma": 13},
+    "proficiencies": {
+      "skills": ["Choose any one skill"],
+      "tools": ["one musical instrument of your choice"],
+      "armor": ["light armor"]
+    }
+  },
   "features_by_level": {
     "1": [
       {

--- a/data/classes/cleric.json
+++ b/data/classes/cleric.json
@@ -1,6 +1,30 @@
 {
   "name": "Cleric",
   "description": "A priestly champion who wields divine magic in service of a higher power.",
+  "hit_die": "d8",
+  "hp_at_1st_level": "8 + your Constitution modifier",
+  "hp_at_higher_levels": "1d8 (or 5) + your Constitution modifier per Cleric level after 1st",
+  "saving_throws": ["Wisdom", "Charisma"],
+  "skill_proficiencies": {
+    "choose": 2,
+    "options": ["History", "Insight", "Medicine", "Persuasion", "Religion"]
+  },
+  "weapon_proficiencies": ["simple weapons"],
+  "armor_proficiencies": ["light armor", "medium armor", "shields"],
+  "starting_equipment": {
+    "choices": [
+      ["Mace", "Warhammer (if proficient)"],
+      ["Scale mail", "Leather armor", "Chain mail (if proficient)"],
+      ["Light crossbow and 20 bolts", "Any simple weapon"],
+      ["Priest's pack", "Explorer's pack"]
+    ],
+    "fixed": ["Shield", "Holy symbol"],
+    "gold_alternative": "5d4 × 10 gp"
+  },
+  "multiclassing": {
+    "prerequisites": {"Wisdom": 13},
+    "proficiencies": {"armor": ["light armor", "medium armor", "shields"]}
+  },
   "features_by_level": {
     "1": [
       {

--- a/data/classes/fighter.json
+++ b/data/classes/fighter.json
@@ -1,5 +1,42 @@
 {
   "name": "Fighter",
+  "description": "A master of martial combat, skilled with a variety of weapons and armor.",
+  "hit_die": "d10",
+  "hp_at_1st_level": "10 + your Constitution modifier",
+  "hp_at_higher_levels": "1d10 (or 6) + your Constitution modifier per Fighter level after 1st",
+  "saving_throws": ["Strength", "Constitution"],
+  "skill_proficiencies": {
+    "choose": 2,
+    "options": [
+      "Acrobatics",
+      "Animal Handling",
+      "Athletics",
+      "History",
+      "Insight",
+      "Intimidation",
+      "Perception",
+      "Survival"
+    ]
+  },
+  "weapon_proficiencies": ["simple weapons", "martial weapons"],
+  "armor_proficiencies": ["light armor", "medium armor", "heavy armor", "shields"],
+  "starting_equipment": {
+    "choices": [
+      ["Chain mail", "Leather armor, longbow, and 20 arrows"],
+      ["A martial weapon and a shield", "Two martial weapons"],
+      ["Light crossbow and 20 bolts", "Two handaxes"],
+      ["Dungeoneer's pack", "Explorer's pack"]
+    ],
+    "fixed": [],
+    "gold_alternative": "5d4 × 10 gp"
+  },
+  "multiclassing": {
+    "prerequisites": {"Strength": 13, "Dexterity": 13},
+    "proficiencies": {
+      "weapons": ["simple weapons", "martial weapons"],
+      "armor": ["light armor", "medium armor", "shields"]
+    }
+  },
   "subclasses": [
     {
       "name": "Arcane Archer",

--- a/data/classes/paladin.json
+++ b/data/classes/paladin.json
@@ -1,6 +1,32 @@
 {
   "name": "Paladin",
   "description": "A holy warrior bound to a sacred oath.",
+  "hit_die": "d10",
+  "hp_at_1st_level": "10 + your Constitution modifier",
+  "hp_at_higher_levels": "1d10 (or 6) + your Constitution modifier per Paladin level after 1st",
+  "saving_throws": ["Wisdom", "Charisma"],
+  "skill_proficiencies": {
+    "choose": 2,
+    "options": ["Athletics", "Insight", "Intimidation", "Medicine", "Persuasion", "Religion"]
+  },
+  "weapon_proficiencies": ["simple weapons", "martial weapons"],
+  "armor_proficiencies": ["light armor", "medium armor", "heavy armor", "shields"],
+  "starting_equipment": {
+    "choices": [
+      ["A martial weapon and a shield", "Two martial weapons"],
+      ["Five javelins", "Any simple melee weapon"],
+      ["Priest's pack", "Explorer's pack"]
+    ],
+    "fixed": ["Chain mail", "Holy symbol"],
+    "gold_alternative": "5d4 × 10 gp"
+  },
+  "multiclassing": {
+    "prerequisites": {"Strength": 13, "Charisma": 13},
+    "proficiencies": {
+      "weapons": ["simple weapons", "martial weapons"],
+      "armor": ["light armor", "medium armor", "shields"]
+    }
+  },
   "features_by_level": {
     "1": [
       {

--- a/data/classes/rogue.json
+++ b/data/classes/rogue.json
@@ -1,5 +1,46 @@
 {
   "name": "Rogue",
+  "description": "A scoundrel who uses stealth and trickery to overcome obstacles and enemies.",
+  "hit_die": "d8",
+  "hp_at_1st_level": "8 + your Constitution modifier",
+  "hp_at_higher_levels": "1d8 (or 5) + your Constitution modifier per Rogue level after 1st",
+  "saving_throws": ["Dexterity", "Intelligence"],
+  "skill_proficiencies": {
+    "choose": 4,
+    "options": [
+      "Acrobatics",
+      "Athletics",
+      "Deception",
+      "Insight",
+      "Intimidation",
+      "Investigation",
+      "Perception",
+      "Performance",
+      "Persuasion",
+      "Sleight of Hand",
+      "Stealth"
+    ]
+  },
+  "weapon_proficiencies": ["simple weapons", "hand crossbows", "longswords", "rapiers", "shortswords"],
+  "tool_proficiencies": ["thieves' tools"],
+  "armor_proficiencies": ["light armor"],
+  "starting_equipment": {
+    "choices": [
+      ["Rapier", "Shortsword"],
+      ["Shortbow and quiver of 20 arrows", "Shortsword"],
+      ["Burglar's pack", "Dungeoneer's pack", "Explorer's pack"]
+    ],
+    "fixed": ["Leather armor", "Two daggers", "Thieves' tools"],
+    "gold_alternative": "4d4 × 10 gp"
+  },
+  "multiclassing": {
+    "prerequisites": {"Dexterity": 13},
+    "proficiencies": {
+      "skills": ["Choose one Rogue skill"],
+      "tools": ["thieves' tools"],
+      "armor": ["light armor"]
+    }
+  },
   "subclasses": [
     {
       "name": "Thief",

--- a/data/classes/sorcerer.json
+++ b/data/classes/sorcerer.json
@@ -1,5 +1,25 @@
 {
   "name": "Sorcerer",
+  "description": "A spellcaster who draws on inherent magic from a gift or bloodline.",
+  "hit_die": "d6",
+  "hp_at_1st_level": "6 + your Constitution modifier",
+  "hp_at_higher_levels": "1d6 (or 4) + your Constitution modifier per Sorcerer level after 1st",
+  "saving_throws": ["Constitution", "Charisma"],
+  "skill_proficiencies": {
+    "choose": 2,
+    "options": ["Arcana", "Deception", "Insight", "Intimidation", "Persuasion", "Religion"]
+  },
+  "weapon_proficiencies": ["daggers", "darts", "slings", "quarterstaffs", "light crossbows"],
+  "starting_equipment": {
+    "choices": [
+      ["Light crossbow and 20 bolts", "Any simple weapon"],
+      ["Component pouch", "Arcane focus"],
+      ["Dungeoneer's pack", "Explorer's pack"]
+    ],
+    "fixed": ["Two daggers"],
+    "gold_alternative": "3d4 × 10 gp"
+  },
+  "multiclassing": {"prerequisites": {"Charisma": 13}},
   "subclasses": [
     {
       "name": "Aberrant Mind",

--- a/data/classes/warlock.json
+++ b/data/classes/warlock.json
@@ -1,6 +1,29 @@
 {
   "name": "Warlock",
   "description": "A wielder of magic derived from a bargain with an extraplanar patron.",
+  "hit_die": "d8",
+  "hp_at_1st_level": "8 + your Constitution modifier",
+  "hp_at_higher_levels": "1d8 (or 5) + your Constitution modifier per Warlock level after 1st",
+  "saving_throws": ["Wisdom", "Charisma"],
+  "skill_proficiencies": {
+    "choose": 2,
+    "options": ["Arcana", "Deception", "History", "Intimidation", "Investigation", "Nature", "Religion"]
+  },
+  "weapon_proficiencies": ["simple weapons"],
+  "armor_proficiencies": ["light armor"],
+  "starting_equipment": {
+    "choices": [
+      ["Light crossbow and 20 bolts", "Any simple weapon"],
+      ["Component pouch", "Arcane focus"],
+      ["Scholar's pack", "Dungeoneer's pack"]
+    ],
+    "fixed": ["Leather armor", "Any simple weapon", "Two daggers"],
+    "gold_alternative": "4d4 × 10 gp"
+  },
+  "multiclassing": {
+    "prerequisites": {"Charisma": 13},
+    "proficiencies": {"weapons": ["simple weapons"], "armor": ["light armor"]}
+  },
   "features_by_level": {
     "1": [
       {

--- a/data/classes/wizard.json
+++ b/data/classes/wizard.json
@@ -1,5 +1,25 @@
 {
   "name": "Wizard",
+  "description": "A scholarly magic-user capable of manipulating the structures of reality.",
+  "hit_die": "d6",
+  "hp_at_1st_level": "6 + your Constitution modifier",
+  "hp_at_higher_levels": "1d6 (or 4) + your Constitution modifier per Wizard level after 1st",
+  "saving_throws": ["Intelligence", "Wisdom"],
+  "skill_proficiencies": {
+    "choose": 2,
+    "options": ["Arcana", "History", "Insight", "Investigation", "Medicine", "Religion"]
+  },
+  "weapon_proficiencies": ["daggers", "darts", "slings", "quarterstaffs", "light crossbows"],
+  "starting_equipment": {
+    "choices": [
+      ["Quarterstaff", "Dagger"],
+      ["Component pouch", "Arcane focus"],
+      ["Scholar's pack", "Explorer's pack"]
+    ],
+    "fixed": ["Spellbook"],
+    "gold_alternative": "4d4 × 10 gp"
+  },
+  "multiclassing": {"prerequisites": {"Intelligence": 13}},
   "subclasses": [
     {
       "name": "School of Abjuration",


### PR DESCRIPTION
## Summary
- populate missing core data for Artificer, Barbarian, Bard, Cleric, Fighter, Paladin, Rogue, Sorcerer, Warlock, and Wizard
- include hit dice, proficiencies, starting equipment, and multiclassing requirements

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a4e1e70130832eba6a2c38eefa3eb0