### PR TITLE
Remove starting equipment from class core traits

### DIFF
--- a/data/classes/artificer.json
+++ b/data/classes/artificer.json
@@ -20,18 +20,6 @@
   "weapon_proficiencies": ["simple weapons", "firearms"],
   "tool_proficiencies": ["thieves' tools", "tinker's tools", "one type of artisan's tools of your choice"],
   "armor_proficiencies": ["light armor", "medium armor", "shields"],
-  "starting_equipment": {
-    "choices": [
-      ["Studded leather armor", "Scale mail"]
-    ],
-    "fixed": [
-      "Any two simple weapons",
-      "Light crossbow and 20 bolts",
-      "Thieves' tools",
-      "Dungeoneer's pack"
-    ],
-    "gold_alternative": "5d4 × 10 gp"
-  },
   "multiclassing": {
     "prerequisites": {"Intelligence": 13},
     "proficiencies": {

--- a/data/classes/barbarian.json
+++ b/data/classes/barbarian.json
@@ -18,14 +18,6 @@
   },
   "weapon_proficiencies": ["simple weapons", "martial weapons"],
   "armor_proficiencies": ["light armor", "medium armor", "shields"],
-  "starting_equipment": {
-    "choices": [
-      ["Greataxe", "Any martial melee weapon"],
-      ["Two handaxes", "Any simple weapon"]
-    ],
-    "fixed": ["Explorer's pack", "Four javelins"],
-    "gold_alternative": "2d4 × 10 gp"
-  },
   "multiclassing": {
     "prerequisites": {"Strength": 13},
     "proficiencies": {

--- a/data/classes/bard.json
+++ b/data/classes/bard.json
@@ -31,15 +31,6 @@
   "weapon_proficiencies": ["simple weapons", "hand crossbows", "longswords", "rapiers", "shortswords"],
   "tool_proficiencies": ["three musical instruments of your choice"],
   "armor_proficiencies": ["light armor"],
-  "starting_equipment": {
-    "choices": [
-      ["Rapier", "Longsword", "Any simple weapon"],
-      ["Diplomat's pack", "Entertainer's pack"],
-      ["Lute", "Any other musical instrument"]
-    ],
-    "fixed": ["Leather armor", "Dagger"],
-    "gold_alternative": "5d4 × 10 gp"
-  },
   "multiclassing": {
     "prerequisites": {"Charisma": 13},
     "proficiencies": {

--- a/data/classes/cleric.json
+++ b/data/classes/cleric.json
@@ -11,16 +11,6 @@
   },
   "weapon_proficiencies": ["simple weapons"],
   "armor_proficiencies": ["light armor", "medium armor", "shields"],
-  "starting_equipment": {
-    "choices": [
-      ["Mace", "Warhammer (if proficient)"],
-      ["Scale mail", "Leather armor", "Chain mail (if proficient)"],
-      ["Light crossbow and 20 bolts", "Any simple weapon"],
-      ["Priest's pack", "Explorer's pack"]
-    ],
-    "fixed": ["Shield", "Holy symbol"],
-    "gold_alternative": "5d4 × 10 gp"
-  },
   "multiclassing": {
     "prerequisites": {"Wisdom": 13},
     "proficiencies": {"armor": ["light armor", "medium armor", "shields"]}

--- a/data/classes/druid.json
+++ b/data/classes/druid.json
@@ -32,14 +32,6 @@
   ],
   "tool_proficiencies": ["Herbalism kit"],
   "armor_proficiencies": ["light armor", "medium armor", "shields (non-metal)"],
-  "starting_equipment": {
-    "choices": [
-      ["Wooden shield", "Any simple weapon"],
-      ["Scimitar", "Any simple melee weapon"]
-    ],
-    "fixed": ["Leather armor", "Explorer's pack", "Druidic focus"],
-    "gold_alternative": "2d4 × 10 gp"
-  },
   "multiclassing": {
     "prerequisites": {"Wisdom": 13},
     "proficiencies": {"armor": ["light armor", "medium armor", "shields (non-metal)"]}

--- a/data/classes/fighter.json
+++ b/data/classes/fighter.json
@@ -20,16 +20,6 @@
   },
   "weapon_proficiencies": ["simple weapons", "martial weapons"],
   "armor_proficiencies": ["light armor", "medium armor", "heavy armor", "shields"],
-  "starting_equipment": {
-    "choices": [
-      ["Chain mail", "Leather armor, longbow, and 20 arrows"],
-      ["A martial weapon and a shield", "Two martial weapons"],
-      ["Light crossbow and 20 bolts", "Two handaxes"],
-      ["Dungeoneer's pack", "Explorer's pack"]
-    ],
-    "fixed": [],
-    "gold_alternative": "5d4 × 10 gp"
-  },
   "multiclassing": {
     "prerequisites": {"Strength": 13, "Dexterity": 13},
     "proficiencies": {

--- a/data/classes/monk.json
+++ b/data/classes/monk.json
@@ -18,14 +18,6 @@
   },
   "weapon_proficiencies": ["simple weapons", "shortswords"],
   "tool_proficiencies": ["one type of artisan's tools or one musical instrument"],
-  "starting_equipment": {
-    "choices": [
-      ["Shortsword", "Any simple weapon"],
-      ["Dungeoneer's pack", "Explorer's pack"]
-    ],
-    "fixed": ["10 darts"],
-    "gold_alternative": "5d4 gp"
-  },
   "multiclassing": {
     "prerequisites": {"Dexterity": 13, "Wisdom": 13},
     "proficiencies": {"weapons": ["simple weapons", "shortswords"]}

--- a/data/classes/paladin.json
+++ b/data/classes/paladin.json
@@ -11,15 +11,6 @@
   },
   "weapon_proficiencies": ["simple weapons", "martial weapons"],
   "armor_proficiencies": ["light armor", "medium armor", "heavy armor", "shields"],
-  "starting_equipment": {
-    "choices": [
-      ["A martial weapon and a shield", "Two martial weapons"],
-      ["Five javelins", "Any simple melee weapon"],
-      ["Priest's pack", "Explorer's pack"]
-    ],
-    "fixed": ["Chain mail", "Holy symbol"],
-    "gold_alternative": "5d4 × 10 gp"
-  },
   "multiclassing": {
     "prerequisites": {"Strength": 13, "Charisma": 13},
     "proficiencies": {

--- a/data/classes/ranger.json
+++ b/data/classes/ranger.json
@@ -20,15 +20,6 @@
   },
   "weapon_proficiencies": ["simple weapons", "martial weapons"],
   "armor_proficiencies": ["light armor", "medium armor", "shields"],
-  "starting_equipment": {
-    "choices": [
-      ["Scale mail", "Leather armor"],
-      ["Two shortswords", "Two simple melee weapons"],
-      ["Dungeoneer's pack", "Explorer's pack"]
-    ],
-    "fixed": ["Longbow", "Quiver of 20 arrows"],
-    "gold_alternative": "5d4 × 10 gp"
-  },
   "multiclassing": {
     "prerequisites": {"Dexterity": 13, "Wisdom": 13},
     "proficiencies": {

--- a/data/classes/rogue.json
+++ b/data/classes/rogue.json
@@ -24,15 +24,6 @@
   "weapon_proficiencies": ["simple weapons", "hand crossbows", "longswords", "rapiers", "shortswords"],
   "tool_proficiencies": ["thieves' tools"],
   "armor_proficiencies": ["light armor"],
-  "starting_equipment": {
-    "choices": [
-      ["Rapier", "Shortsword"],
-      ["Shortbow and quiver of 20 arrows", "Shortsword"],
-      ["Burglar's pack", "Dungeoneer's pack", "Explorer's pack"]
-    ],
-    "fixed": ["Leather armor", "Two daggers", "Thieves' tools"],
-    "gold_alternative": "4d4 × 10 gp"
-  },
   "multiclassing": {
     "prerequisites": {"Dexterity": 13},
     "proficiencies": {

--- a/data/classes/sorcerer.json
+++ b/data/classes/sorcerer.json
@@ -10,15 +10,6 @@
     "options": ["Arcana", "Deception", "Insight", "Intimidation", "Persuasion", "Religion"]
   },
   "weapon_proficiencies": ["daggers", "darts", "slings", "quarterstaffs", "light crossbows"],
-  "starting_equipment": {
-    "choices": [
-      ["Light crossbow and 20 bolts", "Any simple weapon"],
-      ["Component pouch", "Arcane focus"],
-      ["Dungeoneer's pack", "Explorer's pack"]
-    ],
-    "fixed": ["Two daggers"],
-    "gold_alternative": "3d4 × 10 gp"
-  },
   "multiclassing": {"prerequisites": {"Charisma": 13}},
   "subclasses": [
     {

--- a/data/classes/warlock.json
+++ b/data/classes/warlock.json
@@ -11,15 +11,6 @@
   },
   "weapon_proficiencies": ["simple weapons"],
   "armor_proficiencies": ["light armor"],
-  "starting_equipment": {
-    "choices": [
-      ["Light crossbow and 20 bolts", "Any simple weapon"],
-      ["Component pouch", "Arcane focus"],
-      ["Scholar's pack", "Dungeoneer's pack"]
-    ],
-    "fixed": ["Leather armor", "Any simple weapon", "Two daggers"],
-    "gold_alternative": "4d4 × 10 gp"
-  },
   "multiclassing": {
     "prerequisites": {"Charisma": 13},
     "proficiencies": {"weapons": ["simple weapons"], "armor": ["light armor"]}

--- a/data/classes/wizard.json
+++ b/data/classes/wizard.json
@@ -10,15 +10,6 @@
     "options": ["Arcana", "History", "Insight", "Investigation", "Medicine", "Religion"]
   },
   "weapon_proficiencies": ["daggers", "darts", "slings", "quarterstaffs", "light crossbows"],
-  "starting_equipment": {
-    "choices": [
-      ["Quarterstaff", "Dagger"],
-      ["Component pouch", "Arcane focus"],
-      ["Scholar's pack", "Explorer's pack"]
-    ],
-    "fixed": ["Spellbook"],
-    "gold_alternative": "4d4 × 10 gp"
-  },
   "multiclassing": {"prerequisites": {"Intelligence": 13}},
   "subclasses": [
     {

--- a/js/script.js
+++ b/js/script.js
@@ -1116,21 +1116,6 @@ async function renderClassFeatures() {
   if (data.skill_proficiencies && data.skill_proficiencies.choose) {
     html += `<p><strong>Skill Proficiencies:</strong> Choose ${data.skill_proficiencies.choose} from ${data.skill_proficiencies.options.join(", ")}</p>`;
   }
-  if (data.starting_equipment) {
-    let equipText = "";
-    if (Array.isArray(data.starting_equipment.fixed) && data.starting_equipment.fixed.length > 0) {
-      equipText += data.starting_equipment.fixed.join(", ");
-    }
-    if (Array.isArray(data.starting_equipment.choices)) {
-      data.starting_equipment.choices.forEach(choice => {
-        equipText += `; ${choice[0]} or ${choice[1]}`;
-      });
-    }
-    if (data.starting_equipment.gold_alternative) {
-      equipText += `; or ${data.starting_equipment.gold_alternative} to buy equipment`;
-    }
-    html += `<p><strong>Starting Equipment:</strong> ${equipText.replace(/^; /, "")}</p>`;
-  }
   if (data.multiclassing && data.multiclassing.prerequisites) {
     const prereqs = Object.entries(data.multiclassing.prerequisites)
       .map(([ability, score]) => `${ability} ${score}`)


### PR DESCRIPTION
## Summary
- drop starting equipment and starting gold data from each class definition
- strip starting equipment rendering from class details script

## Testing
- `npm test` *(fails: enoent package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a4e67b1a50832e904d9bbcba905b15