### PR TITLE
Remove placeholder subclass options

### DIFF
--- a/data/subclasses/aberrant_mind.json
+++ b/data/subclasses/aberrant_mind.json
@@ -34,7 +34,5 @@
         "description": "Teleport up to 120 feet, pulling nearby creatures toward your former space and dealing force damage once per long rest or by spending 5 sorcery points."
       }
     ]
-  },
-  "choices": []
+  }
 }
-

--- a/data/subclasses/abjuration.json
+++ b/data/subclasses/abjuration.json
@@ -30,18 +30,5 @@
         "description": "Description for Spell Resistance."
       }
     ]
-  },
-  "choices": [
-    {
-      "level": 2,
-      "name": "Abjuration Feature",
-      "description": "Choose an option for the Abjuration subclass",
-      "count": 1,
-      "selection": [
-        "Abjuration Option 1",
-        "Abjuration Option 2"
-      ],
-      "type": "Abjuration Feature"
-    }
-  ]
+  }
 }

--- a/data/subclasses/alchemist.json
+++ b/data/subclasses/alchemist.json
@@ -9,7 +9,7 @@
       },
       {
         "name": "Alchemist Spells",
-        "description": "You always have certain spells prepared: 3rd—healing word, ray of sickness; 5th—flaming sphere, Melf's acid arrow; 9th—gaseous form, mass healing word; 13th—blight, death ward; 17th—cloudkill, raise dead. These count as artificer spells for you and don't count against spells prepared."
+        "description": "You always have certain spells prepared: 3rd\u2014healing word, ray of sickness; 5th\u2014flaming sphere, Melf's acid arrow; 9th\u2014gaseous form, mass healing word; 13th\u2014blight, death ward; 17th\u2014cloudkill, raise dead. These count as artificer spells for you and don't count against spells prepared."
       },
       {
         "name": "Experimental Elixir",
@@ -34,18 +34,5 @@
         "description": "You gain resistance to acid and poison damage and immunity to the poisoned condition. You can cast greater restoration and heal without expending spell slots or material components once per long rest each when using alchemist's supplies as the focus."
       }
     ]
-  },
-  "choices": [
-    {
-      "level": 3,
-      "name": "Alchemist Feature",
-      "description": "Choose an option for the Alchemist subclass",
-      "count": 1,
-      "selection": [
-        "Alchemist Option 1",
-        "Alchemist Option 2"
-      ],
-      "type": "Alchemist Feature"
-    }
-  ]
+  }
 }

--- a/data/subclasses/ancestral_guardian.json
+++ b/data/subclasses/ancestral_guardian.json
@@ -26,18 +26,5 @@
         "description": "When you use Spirit Shield, the attacker takes force damage equal to the damage prevented."
       }
     ]
-  },
-  "choices": [
-    {
-      "level": 3,
-      "name": "Ancestral Guardian Feature",
-      "description": "Choose an option for the Ancestral Guardian subclass",
-      "count": 1,
-      "selection": [
-        "Ancestral Guardian Option 1",
-        "Ancestral Guardian Option 2"
-      ],
-      "type": "Ancestral Guardian Feature"
-    }
-  ]
+  }
 }

--- a/data/subclasses/ancients.json
+++ b/data/subclasses/ancients.json
@@ -30,18 +30,5 @@
         "description": "For 1 minute, you regain 10 hit points at the start of each turn, cast paladin spells as bonus actions, and enemies within 10 feet have disadvantage on saves against your paladin spells and Channel Divinity options."
       }
     ]
-  },
-  "choices": [
-    {
-      "level": 3,
-      "name": "Oath of the Ancients Feature",
-      "description": "Choose an option for the Oath of the Ancients subclass",
-      "count": 1,
-      "selection": [
-        "Oath of the Ancients Option 1",
-        "Oath of the Ancients Option 2"
-      ],
-      "type": "Oath of the Ancients Feature"
-    }
-  ]
+  }
 }

--- a/data/subclasses/arcana.json
+++ b/data/subclasses/arcana.json
@@ -32,18 +32,5 @@
         "description": "Choose four wizard spells of 6th to 9th level to add to your domain spells. They are always prepared."
       }
     ]
-  },
-  "choices": [
-    {
-      "level": 1,
-      "name": "Arcana Domain Feature",
-      "description": "Choose an option for the Arcana Domain subclass",
-      "count": 1,
-      "selection": [
-        "Arcana Domain Option 1",
-        "Arcana Domain Option 2"
-      ],
-      "type": "Arcana Domain Feature"
-    }
-  ]
+  }
 }

--- a/data/subclasses/arcane_archer.json
+++ b/data/subclasses/arcane_archer.json
@@ -52,7 +52,5 @@
         "description": "Learn one additional Arcane Shot option; your options also deal extra damage."
       }
     ]
-  },
-  "choices": []
+  }
 }
-

--- a/data/subclasses/arcane_trickster.json
+++ b/data/subclasses/arcane_trickster.json
@@ -30,18 +30,5 @@
         "description": "Description for Spell Thief."
       }
     ]
-  },
-  "choices": [
-    {
-      "level": 3,
-      "name": "Arcane Trickster Feature",
-      "description": "Choose an option for the Arcane Trickster subclass",
-      "count": 1,
-      "selection": [
-        "Arcane Trickster Option 1",
-        "Arcane Trickster Option 2"
-      ],
-      "type": "Arcane Trickster Feature"
-    }
-  ]
+  }
 }

--- a/data/subclasses/archfey.json
+++ b/data/subclasses/archfey.json
@@ -26,18 +26,5 @@
         "description": "Description for Dark Delirium."
       }
     ]
-  },
-  "choices": [
-    {
-      "level": 1,
-      "name": "The Archfey Feature",
-      "description": "Choose an option for the The Archfey subclass",
-      "count": 1,
-      "selection": [
-        "The Archfey Option 1",
-        "The Archfey Option 2"
-      ],
-      "type": "The Archfey Feature"
-    }
-  ]
+  }
 }

--- a/data/subclasses/armorer.json
+++ b/data/subclasses/armorer.json
@@ -9,7 +9,7 @@
       },
       {
         "name": "Armorer Spells",
-        "description": "You always have certain spells prepared: 3rd—magic missile, thunderwave; 5th—mirror image, shatter; 9th—hypnotic pattern, lightning bolt; 13th—fire shield, greater invisibility; 17th—passwall, wall of force. These count as artificer spells for you and don't count against spells prepared."
+        "description": "You always have certain spells prepared: 3rd\u2014magic missile, thunderwave; 5th\u2014mirror image, shatter; 9th\u2014hypnotic pattern, lightning bolt; 13th\u2014fire shield, greater invisibility; 17th\u2014passwall, wall of force. These count as artificer spells for you and don't count against spells prepared."
       },
       {
         "name": "Arcane Armor",
@@ -29,7 +29,7 @@
     "9": [
       {
         "name": "Armor Modifications",
-        "description": "Your arcane armor counts as separate items—armor, boots, helmet, and special weapon—for infusions. You can infuse two additional items, but they must be part of the armor."
+        "description": "Your arcane armor counts as separate items\u2014armor, boots, helmet, and special weapon\u2014for infusions. You can infuse two additional items, but they must be part of the armor."
       }
     ],
     "15": [
@@ -38,18 +38,5 @@
         "description": "Guardian: as a reaction when a creature ends its turn within 30 ft, you can pull it up to 25 ft and make a melee attack if it's within 5 ft; uses equal to your proficiency bonus per long rest. Infiltrator: creatures hit by your lightning launcher shed light and have disadvantage on attack rolls against you until your next turn; the next attack roll against the target has advantage and deals an extra 1d6 lightning damage on a hit."
       }
     ]
-  },
-  "choices": [
-    {
-      "level": 3,
-      "name": "Armorer Feature",
-      "description": "Choose an option for the Armorer subclass",
-      "count": 1,
-      "selection": [
-        "Armorer Option 1",
-        "Armorer Option 2"
-      ],
-      "type": "Armorer Feature"
-    }
-  ]
+  }
 }

--- a/data/subclasses/artillerist.json
+++ b/data/subclasses/artillerist.json
@@ -9,7 +9,7 @@
       },
       {
         "name": "Artillerist Spells",
-        "description": "You always have certain spells prepared: 3rd—shield, thunderwave; 5th—scorching ray, shatter; 9th—fireball, wind wall; 13th—ice storm, wall of fire; 17th—cone of cold, wall of force. These count as artificer spells for you and don't count against spells prepared."
+        "description": "You always have certain spells prepared: 3rd\u2014shield, thunderwave; 5th\u2014scorching ray, shatter; 9th\u2014fireball, wind wall; 13th\u2014ice storm, wall of fire; 17th\u2014cone of cold, wall of force. These count as artificer spells for you and don't count against spells prepared."
       },
       {
         "name": "Eldritch Cannon",
@@ -34,18 +34,5 @@
         "description": "You and your allies have half cover while within 10 ft of any eldritch cannon you create. You can maintain two cannons at once and can activate both with the same bonus action."
       }
     ]
-  },
-  "choices": [
-    {
-      "level": 3,
-      "name": "Artillerist Feature",
-      "description": "Choose an option for the Artillerist subclass",
-      "count": 1,
-      "selection": [
-        "Artillerist Option 1",
-        "Artillerist Option 2"
-      ],
-      "type": "Artillerist Feature"
-    }
-  ]
+  }
 }

--- a/data/subclasses/ascendant_dragon.json
+++ b/data/subclasses/ascendant_dragon.json
@@ -30,18 +30,5 @@
         "description": "Augment your breath to larger shapes and higher damage, gain 10-foot blindsight, and unleash explosive fury when you activate Aspect of the Wyrm."
       }
     ]
-  },
-  "choices": [
-    {
-      "level": 3,
-      "name": "Way of the Ascendant Dragon Feature",
-      "description": "Choose an option for the Way of the Ascendant Dragon subclass",
-      "count": 1,
-      "selection": [
-        "Way of the Ascendant Dragon Option 1",
-        "Way of the Ascendant Dragon Option 2"
-      ],
-      "type": "Way of the Ascendant Dragon Feature"
-    }
-  ]
+  }
 }

--- a/data/subclasses/assassin.json
+++ b/data/subclasses/assassin.json
@@ -30,18 +30,5 @@
         "description": "Description for Death Strike."
       }
     ]
-  },
-  "choices": [
-    {
-      "level": 3,
-      "name": "Assassin Feature",
-      "description": "Choose an option for the Assassin subclass",
-      "count": 1,
-      "selection": [
-        "Assassin Option 1",
-        "Assassin Option 2"
-      ],
-      "type": "Assassin Feature"
-    }
-  ]
+  }
 }

--- a/data/subclasses/astral_self.json
+++ b/data/subclasses/astral_self.json
@@ -26,18 +26,5 @@
         "description": "Spend 5 ki points to fully manifest your astral self for 10 minutes, gaining +2 AC and attacking three times with astral arms when you use Extra Attack."
       }
     ]
-  },
-  "choices": [
-    {
-      "level": 3,
-      "name": "Way of the Astral Self Feature",
-      "description": "Choose an option for the Way of the Astral Self subclass",
-      "count": 1,
-      "selection": [
-        "Way of the Astral Self Option 1",
-        "Way of the Astral Self Option 2"
-      ],
-      "type": "Way of the Astral Self Feature"
-    }
-  ]
+  }
 }

--- a/data/subclasses/barbarian_wild_magic.json
+++ b/data/subclasses/barbarian_wild_magic.json
@@ -30,18 +30,5 @@
         "description": "Whenever you roll on the Wild Magic table, you can roll twice and choose either result; if both are the same, choose any effect on the table."
       }
     ]
-  },
-  "choices": [
-    {
-      "level": 3,
-      "name": "Wild Magic Feature",
-      "description": "Choose an option for the Wild Magic subclass",
-      "count": 1,
-      "selection": [
-        "Wild Magic Option 1",
-        "Wild Magic Option 2"
-      ],
-      "type": "Wild Magic Feature"
-    }
-  ]
+  }
 }

--- a/data/subclasses/battle_smith.json
+++ b/data/subclasses/battle_smith.json
@@ -9,7 +9,7 @@
       },
       {
         "name": "Battle Smith Spells",
-        "description": "You always have certain spells prepared: 3rd—heroism, shield; 5th—branding smite, warding bond; 9th—aura of vitality, conjure barrage; 13th—aura of purity, fire shield; 17th—banishing smite, mass cure wounds. These count as artificer spells for you and don't count against spells prepared."
+        "description": "You always have certain spells prepared: 3rd\u2014heroism, shield; 5th\u2014branding smite, warding bond; 9th\u2014aura of vitality, conjure barrage; 13th\u2014aura of purity, fire shield; 17th\u2014banishing smite, mass cure wounds. These count as artificer spells for you and don't count against spells prepared."
       },
       {
         "name": "Battle Ready",
@@ -38,18 +38,5 @@
         "description": "Arcane Jolt's extra damage or healing becomes 4d6. Your steel defender's AC increases by 2, and its Deflect Attack reaction deals 1d4 + your Intelligence modifier force damage to the attacker."
       }
     ]
-  },
-  "choices": [
-    {
-      "level": 3,
-      "name": "Battle Smith Feature",
-      "description": "Choose an option for the Battle Smith subclass",
-      "count": 1,
-      "selection": [
-        "Battle Smith Option 1",
-        "Battle Smith Option 2"
-      ],
-      "type": "Battle Smith Feature"
-    }
-  ]
+  }
 }

--- a/data/subclasses/battlerager.json
+++ b/data/subclasses/battlerager.json
@@ -4,7 +4,7 @@
   "features_by_level": {
     "3": [
       {
-        "name": "Restriction—Dwarves Only",
+        "name": "Restriction\u2014Dwarves Only",
         "description": "Only dwarves can choose this path, though a DM may lift this restriction to suit the campaign."
       },
       {
@@ -30,18 +30,5 @@
         "description": "While raging in spiked armor, a creature that hits you with a melee attack takes 3 piercing damage if it is within 5 feet of you."
       }
     ]
-  },
-  "choices": [
-    {
-      "level": 3,
-      "name": "Battlerager Feature",
-      "description": "Choose an option for the Battlerager subclass",
-      "count": 1,
-      "selection": [
-        "Battlerager Option 1",
-        "Battlerager Option 2"
-      ],
-      "type": "Battlerager Feature"
-    }
-  ]
+  }
 }

--- a/data/subclasses/beast.json
+++ b/data/subclasses/beast.json
@@ -5,7 +5,7 @@
     "3": [
       {
         "name": "Form of the Beast",
-        "description": "When you rage, manifest natural weapons—bite, claws, or tail—each granting unique benefits and counting as simple melee weapons."
+        "description": "When you rage, manifest natural weapons\u2014bite, claws, or tail\u2014each granting unique benefits and counting as simple melee weapons."
       }
     ],
     "6": [
@@ -26,18 +26,5 @@
         "description": "When you rage, choose creatures equal to your Constitution modifier to gain 5 temporary hit points. Until the rage ends, they can add 1d6 damage once per turn. Uses equal to your proficiency bonus per long rest."
       }
     ]
-  },
-  "choices": [
-    {
-      "level": 3,
-      "name": "Beast Feature",
-      "description": "Choose an option for the Beast subclass",
-      "count": 1,
-      "selection": [
-        "Beast Option 1",
-        "Beast Option 2"
-      ],
-      "type": "Beast Feature"
-    }
-  ]
+  }
 }

--- a/data/subclasses/berserker.json
+++ b/data/subclasses/berserker.json
@@ -1,6 +1,6 @@
 {
   "name": "Berserker",
-  "description": "For some barbarians, rage is a means to an end—the end being violence and chaos on the battlefield.",
+  "description": "For some barbarians, rage is a means to an end\u2014the end being violence and chaos on the battlefield.",
   "features_by_level": {
     "3": [
       {
@@ -26,18 +26,5 @@
         "description": "When you take damage from a creature within 5 feet of you, you can use your reaction to make a melee weapon attack against that creature."
       }
     ]
-  },
-  "choices": [
-    {
-      "level": 3,
-      "name": "Berserker Feature",
-      "description": "Choose an option for the Berserker subclass",
-      "count": 1,
-      "selection": [
-        "Berserker Option 1",
-        "Berserker Option 2"
-      ],
-      "type": "Berserker Feature"
-    }
-  ]
+  }
 }

--- a/data/subclasses/cavalier.json
+++ b/data/subclasses/cavalier.json
@@ -40,7 +40,5 @@
         "description": "Gain a special reaction each round that can be used for opportunity attacks."
       }
     ]
-  },
-  "choices": []
+  }
 }
-

--- a/data/subclasses/celestial.json
+++ b/data/subclasses/celestial.json
@@ -30,18 +30,5 @@
         "description": "Description for Searing Vengeance."
       }
     ]
-  },
-  "choices": [
-    {
-      "level": 1,
-      "name": "The Celestial Feature",
-      "description": "Choose an option for the The Celestial subclass",
-      "count": 1,
-      "selection": [
-        "The Celestial Option 1",
-        "The Celestial Option 2"
-      ],
-      "type": "The Celestial Feature"
-    }
-  ]
+  }
 }

--- a/data/subclasses/circle_of_dreams.json
+++ b/data/subclasses/circle_of_dreams.json
@@ -26,18 +26,5 @@
         "description": "After a short rest, cast dream, scrying, or teleportation circle (to your last long-rest location) once per long rest without expending a slot."
       }
     ]
-  },
-  "choices": [
-    {
-      "level": 2,
-      "name": "Circle of Dreams Feature",
-      "description": "Choose an option for the Circle of Dreams subclass",
-      "count": 1,
-      "selection": [
-        "Circle of Dreams Option 1",
-        "Circle of Dreams Option 2"
-      ],
-      "type": "Circle of Dreams Feature"
-    }
-  ]
+  }
 }

--- a/data/subclasses/circle_of_spores.json
+++ b/data/subclasses/circle_of_spores.json
@@ -34,18 +34,5 @@
         "description": "You can't be blinded, deafened, frightened or poisoned, and critical hits count as normal hits."
       }
     ]
-  },
-  "choices": [
-    {
-      "level": 2,
-      "name": "Circle of Spores Feature",
-      "description": "Choose an option for the Circle of Spores subclass",
-      "count": 1,
-      "selection": [
-        "Circle of Spores Option 1",
-        "Circle of Spores Option 2"
-      ],
-      "type": "Circle of Spores Feature"
-    }
-  ]
+  }
 }

--- a/data/subclasses/circle_of_stars.json
+++ b/data/subclasses/circle_of_stars.json
@@ -30,18 +30,5 @@
         "description": "While in Starry Form, you gain resistance to bludgeoning, piercing and slashing damage."
       }
     ]
-  },
-  "choices": [
-    {
-      "level": 2,
-      "name": "Circle of Stars Feature",
-      "description": "Choose an option for the Circle of Stars subclass",
-      "count": 1,
-      "selection": [
-        "Circle of Stars Option 1",
-        "Circle of Stars Option 2"
-      ],
-      "type": "Circle of Stars Feature"
-    }
-  ]
+  }
 }

--- a/data/subclasses/circle_of_the_blighted.json
+++ b/data/subclasses/circle_of_the_blighted.json
@@ -38,18 +38,5 @@
         "description": "Gain resistance to necrotic damage, +2 AC, and can gain temporary hit points when starting your turn in your defiled ground."
       }
     ]
-  },
-  "choices": [
-    {
-      "level": 2,
-      "name": "Circle of the Blighted Feature",
-      "description": "Choose an option for the Circle of the Blighted subclass",
-      "count": 1,
-      "selection": [
-        "Circle of the Blighted Option 1",
-        "Circle of the Blighted Option 2"
-      ],
-      "type": "Circle of the Blighted Feature"
-    }
-  ]
+  }
 }

--- a/data/subclasses/circle_of_the_land.json
+++ b/data/subclasses/circle_of_the_land.json
@@ -34,18 +34,5 @@
         "description": "Beasts and plants must succeed on a Wisdom save to attack you; on a failure they must choose another target."
       }
     ]
-  },
-  "choices": [
-    {
-      "level": 2,
-      "name": "Circle of the Land Feature",
-      "description": "Choose an option for the Circle of the Land subclass",
-      "count": 1,
-      "selection": [
-        "Circle of the Land Option 1",
-        "Circle of the Land Option 2"
-      ],
-      "type": "Circle of the Land Feature"
-    }
-  ]
+  }
 }

--- a/data/subclasses/circle_of_the_moon.json
+++ b/data/subclasses/circle_of_the_moon.json
@@ -30,18 +30,5 @@
         "description": "Cast alter self at will."
       }
     ]
-  },
-  "choices": [
-    {
-      "level": 2,
-      "name": "Circle of the Moon Feature",
-      "description": "Choose an option for the Circle of the Moon subclass",
-      "count": 1,
-      "selection": [
-        "Circle of the Moon Option 1",
-        "Circle of the Moon Option 2"
-      ],
-      "type": "Circle of the Moon Feature"
-    }
-  ]
+  }
 }

--- a/data/subclasses/circle_of_the_shepherd.json
+++ b/data/subclasses/circle_of_the_shepherd.json
@@ -30,18 +30,5 @@
         "description": "If reduced to 0 hit points or incapacitated, automatically cast conjure animals at 9th level to summon protective beasts."
       }
     ]
-  },
-  "choices": [
-    {
-      "level": 2,
-      "name": "Circle of the Shepherd Feature",
-      "description": "Choose an option for the Circle of the Shepherd subclass",
-      "count": 1,
-      "selection": [
-        "Circle of the Shepherd Option 1",
-        "Circle of the Shepherd Option 2"
-      ],
-      "type": "Circle of the Shepherd Feature"
-    }
-  ]
+  }
 }

--- a/data/subclasses/circle_of_wildfire.json
+++ b/data/subclasses/circle_of_wildfire.json
@@ -30,18 +30,5 @@
         "description": "If you drop to 0 hit points while the spirit is within 120 feet, it can drop to 0 to restore you to half hit points and stand you up."
       }
     ]
-  },
-  "choices": [
-    {
-      "level": 2,
-      "name": "Circle of Wildfire Feature",
-      "description": "Choose an option for the Circle of Wildfire subclass",
-      "count": 1,
-      "selection": [
-        "Circle of Wildfire Option 1",
-        "Circle of Wildfire Option 2"
-      ],
-      "type": "Circle of Wildfire Feature"
-    }
-  ]
+  }
 }

--- a/data/subclasses/clockwork_soul.json
+++ b/data/subclasses/clockwork_soul.json
@@ -30,7 +30,5 @@
         "description": "Summon spirits of order to heal, repair, and end spells in a 30-foot cube once per long rest or by spending 7 sorcery points."
       }
     ]
-  },
-  "choices": []
+  }
 }
-

--- a/data/subclasses/cobalt_soul.json
+++ b/data/subclasses/cobalt_soul.json
@@ -38,18 +38,5 @@
         "description": "Gain a third language and skill proficiency or doubled proficiency from the list."
       }
     ]
-  },
-  "choices": [
-    {
-      "level": 3,
-      "name": "Way of the Cobalt Soul Feature",
-      "description": "Choose an option for the Way of the Cobalt Soul subclass",
-      "count": 1,
-      "selection": [
-        "Way of the Cobalt Soul Option 1",
-        "Way of the Cobalt Soul Option 2"
-      ],
-      "type": "Way of the Cobalt Soul Feature"
-    }
-  ]
+  }
 }

--- a/data/subclasses/college_of_creation.json
+++ b/data/subclasses/college_of_creation.json
@@ -24,18 +24,5 @@
         "description": "You can create multiple items with Performance of Creation up to a number equal to your Charisma modifier, ignoring gp limits; only one can be of the maximum size."
       }
     ]
-  },
-  "choices": [
-    {
-      "level": 3,
-      "name": "College of Creation Feature",
-      "description": "Choose an option for the College of Creation subclass",
-      "count": 1,
-      "selection": [
-        "College of Creation Option 1",
-        "College of Creation Option 2"
-      ],
-      "type": "College of Creation Feature"
-    }
-  ]
+  }
 }

--- a/data/subclasses/college_of_eloquence.json
+++ b/data/subclasses/college_of_eloquence.json
@@ -28,18 +28,5 @@
         "description": "When a creature succeeds using your Bardic Inspiration die, you can use your reaction to give a Bardic Inspiration die to another creature within 60 feet. Uses equal your Charisma modifier per long rest."
       }
     ]
-  },
-  "choices": [
-    {
-      "level": 3,
-      "name": "College of Eloquence Feature",
-      "description": "Choose an option for the College of Eloquence subclass",
-      "count": 1,
-      "selection": [
-        "College of Eloquence Option 1",
-        "College of Eloquence Option 2"
-      ],
-      "type": "College of Eloquence Feature"
-    }
-  ]
+  }
 }

--- a/data/subclasses/college_of_glamour.json
+++ b/data/subclasses/college_of_glamour.json
@@ -24,18 +24,5 @@
         "description": "As a bonus action, assume a majestic presence for 1 minute. Creatures that try to attack you must make a Charisma save or choose another target; on a success they have disadvantage on saves against your spells on your next turn."
       }
     ]
-  },
-  "choices": [
-    {
-      "level": 3,
-      "name": "College of Glamour Feature",
-      "description": "Choose an option for the College of Glamour subclass",
-      "count": 1,
-      "selection": [
-        "College of Glamour Option 1",
-        "College of Glamour Option 2"
-      ],
-      "type": "College of Glamour Feature"
-    }
-  ]
+  }
 }

--- a/data/subclasses/college_of_lore.json
+++ b/data/subclasses/college_of_lore.json
@@ -24,18 +24,5 @@
         "description": "When you make an ability check, expend a Bardic Inspiration die and add it to the roll. You can decide after seeing the d20 but before the DM determines success."
       }
     ]
-  },
-  "choices": [
-    {
-      "level": 3,
-      "name": "College of Lore Feature",
-      "description": "Choose an option for the College of Lore subclass",
-      "count": 1,
-      "selection": [
-        "College of Lore Option 1",
-        "College of Lore Option 2"
-      ],
-      "type": "College of Lore Feature"
-    }
-  ]
+  }
 }

--- a/data/subclasses/college_of_spirits.json
+++ b/data/subclasses/college_of_spirits.json
@@ -28,18 +28,5 @@
         "description": "When rolling on the Spirit Tales table, roll twice and choose which effect to use; if you roll the same number, choose any tale."
       }
     ]
-  },
-  "choices": [
-    {
-      "level": 3,
-      "name": "College of Spirits Feature",
-      "description": "Choose an option for the College of Spirits subclass",
-      "count": 1,
-      "selection": [
-        "College of Spirits Option 1",
-        "College of Spirits Option 2"
-      ],
-      "type": "College of Spirits Feature"
-    }
-  ]
+  }
 }

--- a/data/subclasses/college_of_swords.json
+++ b/data/subclasses/college_of_swords.json
@@ -28,18 +28,5 @@
         "description": "Whenever you use a Blade Flourish option, you can roll a d6 instead of expending a Bardic Inspiration die."
       }
     ]
-  },
-  "choices": [
-    {
-      "level": 3,
-      "name": "College of Swords Feature",
-      "description": "Choose an option for the College of Swords subclass",
-      "count": 1,
-      "selection": [
-        "College of Swords Option 1",
-        "College of Swords Option 2"
-      ],
-      "type": "College of Swords Feature"
-    }
-  ]
+  }
 }

--- a/data/subclasses/college_of_valor.json
+++ b/data/subclasses/college_of_valor.json
@@ -24,18 +24,5 @@
         "description": "When you use your action to cast a bard spell, you can make one weapon attack as a bonus action."
       }
     ]
-  },
-  "choices": [
-    {
-      "level": 3,
-      "name": "College of Valor Feature",
-      "description": "Choose an option for the College of Valor subclass",
-      "count": 1,
-      "selection": [
-        "College of Valor Option 1",
-        "College of Valor Option 2"
-      ],
-      "type": "College of Valor Feature"
-    }
-  ]
+  }
 }

--- a/data/subclasses/college_of_whispers.json
+++ b/data/subclasses/college_of_whispers.json
@@ -24,18 +24,5 @@
         "description": "As an action, whisper to one creature within 30 feet, forcing a Wisdom save. On a failure it is charmed for 8 hours, convinced you know its most mortifying secret and obeying your commands."
       }
     ]
-  },
-  "choices": [
-    {
-      "level": 3,
-      "name": "College of Whispers Feature",
-      "description": "Choose an option for the College of Whispers subclass",
-      "count": 1,
-      "selection": [
-        "College of Whispers Option 1",
-        "College of Whispers Option 2"
-      ],
-      "type": "College of Whispers Feature"
-    }
-  ]
+  }
 }

--- a/data/subclasses/conjuration.json
+++ b/data/subclasses/conjuration.json
@@ -30,18 +30,5 @@
         "description": "Description for Durable Summons."
       }
     ]
-  },
-  "choices": [
-    {
-      "level": 2,
-      "name": "Conjuration Feature",
-      "description": "Choose an option for the Conjuration subclass",
-      "count": 1,
-      "selection": [
-        "Conjuration Option 1",
-        "Conjuration Option 2"
-      ],
-      "type": "Conjuration Feature"
-    }
-  ]
+  }
 }

--- a/data/subclasses/conquest.json
+++ b/data/subclasses/conquest.json
@@ -9,13 +9,13 @@
       },
       {
         "name": "Guided Strike",
-        "description": "Use Channel Divinity to gain a +10 bonus to an attack roll after seeing the roll." 
+        "description": "Use Channel Divinity to gain a +10 bonus to an attack roll after seeing the roll."
       }
     ],
     "7": [
       {
         "name": "Aura of Conquest",
-        "description": "Creatures frightened of you that start their turn in your 10-foot aura have their speed reduced to 0 and take psychic damage equal to half your paladin level." 
+        "description": "Creatures frightened of you that start their turn in your 10-foot aura have their speed reduced to 0 and take psychic damage equal to half your paladin level."
       }
     ],
     "15": [
@@ -27,22 +27,8 @@
     "20": [
       {
         "name": "Invincible Conqueror",
-        "description": "For 1 minute, you have resistance to all damage, make one additional attack when you take the Attack action, and your melee weapon attacks score a critical hit on a 19 or 20. Once per long rest." 
+        "description": "For 1 minute, you have resistance to all damage, make one additional attack when you take the Attack action, and your melee weapon attacks score a critical hit on a 19 or 20. Once per long rest."
       }
     ]
-  },
-  "choices": [
-    {
-      "level": 3,
-      "name": "Oath of Conquest Feature",
-      "description": "Choose an option for the Oath of Conquest subclass",
-      "count": 1,
-      "selection": [
-        "Oath of Conquest Option 1",
-        "Oath of Conquest Option 2"
-      ],
-      "type": "Oath of Conquest Feature"
-    }
-  ]
+  }
 }
-

--- a/data/subclasses/crown.json
+++ b/data/subclasses/crown.json
@@ -5,44 +5,30 @@
     "3": [
       {
         "name": "Champion Challenge",
-        "description": "As a bonus action, compel creatures you choose within 30 feet to make a Wisdom save or be unable to willingly move more than 30 feet away from you." 
+        "description": "As a bonus action, compel creatures you choose within 30 feet to make a Wisdom save or be unable to willingly move more than 30 feet away from you."
       },
       {
         "name": "Turn the Tide",
-        "description": "As a bonus action, each creature of your choice within 30 feet that can hear you regains 1d6 + your Charisma modifier hit points if it has no more than half its hit points." 
+        "description": "As a bonus action, each creature of your choice within 30 feet that can hear you regains 1d6 + your Charisma modifier hit points if it has no more than half its hit points."
       }
     ],
     "7": [
       {
         "name": "Divine Allegiance",
-        "description": "When a creature within 5 feet of you takes damage, you can use your reaction to take the damage instead." 
+        "description": "When a creature within 5 feet of you takes damage, you can use your reaction to take the damage instead."
       }
     ],
     "15": [
       {
         "name": "Unyielding Spirit",
-        "description": "You have advantage on saving throws to avoid becoming paralyzed or stunned." 
+        "description": "You have advantage on saving throws to avoid becoming paralyzed or stunned."
       }
     ],
     "20": [
       {
         "name": "Exalted Champion",
-        "description": "For 1 hour, you gain resistance to nonmagical weapon damage, allies within 30 feet have advantage on death saves, and you and allies within 30 feet have advantage on Wisdom saves. Once per long rest." 
+        "description": "For 1 hour, you gain resistance to nonmagical weapon damage, allies within 30 feet have advantage on death saves, and you and allies within 30 feet have advantage on Wisdom saves. Once per long rest."
       }
     ]
-  },
-  "choices": [
-    {
-      "level": 3,
-      "name": "Oath of the Crown Feature",
-      "description": "Choose an option for the Oath of the Crown subclass",
-      "count": 1,
-      "selection": [
-        "Oath of the Crown Option 1",
-        "Oath of the Crown Option 2"
-      ],
-      "type": "Oath of the Crown Feature"
-    }
-  ]
+  }
 }
-

--- a/data/subclasses/death.json
+++ b/data/subclasses/death.json
@@ -36,18 +36,5 @@
         "description": "When you cast a necromancy spell of 1st through 5th level that targets only one creature, you can target two creatures within 5 feet of each other instead."
       }
     ]
-  },
-  "choices": [
-    {
-      "level": 1,
-      "name": "Death Domain Feature",
-      "description": "Choose an option for the Death Domain subclass",
-      "count": 1,
-      "selection": [
-        "Death Domain Option 1",
-        "Death Domain Option 2"
-      ],
-      "type": "Death Domain Feature"
-    }
-  ]
+  }
 }

--- a/data/subclasses/devotion.json
+++ b/data/subclasses/devotion.json
@@ -30,18 +30,5 @@
         "description": "As an action, emit a 30-foot aura of bright light for 1 minute. Enemies in the bright light take 10 radiant damage at the start of their turn, and you have advantage on saves against spells cast by fiends or undead. Once per long rest."
       }
     ]
-  },
-  "choices": [
-    {
-      "level": 3,
-      "name": "Oath of Devotion Feature",
-      "description": "Choose an option for the Oath of Devotion subclass",
-      "count": 1,
-      "selection": [
-        "Oath of Devotion Option 1",
-        "Oath of Devotion Option 2"
-      ],
-      "type": "Oath of Devotion Feature"
-    }
-  ]
+  }
 }

--- a/data/subclasses/divination.json
+++ b/data/subclasses/divination.json
@@ -30,18 +30,5 @@
         "description": "Description for Greater Portent."
       }
     ]
-  },
-  "choices": [
-    {
-      "level": 2,
-      "name": "Divination Feature",
-      "description": "Choose an option for the Divination subclass",
-      "count": 1,
-      "selection": [
-        "Divination Option 1",
-        "Divination Option 2"
-      ],
-      "type": "Divination Feature"
-    }
-  ]
+  }
 }

--- a/data/subclasses/drunken_master.json
+++ b/data/subclasses/drunken_master.json
@@ -30,18 +30,5 @@
         "description": "When you use Flurry of Blows, make up to three additional attacks provided each targets a different creature."
       }
     ]
-  },
-  "choices": [
-    {
-      "level": 3,
-      "name": "Way of the Drunken Master Feature",
-      "description": "Choose an option for the Way of the Drunken Master subclass",
-      "count": 1,
-      "selection": [
-        "Way of the Drunken Master Option 1",
-        "Way of the Drunken Master Option 2"
-      ],
-      "type": "Way of the Drunken Master Feature"
-    }
-  ]
+  }
 }

--- a/data/subclasses/echo_knight.json
+++ b/data/subclasses/echo_knight.json
@@ -36,7 +36,5 @@
         "description": "Create two echoes at once and regain an Unleash Incarnation use if you have none when rolling initiative."
       }
     ]
-  },
-  "choices": []
+  }
 }
-

--- a/data/subclasses/eldritch_knight.json
+++ b/data/subclasses/eldritch_knight.json
@@ -36,7 +36,5 @@
         "description": "After casting a spell, make one weapon attack as a bonus action."
       }
     ]
-  },
-  "choices": []
+  }
 }
-

--- a/data/subclasses/enchantment.json
+++ b/data/subclasses/enchantment.json
@@ -30,18 +30,5 @@
         "description": "Description for Alter Memories."
       }
     ]
-  },
-  "choices": [
-    {
-      "level": 2,
-      "name": "Enchantment Feature",
-      "description": "Choose an option for the Enchantment subclass",
-      "count": 1,
-      "selection": [
-        "Enchantment Option 1",
-        "Enchantment Option 2"
-      ],
-      "type": "Enchantment Feature"
-    }
-  ]
+  }
 }

--- a/data/subclasses/evocation.json
+++ b/data/subclasses/evocation.json
@@ -30,18 +30,5 @@
         "description": "Description for Overchannel."
       }
     ]
-  },
-  "choices": [
-    {
-      "level": 2,
-      "name": "Evocation Feature",
-      "description": "Choose an option for the Evocation subclass",
-      "count": 1,
-      "selection": [
-        "Evocation Option 1",
-        "Evocation Option 2"
-      ],
-      "type": "Evocation Feature"
-    }
-  ]
+  }
 }

--- a/data/subclasses/fathomless.json
+++ b/data/subclasses/fathomless.json
@@ -34,18 +34,5 @@
         "description": "Description for Fathomless Plunge."
       }
     ]
-  },
-  "choices": [
-    {
-      "level": 1,
-      "name": "The Fathomless Feature",
-      "description": "Choose an option for the The Fathomless subclass",
-      "count": 1,
-      "selection": [
-        "The Fathomless Option 1",
-        "The Fathomless Option 2"
-      ],
-      "type": "The Fathomless Feature"
-    }
-  ]
+  }
 }

--- a/data/subclasses/fiend.json
+++ b/data/subclasses/fiend.json
@@ -26,18 +26,5 @@
         "description": "Description for Hurl Through Hell."
       }
     ]
-  },
-  "choices": [
-    {
-      "level": 1,
-      "name": "The Fiend Feature",
-      "description": "Choose an option for the The Fiend subclass",
-      "count": 1,
-      "selection": [
-        "The Fiend Option 1",
-        "The Fiend Option 2"
-      ],
-      "type": "The Fiend Feature"
-    }
-  ]
+  }
 }

--- a/data/subclasses/forge.json
+++ b/data/subclasses/forge.json
@@ -36,18 +36,5 @@
         "description": "You are immune to fire damage and have resistance to nonmagical bludgeoning, piercing, and slashing damage while wearing heavy armor."
       }
     ]
-  },
-  "choices": [
-    {
-      "level": 1,
-      "name": "Forge Domain Feature",
-      "description": "Choose an option for the Forge Domain subclass",
-      "count": 1,
-      "selection": [
-        "Forge Domain Option 1",
-        "Forge Domain Option 2"
-      ],
-      "type": "Forge Domain Feature"
-    }
-  ]
+  }
 }

--- a/data/subclasses/four_elements.json
+++ b/data/subclasses/four_elements.json
@@ -30,18 +30,5 @@
         "description": "Learn a final elemental discipline, and you may replace one you know."
       }
     ]
-  },
-  "choices": [
-    {
-      "level": 3,
-      "name": "Way of the Four Elements Feature",
-      "description": "Choose an option for the Way of the Four Elements subclass",
-      "count": 1,
-      "selection": [
-        "Way of the Four Elements Option 1",
-        "Way of the Four Elements Option 2"
-      ],
-      "type": "Way of the Four Elements Feature"
-    }
-  ]
+  }
 }

--- a/data/subclasses/genie.json
+++ b/data/subclasses/genie.json
@@ -26,18 +26,5 @@
         "description": "Description for Limited Wish."
       }
     ]
-  },
-  "choices": [
-    {
-      "level": 1,
-      "name": "The Genie Feature",
-      "description": "Choose an option for the The Genie subclass",
-      "count": 1,
-      "selection": [
-        "The Genie Option 1",
-        "The Genie Option 2"
-      ],
-      "type": "The Genie Feature"
-    }
-  ]
+  }
 }

--- a/data/subclasses/giant.json
+++ b/data/subclasses/giant.json
@@ -30,18 +30,5 @@
         "description": "When you rage, your reach increases by 10 feet, your size can become Large or Huge, and Elemental Cleaver's extra damage becomes 2d6. Mighty Impel can move Large or smaller creatures."
       }
     ]
-  },
-  "choices": [
-    {
-      "level": 3,
-      "name": "Giant Feature",
-      "description": "Choose an option for the Giant subclass",
-      "count": 1,
-      "selection": [
-        "Giant Option 1",
-        "Giant Option 2"
-      ],
-      "type": "Giant Feature"
-    }
-  ]
+  }
 }

--- a/data/subclasses/glory.json
+++ b/data/subclasses/glory.json
@@ -15,7 +15,7 @@
     "7": [
       {
         "name": "Aura of Alacrity",
-        "description": "Your speed increases by 10 feet. Allies who start their turn within 5 feet of you gain a 10‑foot speed bonus until the end of that turn."
+        "description": "Your speed increases by 10 feet. Allies who start their turn within 5 feet of you gain a 10\u2011foot speed bonus until the end of that turn."
       }
     ],
     "15": [
@@ -30,19 +30,5 @@
         "description": "For 1 minute, gain advantage on Charisma checks, turn one missed weapon attack per turn into a hit, and reroll failed saving throws. Once per long rest or by expending a 5th-level spell slot."
       }
     ]
-  },
-  "choices": [
-    {
-      "level": 3,
-      "name": "Oath of Glory Feature",
-      "description": "Choose an option for the Oath of Glory subclass",
-      "count": 1,
-      "selection": [
-        "Oath of Glory Option 1",
-        "Oath of Glory Option 2"
-      ],
-      "type": "Oath of Glory Feature"
-    }
-  ]
+  }
 }
-

--- a/data/subclasses/grave.json
+++ b/data/subclasses/grave.json
@@ -36,18 +36,5 @@
         "description": "When an enemy dies within 60 feet, you or an ally within the same range regains hit points equal to the enemy's Hit Dice. Once per turn."
       }
     ]
-  },
-  "choices": [
-    {
-      "level": 1,
-      "name": "Grave Domain Feature",
-      "description": "Choose an option for the Grave Domain subclass",
-      "count": 1,
-      "selection": [
-        "Grave Domain Option 1",
-        "Grave Domain Option 2"
-      ],
-      "type": "Grave Domain Feature"
-    }
-  ]
+  }
 }

--- a/data/subclasses/great_old_one.json
+++ b/data/subclasses/great_old_one.json
@@ -26,18 +26,5 @@
         "description": "Description for Create Thrall."
       }
     ]
-  },
-  "choices": [
-    {
-      "level": 1,
-      "name": "The Great Old One Feature",
-      "description": "Choose an option for the The Great Old One subclass",
-      "count": 1,
-      "selection": [
-        "The Great Old One Option 1",
-        "The Great Old One Option 2"
-      ],
-      "type": "The Great Old One Feature"
-    }
-  ]
+  }
 }

--- a/data/subclasses/hexblade.json
+++ b/data/subclasses/hexblade.json
@@ -30,18 +30,5 @@
         "description": "Description for Master of Hexes."
       }
     ]
-  },
-  "choices": [
-    {
-      "level": 1,
-      "name": "The Hexblade Feature",
-      "description": "Choose an option for the The Hexblade subclass",
-      "count": 1,
-      "selection": [
-        "The Hexblade Option 1",
-        "The Hexblade Option 2"
-      ],
-      "type": "The Hexblade Feature"
-    }
-  ]
+  }
 }

--- a/data/subclasses/illusion.json
+++ b/data/subclasses/illusion.json
@@ -30,18 +30,5 @@
         "description": "Description for Illusory Reality."
       }
     ]
-  },
-  "choices": [
-    {
-      "level": 2,
-      "name": "Illusion Feature",
-      "description": "Choose an option for the Illusion subclass",
-      "count": 1,
-      "selection": [
-        "Illusion Option 1",
-        "Illusion Option 2"
-      ],
-      "type": "Illusion Feature"
-    }
-  ]
+  }
 }

--- a/data/subclasses/inquisitive.json
+++ b/data/subclasses/inquisitive.json
@@ -34,18 +34,5 @@
         "description": "While Insightful Fighting applies, your Sneak Attack against that creature deals an extra 3d6 damage."
       }
     ]
-  },
-  "choices": [
-    {
-      "level": 3,
-      "name": "Inquisitive Feature",
-      "description": "Choose an option for the Inquisitive subclass",
-      "count": 1,
-      "selection": [
-        "Inquisitive Option 1",
-        "Inquisitive Option 2"
-      ],
-      "type": "Inquisitive Feature"
-    }
-  ]
+  }
 }

--- a/data/subclasses/kensei.json
+++ b/data/subclasses/kensei.json
@@ -26,18 +26,5 @@
         "description": "If you miss with a monk weapon attack on your turn, reroll the attack roll once."
       }
     ]
-  },
-  "choices": [
-    {
-      "level": 3,
-      "name": "Way of the Kensei Feature",
-      "description": "Choose an option for the Way of the Kensei subclass",
-      "count": 1,
-      "selection": [
-        "Way of the Kensei Option 1",
-        "Way of the Kensei Option 2"
-      ],
-      "type": "Way of the Kensei Feature"
-    }
-  ]
+  }
 }

--- a/data/subclasses/knowledge.json
+++ b/data/subclasses/knowledge.json
@@ -32,18 +32,5 @@
         "description": "Meditate to receive dreamlike glimpses of past events related to an object you hold or your current surroundings."
       }
     ]
-  },
-  "choices": [
-    {
-      "level": 1,
-      "name": "Knowledge Domain Feature",
-      "description": "Choose an option for the Knowledge Domain subclass",
-      "count": 1,
-      "selection": [
-        "Knowledge Domain Option 1",
-        "Knowledge Domain Option 2"
-      ],
-      "type": "Knowledge Domain Feature"
-    }
-  ]
+  }
 }

--- a/data/subclasses/life.json
+++ b/data/subclasses/life.json
@@ -36,18 +36,5 @@
         "description": "When you roll dice to restore hit points, use the highest number possible for each die."
       }
     ]
-  },
-  "choices": [
-    {
-      "level": 1,
-      "name": "Life Domain Feature",
-      "description": "Choose an option for the Life Domain subclass",
-      "count": 1,
-      "selection": [
-        "Life Domain Option 1",
-        "Life Domain Option 2"
-      ],
-      "type": "Life Domain Feature"
-    }
-  ]
+  }
 }

--- a/data/subclasses/light.json
+++ b/data/subclasses/light.json
@@ -36,18 +36,5 @@
         "description": "As an action, emit bright light in a 60-foot radius for 1 minute. Enemies in the light have disadvantage on saving throws against fire or radiant spells."
       }
     ]
-  },
-  "choices": [
-    {
-      "level": 1,
-      "name": "Light Domain Feature",
-      "description": "Choose an option for the Light Domain subclass",
-      "count": 1,
-      "selection": [
-        "Light Domain Option 1",
-        "Light Domain Option 2"
-      ],
-      "type": "Light Domain Feature"
-    }
-  ]
+  }
 }

--- a/data/subclasses/long_death.json
+++ b/data/subclasses/long_death.json
@@ -26,18 +26,5 @@
         "description": "As an action, touch a creature and spend 1 to 10 ki points; the target takes 2d10 necrotic damage per ki point on a failed Constitution save, or half as much on a success."
       }
     ]
-  },
-  "choices": [
-    {
-      "level": 3,
-      "name": "Way of the Long Death Feature",
-      "description": "Choose an option for the Way of the Long Death subclass",
-      "count": 1,
-      "selection": [
-        "Way of the Long Death Option 1",
-        "Way of the Long Death Option 2"
-      ],
-      "type": "Way of the Long Death Feature"
-    }
-  ]
+  }
 }

--- a/data/subclasses/lunar_sorcery.json
+++ b/data/subclasses/lunar_sorcery.json
@@ -34,7 +34,5 @@
         "description": "Bonus action to unleash a phase power such as blinding light, necrotic gloom, or teleportation; usable once per long rest or by spending 5 sorcery points."
       }
     ]
-  },
-  "choices": []
+  }
 }
-

--- a/data/subclasses/mastermind.json
+++ b/data/subclasses/mastermind.json
@@ -30,18 +30,5 @@
         "description": "Your thoughts can't be read, you can present false thoughts, and magic can't compel you to tell the truth."
       }
     ]
-  },
-  "choices": [
-    {
-      "level": 3,
-      "name": "Mastermind Feature",
-      "description": "Choose an option for the Mastermind subclass",
-      "count": 1,
-      "selection": [
-        "Mastermind Option 1",
-        "Mastermind Option 2"
-      ],
-      "type": "Mastermind Feature"
-    }
-  ]
+  }
 }

--- a/data/subclasses/mercy.json
+++ b/data/subclasses/mercy.json
@@ -34,18 +34,5 @@
         "description": "As an action, spend 5 ki points to revive a creature that died within the last 24 hours, restoring hit points and removing certain conditions."
       }
     ]
-  },
-  "choices": [
-    {
-      "level": 3,
-      "name": "Way of Mercy Feature",
-      "description": "Choose an option for the Way of Mercy subclass",
-      "count": 1,
-      "selection": [
-        "Way of Mercy Option 1",
-        "Way of Mercy Option 2"
-      ],
-      "type": "Way of Mercy Feature"
-    }
-  ]
+  }
 }

--- a/data/subclasses/nature.json
+++ b/data/subclasses/nature.json
@@ -36,18 +36,5 @@
         "description": "While creatures are charmed by you, you can use a bonus action to verbally command them on their next turn."
       }
     ]
-  },
-  "choices": [
-    {
-      "level": 1,
-      "name": "Nature Domain Feature",
-      "description": "Choose an option for the Nature Domain subclass",
-      "count": 1,
-      "selection": [
-        "Nature Domain Option 1",
-        "Nature Domain Option 2"
-      ],
-      "type": "Nature Domain Feature"
-    }
-  ]
+  }
 }

--- a/data/subclasses/necromancy.json
+++ b/data/subclasses/necromancy.json
@@ -30,18 +30,5 @@
         "description": "Description for Command Undead."
       }
     ]
-  },
-  "choices": [
-    {
-      "level": 2,
-      "name": "Necromancy Feature",
-      "description": "Choose an option for the Necromancy subclass",
-      "count": 1,
-      "selection": [
-        "Necromancy Option 1",
-        "Necromancy Option 2"
-      ],
-      "type": "Necromancy Feature"
-    }
-  ]
+  }
 }

--- a/data/subclasses/oathbreaker.json
+++ b/data/subclasses/oathbreaker.json
@@ -15,34 +15,20 @@
     "7": [
       {
         "name": "Aura of Hate",
-        "description": "You and any fiends and undead within 10 feet gain a bonus to melee weapon damage rolls equal to your Charisma modifier." 
+        "description": "You and any fiends and undead within 10 feet gain a bonus to melee weapon damage rolls equal to your Charisma modifier."
       }
     ],
     "15": [
       {
         "name": "Supernatural Resistance",
-        "description": "You gain resistance to bludgeoning, piercing, and slashing damage from nonmagical weapons." 
+        "description": "You gain resistance to bludgeoning, piercing, and slashing damage from nonmagical weapons."
       }
     ],
     "20": [
       {
         "name": "Dread Lord",
-        "description": "As an action, for 1 minute an aura of gloom surrounds you. Frightened enemies in the aura take 4d10 psychic damage at the start of their turns, and you and chosen creatures are shrouded in darkness. You can use a bonus action to make a melee spell attack dealing 3d10 + your Charisma modifier necrotic damage. Once per long rest." 
+        "description": "As an action, for 1 minute an aura of gloom surrounds you. Frightened enemies in the aura take 4d10 psychic damage at the start of their turns, and you and chosen creatures are shrouded in darkness. You can use a bonus action to make a melee spell attack dealing 3d10 + your Charisma modifier necrotic damage. Once per long rest."
       }
     ]
-  },
-  "choices": [
-    {
-      "level": 3,
-      "name": "Oathbreaker Feature",
-      "description": "Choose an option for the Oathbreaker subclass",
-      "count": 1,
-      "selection": [
-        "Oathbreaker Option 1",
-        "Oathbreaker Option 2"
-      ],
-      "type": "Oathbreaker Feature"
-    }
-  ]
+  }
 }
-

--- a/data/subclasses/open_hand.json
+++ b/data/subclasses/open_hand.json
@@ -26,18 +26,5 @@
         "description": "Spend 3 ki points to set up lethal vibrations in a creature; later use an action to either reduce it to 0 hit points or deal 10d10 necrotic damage on a successful save."
       }
     ]
-  },
-  "choices": [
-    {
-      "level": 3,
-      "name": "Way of the Open Hand Feature",
-      "description": "Choose an option for the Way of the Open Hand subclass",
-      "count": 1,
-      "selection": [
-        "Way of the Open Hand Option 1",
-        "Way of the Open Hand Option 2"
-      ],
-      "type": "Way of the Open Hand Feature"
-    }
-  ]
+  }
 }

--- a/data/subclasses/order.json
+++ b/data/subclasses/order.json
@@ -36,18 +36,5 @@
         "description": "When you deal Divine Strike damage to a creature, you can curse it. The next ally to hit it deals an extra 2d8 psychic damage and the curse ends."
       }
     ]
-  },
-  "choices": [
-    {
-      "level": 1,
-      "name": "Order Domain Feature",
-      "description": "Choose an option for the Order Domain subclass",
-      "count": 1,
-      "selection": [
-        "Order Domain Option 1",
-        "Order Domain Option 2"
-      ],
-      "type": "Order Domain Feature"
-    }
-  ]
+  }
 }

--- a/data/subclasses/peace.json
+++ b/data/subclasses/peace.json
@@ -36,18 +36,5 @@
         "description": "Your bond and protective bond work within 60 feet, and the creature that takes another's damage has resistance to that damage."
       }
     ]
-  },
-  "choices": [
-    {
-      "level": 1,
-      "name": "Peace Domain Feature",
-      "description": "Choose an option for the Peace Domain subclass",
-      "count": 1,
-      "selection": [
-        "Peace Domain Option 1",
-        "Peace Domain Option 2"
-      ],
-      "type": "Peace Domain Feature"
-    }
-  ]
+  }
 }

--- a/data/subclasses/phantom.json
+++ b/data/subclasses/phantom.json
@@ -30,18 +30,5 @@
         "description": "Wails from the Grave damages both the first and second creature, and you gain a soul trinket at the end of a long rest if you have none."
       }
     ]
-  },
-  "choices": [
-    {
-      "level": 3,
-      "name": "Phantom Feature",
-      "description": "Choose an option for the Phantom subclass",
-      "count": 1,
-      "selection": [
-        "Phantom Option 1",
-        "Phantom Option 2"
-      ],
-      "type": "Phantom Feature"
-    }
-  ]
+  }
 }

--- a/data/subclasses/psi_warrior.json
+++ b/data/subclasses/psi_warrior.json
@@ -32,7 +32,5 @@
         "description": "Cast telekinesis without components and make a weapon attack as a bonus action while maintaining it."
       }
     ]
-  },
-  "choices": []
+  }
 }
-

--- a/data/subclasses/purple_dragon_knight.json
+++ b/data/subclasses/purple_dragon_knight.json
@@ -32,7 +32,5 @@
         "description": "When you use Action Surge, two allies can make attacks instead of one."
       }
     ]
-  },
-  "choices": []
+  }
 }
-

--- a/data/subclasses/redemption.json
+++ b/data/subclasses/redemption.json
@@ -30,19 +30,5 @@
         "description": "You have resistance to all damage from creatures, and whenever a creature hits you it takes radiant damage equal to half the damage you take, unless you harmed it."
       }
     ]
-  },
-  "choices": [
-    {
-      "level": 3,
-      "name": "Oath of Redemption Feature",
-      "description": "Choose an option for the Oath of Redemption subclass",
-      "count": 1,
-      "selection": [
-        "Oath of Redemption Option 1",
-        "Oath of Redemption Option 2"
-      ],
-      "type": "Oath of Redemption Feature"
-    }
-  ]
+  }
 }
-

--- a/data/subclasses/rune_knight.json
+++ b/data/subclasses/rune_knight.json
@@ -52,7 +52,5 @@
         "description": "Giant's Might extra damage becomes 1d10, you can grow to Huge size, and your reach increases by 5 feet."
       }
     ]
-  },
-  "choices": []
+  }
 }
-

--- a/data/subclasses/runechild.json
+++ b/data/subclasses/runechild.json
@@ -46,7 +46,5 @@
         "description": "Spend a charged rune to become pure magical energy, gaining flight, resistance to spell damage, healing when casting spells, and imposing disadvantage on saves against your spells."
       }
     ]
-  },
-  "choices": []
+  }
 }
-

--- a/data/subclasses/samurai.json
+++ b/data/subclasses/samurai.json
@@ -36,7 +36,5 @@
         "description": "Use your reaction to take an extra turn when reduced to 0 hit points, before falling unconscious."
       }
     ]
-  },
-  "choices": []
+  }
 }
-

--- a/data/subclasses/scout.json
+++ b/data/subclasses/scout.json
@@ -30,18 +30,5 @@
         "description": "When you take the Attack action, you can make one additional attack as a bonus action. Each attack can use Sneak Attack, but not against the same target more than once per turn."
       }
     ]
-  },
-  "choices": [
-    {
-      "level": 3,
-      "name": "Scout Feature",
-      "description": "Choose an option for the Scout subclass",
-      "count": 1,
-      "selection": [
-        "Scout Option 1",
-        "Scout Option 2"
-      ],
-      "type": "Scout Feature"
-    }
-  ]
+  }
 }

--- a/data/subclasses/shadow.json
+++ b/data/subclasses/shadow.json
@@ -26,18 +26,5 @@
         "description": "When a creature within 5 feet of you is hit by an attack made by another creature, use your reaction to make a melee attack against it."
       }
     ]
-  },
-  "choices": [
-    {
-      "level": 3,
-      "name": "Way of Shadow Feature",
-      "description": "Choose an option for the Way of Shadow subclass",
-      "count": 1,
-      "selection": [
-        "Way of Shadow Option 1",
-        "Way of Shadow Option 2"
-      ],
-      "type": "Way of Shadow Feature"
-    }
-  ]
+  }
 }

--- a/data/subclasses/shadow_magic.json
+++ b/data/subclasses/shadow_magic.json
@@ -30,7 +30,5 @@
         "description": "Spend 6 sorcery points to become shadowy for 1 minute, gaining resistance to all but force and radiant damage and the ability to move through creatures and objects."
       }
     ]
-  },
-  "choices": []
+  }
 }
-

--- a/data/subclasses/soulknife.json
+++ b/data/subclasses/soulknife.json
@@ -30,18 +30,5 @@
         "description": "When you deal Sneak Attack damage, force a Wisdom save or the target is stunned for 1 minute. Once per long rest or by expending three Psionic Energy dice."
       }
     ]
-  },
-  "choices": [
-    {
-      "level": 3,
-      "name": "Soulknife Feature",
-      "description": "Choose an option for the Soulknife subclass",
-      "count": 1,
-      "selection": [
-        "Soulknife Option 1",
-        "Soulknife Option 2"
-      ],
-      "type": "Soulknife Feature"
-    }
-  ]
+  }
 }

--- a/data/subclasses/storm_herald.json
+++ b/data/subclasses/storm_herald.json
@@ -26,18 +26,5 @@
         "description": "Your aura lashes out at foes with effects based on your environment, such as burning attackers or knocking enemies prone."
       }
     ]
-  },
-  "choices": [
-    {
-      "level": 3,
-      "name": "Storm Herald Feature",
-      "description": "Choose an option for the Storm Herald subclass",
-      "count": 1,
-      "selection": [
-        "Storm Herald Option 1",
-        "Storm Herald Option 2"
-      ],
-      "type": "Storm Herald Feature"
-    }
-  ]
+  }
 }

--- a/data/subclasses/storm_sorcery.json
+++ b/data/subclasses/storm_sorcery.json
@@ -34,7 +34,5 @@
         "description": "Gain immunity to lightning and thunder damage and a 60-foot flying speed; you can share a 30-foot flying speed with others for 1 hour."
       }
     ]
-  },
-  "choices": []
+  }
 }
-

--- a/data/subclasses/sun_soul.json
+++ b/data/subclasses/sun_soul.json
@@ -26,18 +26,5 @@
         "description": "You shed bright light in a 30-foot radius and can use your reaction to deal radiant damage equal to 5 + Wisdom modifier to creatures that hit you in melee."
       }
     ]
-  },
-  "choices": [
-    {
-      "level": 3,
-      "name": "Way of the Sun Soul Feature",
-      "description": "Choose an option for the Way of the Sun Soul subclass",
-      "count": 1,
-      "selection": [
-        "Way of the Sun Soul Option 1",
-        "Way of the Sun Soul Option 2"
-      ],
-      "type": "Way of the Sun Soul Feature"
-    }
-  ]
+  }
 }

--- a/data/subclasses/swashbuckler.json
+++ b/data/subclasses/swashbuckler.json
@@ -30,18 +30,5 @@
         "description": "If you miss with an attack, you can reroll it with advantage. Once used, this feature can't be used again until a short or long rest."
       }
     ]
-  },
-  "choices": [
-    {
-      "level": 3,
-      "name": "Swashbuckler Feature",
-      "description": "Choose an option for the Swashbuckler subclass",
-      "count": 1,
-      "selection": [
-        "Swashbuckler Option 1",
-        "Swashbuckler Option 2"
-      ],
-      "type": "Swashbuckler Feature"
-    }
-  ]
+  }
 }

--- a/data/subclasses/tempest.json
+++ b/data/subclasses/tempest.json
@@ -36,18 +36,5 @@
         "description": "You have a flying speed equal to your walking speed whenever you are not underground or indoors."
       }
     ]
-  },
-  "choices": [
-    {
-      "level": 1,
-      "name": "Tempest Domain Feature",
-      "description": "Choose an option for the Tempest Domain subclass",
-      "count": 1,
-      "selection": [
-        "Tempest Domain Option 1",
-        "Tempest Domain Option 2"
-      ],
-      "type": "Tempest Domain Feature"
-    }
-  ]
+  }
 }

--- a/data/subclasses/thief.json
+++ b/data/subclasses/thief.json
@@ -30,18 +30,5 @@
         "description": "Description for Thief's Reflexes."
       }
     ]
-  },
-  "choices": [
-    {
-      "level": 3,
-      "name": "Thief Feature",
-      "description": "Choose an option for the Thief subclass",
-      "count": 1,
-      "selection": [
-        "Thief Option 1",
-        "Thief Option 2"
-      ],
-      "type": "Thief Feature"
-    }
-  ]
+  }
 }

--- a/data/subclasses/totem_warrior.json
+++ b/data/subclasses/totem_warrior.json
@@ -30,18 +30,5 @@
         "description": "Gain a powerful ability based on a totem animal of your choice while raging, such as the bear's protection or the eagle's flight."
       }
     ]
-  },
-  "choices": [
-    {
-      "level": 3,
-      "name": "Totem Warrior Feature",
-      "description": "Choose an option for the Totem Warrior subclass",
-      "count": 1,
-      "selection": [
-        "Totem Warrior Option 1",
-        "Totem Warrior Option 2"
-      ],
-      "type": "Totem Warrior Feature"
-    }
-  ]
+  }
 }

--- a/data/subclasses/transmutation.json
+++ b/data/subclasses/transmutation.json
@@ -30,18 +30,5 @@
         "description": "Description for Master Transmuter."
       }
     ]
-  },
-  "choices": [
-    {
-      "level": 2,
-      "name": "Transmutation Feature",
-      "description": "Choose an option for the Transmutation subclass",
-      "count": 1,
-      "selection": [
-        "Transmutation Option 1",
-        "Transmutation Option 2"
-      ],
-      "type": "Transmutation Feature"
-    }
-  ]
+  }
 }

--- a/data/subclasses/trickery.json
+++ b/data/subclasses/trickery.json
@@ -32,18 +32,5 @@
         "description": "You can create up to four duplicates with Invoke Duplicity and move any number of them up to 30 feet each as a bonus action."
       }
     ]
-  },
-  "choices": [
-    {
-      "level": 1,
-      "name": "Trickery Domain Feature",
-      "description": "Choose an option for the Trickery Domain subclass",
-      "count": 1,
-      "selection": [
-        "Trickery Domain Option 1",
-        "Trickery Domain Option 2"
-      ],
-      "type": "Trickery Domain Feature"
-    }
-  ]
+  }
 }

--- a/data/subclasses/twilight.json
+++ b/data/subclasses/twilight.json
@@ -40,18 +40,5 @@
         "description": "Creatures in your Twilight Sanctuary have half cover."
       }
     ]
-  },
-  "choices": [
-    {
-      "level": 1,
-      "name": "Twilight Domain Feature",
-      "description": "Choose an option for the Twilight Domain subclass",
-      "count": 1,
-      "selection": [
-        "Twilight Domain Option 1",
-        "Twilight Domain Option 2"
-      ],
-      "type": "Twilight Domain Feature"
-    }
-  ]
+  }
 }

--- a/data/subclasses/undead.json
+++ b/data/subclasses/undead.json
@@ -26,18 +26,5 @@
         "description": "Description for Spirit Projection."
       }
     ]
-  },
-  "choices": [
-    {
-      "level": 1,
-      "name": "The Undead Feature",
-      "description": "Choose an option for the The Undead subclass",
-      "count": 1,
-      "selection": [
-        "The Undead Option 1",
-        "The Undead Option 2"
-      ],
-      "type": "The Undead Feature"
-    }
-  ]
+  }
 }

--- a/data/subclasses/undying.json
+++ b/data/subclasses/undying.json
@@ -26,18 +26,5 @@
         "description": "Description for Indestructible Life."
       }
     ]
-  },
-  "choices": [
-    {
-      "level": 1,
-      "name": "The Undying Feature",
-      "description": "Choose an option for the The Undying subclass",
-      "count": 1,
-      "selection": [
-        "The Undying Option 1",
-        "The Undying Option 2"
-      ],
-      "type": "The Undying Feature"
-    }
-  ]
+  }
 }

--- a/data/subclasses/vengeance.json
+++ b/data/subclasses/vengeance.json
@@ -27,21 +27,8 @@
     "20": [
       {
         "name": "Avenging Angel",
-        "description": "As an action, transform for 1 hour, gaining a 60‑foot fly speed and an aura that can frighten enemies within 30 feet."
+        "description": "As an action, transform for 1 hour, gaining a 60\u2011foot fly speed and an aura that can frighten enemies within 30 feet."
       }
     ]
-  },
-  "choices": [
-    {
-      "level": 3,
-      "name": "Oath of Vengeance Feature",
-      "description": "Choose an option for the Oath of Vengeance subclass",
-      "count": 1,
-      "selection": [
-        "Oath of Vengeance Option 1",
-        "Oath of Vengeance Option 2"
-      ],
-      "type": "Oath of Vengeance Feature"
-    }
-  ]
+  }
 }

--- a/data/subclasses/war.json
+++ b/data/subclasses/war.json
@@ -36,18 +36,5 @@
         "description": "You gain resistance to bludgeoning, piercing, and slashing damage from nonmagical attacks."
       }
     ]
-  },
-  "choices": [
-    {
-      "level": 1,
-      "name": "War Domain Feature",
-      "description": "Choose an option for the War Domain subclass",
-      "count": 1,
-      "selection": [
-        "War Domain Option 1",
-        "War Domain Option 2"
-      ],
-      "type": "War Domain Feature"
-    }
-  ]
+  }
 }

--- a/data/subclasses/watchers.json
+++ b/data/subclasses/watchers.json
@@ -9,40 +9,26 @@
       },
       {
         "name": "Abjure the Extraplanar",
-        "description": "Use Channel Divinity to turn aberrations, celestials, elementals, fey, and fiends within 30 feet for 1 minute." 
+        "description": "Use Channel Divinity to turn aberrations, celestials, elementals, fey, and fiends within 30 feet for 1 minute."
       }
     ],
     "7": [
       {
         "name": "Aura of the Sentinel",
-        "description": "You and creatures of your choice within 10 feet gain a bonus to initiative rolls equal to your proficiency bonus." 
+        "description": "You and creatures of your choice within 10 feet gain a bonus to initiative rolls equal to your proficiency bonus."
       }
     ],
     "15": [
       {
         "name": "Vigilant Rebuke",
-        "description": "When you or a creature within 30 feet succeeds on an Intelligence, Wisdom, or Charisma saving throw, use your reaction to deal 2d8 + your Charisma modifier force damage to the source." 
+        "description": "When you or a creature within 30 feet succeeds on an Intelligence, Wisdom, or Charisma saving throw, use your reaction to deal 2d8 + your Charisma modifier force damage to the source."
       }
     ],
     "20": [
       {
         "name": "Mortal Bulwark",
-        "description": "For 1 minute, you gain 120‑foot truesight, advantage on attacks against aberrations, celestials, elementals, fey, and fiends, and can attempt to banish them on a failed Charisma save. Once per long rest or by expending a 5th-level spell slot." 
+        "description": "For 1 minute, you gain 120\u2011foot truesight, advantage on attacks against aberrations, celestials, elementals, fey, and fiends, and can attempt to banish them on a failed Charisma save. Once per long rest or by expending a 5th-level spell slot."
       }
     ]
-  },
-  "choices": [
-    {
-      "level": 3,
-      "name": "Oath of the Watchers Feature",
-      "description": "Choose an option for the Oath of the Watchers subclass",
-      "count": 1,
-      "selection": [
-        "Oath of the Watchers Option 1",
-        "Oath of the Watchers Option 2"
-      ],
-      "type": "Oath of the Watchers Feature"
-    }
-  ]
+  }
 }
-

--- a/data/subclasses/wild_magic.json
+++ b/data/subclasses/wild_magic.json
@@ -30,7 +30,5 @@
         "description": "When you roll the highest number on a damage die for a spell, roll that die again and add it to the damage once per turn."
       }
     ]
-  },
-  "choices": []
+  }
 }
-

--- a/data/subclasses/zealot.json
+++ b/data/subclasses/zealot.json
@@ -30,18 +30,5 @@
         "description": "While raging, having 0 hit points doesn't knock you unconscious. You still make death saves and only die after your rage ends if you still have 0 hit points."
       }
     ]
-  },
-  "choices": [
-    {
-      "level": 3,
-      "name": "Zealot Feature",
-      "description": "Choose an option for the Zealot subclass",
-      "count": 1,
-      "selection": [
-        "Zealot Option 1",
-        "Zealot Option 2"
-      ],
-      "type": "Zealot Feature"
-    }
-  ]
+  }
 }


### PR DESCRIPTION
## Summary
- remove placeholder choice arrays from subclass data files
- keep only meaningful subclass feature selections

## Testing
- `rg '"choices"' -n data/subclasses | wc -l`
- `python3 -m http.server 8000` (via curl)


------
https://chatgpt.com/codex/tasks/task_e_68a4e6037890832e8fcdb96a01a4edf1