### PR TITLE
Enable class selection without early subclass choice

### DIFF
--- a/index.html
+++ b/index.html
@@ -104,6 +104,8 @@
         <div id="divineDomainSelection" style="display:none;"></div>
         <div id="metamagicSelection" style="display:none;"></div>
         <div id="abilityImprovementSelection" style="display:none;"></div>
+        <div id="skillSelectionContainer" style="display:none;"></div>
+        <div id="toolSelectionContainer" style="display:none;"></div>
         <div id="classExtrasAccordion" class="accordion"></div>
       </div>
       <!-- Step 3: Scelta della Razza -->

--- a/js/main.js
+++ b/js/main.js
@@ -82,11 +82,15 @@ document.addEventListener('DOMContentLoaded', () => {
   document.getElementById('confirmClassSelection').addEventListener('click', async () => {
     const classSelect = document.getElementById('classSelect');
     const subclassSelect = document.getElementById('subclassSelect');
+    const level = parseInt(document.getElementById('levelSelect')?.value) || 1;
     if (!classSelect.value) {
       alert('⚠️ Seleziona una classe prima di procedere!');
       return;
     }
-    if (subclassSelect.style.display !== 'none' && !subclassSelect.value) {
+    const className = classSelect.selectedOptions[0]?.text || '';
+    const subclassLevels = { Cleric: 1, Warlock: 1, Sorcerer: 1 };
+    const requiredLevel = subclassLevels[className] || 3;
+    if (subclassSelect.style.display !== 'none' && level >= requiredLevel && !subclassSelect.value) {
       alert('⚠️ Seleziona una sottoclasse prima di procedere!');
       return;
     }


### PR DESCRIPTION
## Summary
- Allow confirming class selection at low levels without forcing a subclass, unless required for certain classes
- Add containers for displaying chosen skill and tool proficiencies in the class step

## Testing
- `npm test` *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68a4e82e1f30832e8f47f56b579ff4d2