### PR TITLE
Fix cleric starting equipment

### DIFF
--- a/data/equipment.json
+++ b/data/equipment.json
@@ -103,28 +103,6 @@
           "label": "Weapon",
           "type": "radio",
           "options": [
-            {
-              "value": "Quarterstaff",
-              "label": "Quarterstaff"
-            },
-            {
-              "value": "Dagger",
-              "label": "Dagger"
-            }
-          ]
-        },
-        {
-          "label": "Arcane focus",
-          "type": "radio",
-          "options": [
-            {
-              "value": "Component pouch",
-              "label": "Component pouch"
-            },
-            {
-              "value": "Arcane focus",
-              "label": "Arcane focus"
-            },
             { "value": "Mazza", "label": "Mazza" },
             { "value": "Martello da guerra", "label": "Martello da guerra" }
           ]
@@ -152,7 +130,6 @@
           "options": [
             { "value": "Pacchetto da sacerdote", "label": "Pacchetto da sacerdote" },
             { "value": "Pacchetto da esploratore", "label": "Pacchetto da esploratore" }
-
           ]
         }
       ]


### PR DESCRIPTION
## Summary
- Correct cleric starting weapon choices
- Remove incorrect arcane focus option

## Testing
- `node -e "JSON.parse(require('fs').readFileSync('data/equipment.json','utf8')); console.log('JSON valid');"`


------
https://chatgpt.com/codex/tasks/task_e_68a57b28fed0832eb842019c8baa2f11