### PR TITLE
Enable reselecting class and skill proficiency options

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -35,7 +35,17 @@ document.addEventListener('DOMContentLoaded', () => {
   const classSelectElem = document.getElementById('classSelect');
   const subclassSelectElem = document.getElementById('subclassSelect');
   const levelSelectElem = document.getElementById('levelSelect');
-  if (classSelectElem) classSelectElem.addEventListener('change', updateSubclasses);
+  if (classSelectElem)
+    classSelectElem.addEventListener('change', () => {
+      classSelectionConfirmed = false;
+      if (window.selectedData) {
+        Object.keys(window.selectedData).forEach(k => delete window.selectedData[k]);
+        sessionStorage.setItem('selectedData', JSON.stringify(window.selectedData));
+      }
+      const confirmBtn = document.getElementById('confirmClassSelection');
+      if (confirmBtn) confirmBtn.style.display = 'inline-block';
+      updateSubclasses();
+    });
   if (subclassSelectElem)
     subclassSelectElem.addEventListener('change', async () => {
       const selections = await renderClassFeatures();
@@ -85,9 +95,6 @@ document.addEventListener('DOMContentLoaded', () => {
     if (selections.length > 0) {
       openExtrasModal(selections, 'class');
     }
-    classSelect.disabled = true;
-    subclassSelect.disabled = true;
-    document.getElementById('confirmClassSelection').style.display = 'none';
   });
 
   document.getElementById('confirmRaceSelection').addEventListener('click', () => {

--- a/js/script.js
+++ b/js/script.js
@@ -1200,6 +1200,15 @@ async function renderClassFeatures() {
   });
 
   const allChoices = [...(data.choices || []), ...(subData?.choices || [])];
+  if (data.skill_proficiencies && !allChoices.some(c => c.name === 'Skill Proficiency')) {
+    allChoices.push({
+      level: 1,
+      name: 'Skill Proficiency',
+      description: `Choose ${data.skill_proficiencies.choose} from the class skill list`,
+      count: data.skill_proficiencies.choose,
+      selection: data.skill_proficiencies.options
+    });
+  }
   const selections = gatherExtraSelections({ choices: allChoices }, "class", charLevel);
 
   if (!subclassName) {


### PR DESCRIPTION
## Summary
- Allow class and subclass selection changes by clearing stored class data and re-rendering subclasses on change
- Include class skill proficiency choices at level 1 when available

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a4e1cefaf0832e85751e9936abcf14