### PR TITLE
Fix equipment selection by class display name

### DIFF
--- a/js/step5.js
+++ b/js/step5.js
@@ -1,9 +1,16 @@
 // Step 5: Equipment selection
 let equipmentData = null;
 
+function getSelectedClassName() {
+  const sel = document.getElementById('classSelect');
+  return sel && sel.selectedOptions.length
+    ? sel.selectedOptions[0].text.trim().normalize('NFC')
+    : '';
+}
+
 function renderEquipment() {
   if (!equipmentData) return;
-  const className = document.getElementById('classSelect').value;
+  const className = getSelectedClassName();
   const level = parseInt(document.getElementById('levelSelect').value || '1', 10);
   const standardDiv = document.getElementById('standardEquipment');
   const classDiv = document.getElementById('classEquipmentChoices');
@@ -122,7 +129,7 @@ document.addEventListener('DOMContentLoaded', () => {
   const confirmBtn = document.getElementById('confirmEquipment');
   if (confirmBtn) {
     confirmBtn.addEventListener('click', () => {
-      const className = document.getElementById('classSelect').value;
+      const className = getSelectedClassName();
       const classInfo = equipmentData.classes[className] || { fixed: [] };
       const chosen = [];
       if (Array.isArray(classInfo.fixed)) chosen.push(...classInfo.fixed);


### PR DESCRIPTION
## Summary
- Use the selected class's display text when rendering and confirming equipment
- Normalize class name to ensure proper lookup in equipment data

## Testing
- `node <<'NODE' ... NODE`

------
https://chatgpt.com/codex/tasks/task_e_68a57b25d6cc832ebb6f6ca3f2df4677