### PR TITLE
Refactor accordion visibility and centralize step accordions

### DIFF
--- a/css/site-theme.css
+++ b/css/site-theme.css
@@ -84,11 +84,6 @@ h1, h2 {
   border-radius: 5px;
   box-shadow: 0 2px 5px rgba(0,0,0,0.1);
   margin-bottom: 20px;
-  display: none;
-}
-
-.step.active {
-  display: block;
 }
 
 label {
@@ -154,6 +149,10 @@ th {
   text-align: center;
 }
 
+.hidden {
+  display: none !important;
+}
+
 #stepContainer {
   max-width: 800px;
   margin: 0 auto;
@@ -169,8 +168,9 @@ th {
 
 /* Accordion styles */
 .accordion {
+  max-width: 700px;
   margin: 15px auto;
-  display: none;
+  display: block;
 }
 
 .accordion-item {
@@ -237,7 +237,6 @@ details.needs-selection.incomplete > summary {
 
 /* Modal styles for class details */
 .modal {
-  display: none;
   position: fixed;
   top: 0;
   left: 0;
@@ -247,9 +246,6 @@ details.needs-selection.incomplete > summary {
   justify-content: center;
   align-items: center;
   z-index: 1000;
-}
-
-.modal.show {
   display: flex;
 }
 

--- a/index.html
+++ b/index.html
@@ -78,19 +78,20 @@
       </select>
     </div>
       <!-- Step 2: Scelta della Classe e Sottoclasse -->
-      <div id="step2" class="step">
+      <div id="step2" class="step hidden">
         <h2>Step 2: Scelta della Classe e Sottoclasse</h2>
         <div id="classList" class="class-list"></div>
-        <label for="classSelect" style="display:none">Classe:</label>
-        <select id="classSelect" class="form-control" style="display:none">
+        <label for="classSelect" class="hidden">Classe:</label>
+        <select id="classSelect" class="form-control hidden">
           <option value="">Seleziona una classe</option>
         </select>
         <br>
         <div id="classFeatures"></div>
+        <div id="classExtrasAccordion" class="accordion hidden"></div>
         <button id="confirmClassSelection" class="btn btn-primary">Seleziona Classe</button>
       </div>
       <!-- Step 3: Scelta della Razza -->
-      <div id="step3" class="step">
+      <div id="step3" class="step hidden">
         <h2>Step 3: Scelta della Razza</h2>
         <label for="raceSelect">Razza:</label>
         <select id="raceSelect" class="form-control">
@@ -98,10 +99,11 @@
         </select>
         <br><br>
         <div id="raceTraits"></div>
+        <div id="raceExtraTraitsContainer" class="accordion hidden"></div>
         <button id="confirmRaceSelection" class="btn btn-primary">Seleziona Razza</button>
       </div>
       <!-- Step 4: Background -->
-      <div id="step4" class="step">
+      <div id="step4" class="step hidden">
         <h2>Step 4: Background</h2>
         <label for="backgroundSelect">Background:</label>
         <select id="backgroundSelect" class="form-control">
@@ -113,7 +115,7 @@
         <div id="backgroundFeat"></div>
       </div>
       <!-- Step 5: Equipaggiamento -->
-      <div id="step5" class="step">
+      <div id="step5" class="step hidden">
         <h2>Step 5: Equipaggiamento</h2>
         <div id="standardEquipment"></div>
         <div id="classEquipmentChoices"></div>
@@ -121,7 +123,7 @@
         <button id="confirmEquipment" class="btn btn-primary">Conferma Equipaggiamento</button>
       </div>
       <!-- Step 6: Sistema Point Buy -->
-      <div id="step6" class="step">
+      <div id="step6" class="step hidden">
         <h2>Step 6: Sistema Point Buy</h2>
         <p class="text-center"><strong>Total Points Remaining:</strong> <span id="pointsRemaining">27</span></p>
         <p class="text-center">Assegna i tuoi punti tra i punteggi di caratteristica (FOR, DES, COS, INT, SAG, CAR).</p>
@@ -243,7 +245,7 @@
         <input type="hidden" id="chaBackgroundTalent" value="0">
       </div>
       <!-- Step 7: Recap & Esportazione -->
-      <div id="step7" class="step">
+      <div id="step7" class="step hidden">
         <h2>Step 7: Recap & Esportazione</h2>
         <div id="finalRecap"></div>
         <button id="generateJson" class="btn btn-primary">Genera JSON</button>
@@ -251,7 +253,7 @@
   </div>
 
   <!-- Modal per i dettagli della classe -->
-  <div id="classModal" class="modal">
+  <div id="classModal" class="modal hidden">
     <div class="modal-content">
       <span id="closeClassModal" class="close">&times;</span>
       <div id="classModalDetails"></div>

--- a/js/main.js
+++ b/js/main.js
@@ -46,12 +46,12 @@ async function showClassModal(name, path) {
   } catch (e) {
     details.textContent = 'Errore caricando i dettagli della classe.';
   }
-  modal.classList.add('show');
+  modal.classList.remove('hidden');
 }
 
 function closeClassModal() {
   const modal = document.getElementById('classModal');
-  if (modal) modal.classList.remove('show');
+  if (modal) modal.classList.add('hidden');
 }
 
 document.addEventListener('DOMContentLoaded', () => {

--- a/js/script.js
+++ b/js/script.js
@@ -477,6 +477,7 @@ function openExtrasModal(selections, context = "race") {
   const containerId = context === "class" ? "classExtrasAccordion" : "raceExtraTraitsContainer";
   const container = document.getElementById(containerId);
   if (!container) return;
+  container.classList.remove('hidden');
 
   // Ensure categories exist in selectedData
   selections.forEach(selection => {
@@ -528,7 +529,6 @@ function openExtrasModal(selections, context = "race") {
   });
 
   initializeAccordion(container);
-  container.style.display = 'block';
   updateExtraSelectionsView();
 }
 
@@ -548,10 +548,10 @@ function updateExtraSelectionsView() {
 
     if (values.length > 0) {
       container.innerHTML = `<p><strong>${title}:</strong> ${values.join(", ")}</p>`;
-      container.style.display = "block";
+      container.classList.remove('hidden');
     } else {
       container.innerHTML = "";
-      container.style.display = "none";
+      container.classList.add('hidden');
     }
   }
 
@@ -567,7 +567,7 @@ function updateExtraSelectionsView() {
       updateContainer(id, title, key);
     } else {
       const container = document.getElementById(id);
-      if (container) container.style.display = "none";
+      if (container) container.classList.add('hidden');
     }
   });
 
@@ -666,7 +666,7 @@ function showExtraSelection() {
     closeModalEl.addEventListener("click", () => {
       console.log("🔄 Chiusura pop-up e aggiornamento UI...");
       const raceModal = document.getElementById("raceExtrasModal");
-      if (raceModal) raceModal.style.display = "none";
+      if (raceModal) raceModal.classList.add('hidden');
       sessionStorage.removeItem("popupOpened");
 
       // ✅ Salviamo le selezioni extra PRIMA di eventuali refresh
@@ -800,7 +800,7 @@ function displayRaceTraits() {
       }
 
       // Ancestry placeholder
-      traitsHtml += `<details class="race-trait needs-selection incomplete" id="ancestryTrait" style="display:none;"><summary>Ancestry</summary><div id="ancestrySelectionContainer"></div></details>`;
+      traitsHtml += `<details class="race-trait needs-selection incomplete hidden" id="ancestryTrait"><summary>Ancestry</summary><div id="ancestrySelectionContainer"></div></details>`;
 
       // Tables (rawEntries)
       const tablesHtml = renderTables(raceData.rawEntries);
@@ -830,7 +830,7 @@ function displayRaceTraits() {
       if (ancestryDetail) {
         const ancContainer = document.getElementById("ancestrySelectionContainer");
         if (ancContainer && ancContainer.innerHTML.trim() !== "") {
-          ancestryDetail.style.display = "block";
+          ancestryDetail.classList.remove('hidden');
         }
       }
 

--- a/js/ui.js
+++ b/js/ui.js
@@ -4,11 +4,9 @@ export function showStep(stepId) {
 
   const steps = document.querySelectorAll('.step');
   steps.forEach(step => {
-    if (step.id === stepId) {
-      step.classList.add('active');
-    } else {
-      step.classList.remove('active');
-    }
+    const isTarget = step.id === stepId;
+    step.classList.toggle('active', isTarget);
+    step.classList.toggle('hidden', !isTarget);
   });
 
   updateProgress(stepId);
@@ -67,7 +65,9 @@ export function resetForm() {
   });
   const steps = document.querySelectorAll('.step');
   steps.forEach((step, index) => {
-    step.classList.toggle('active', index === 0);
+    const show = index === 0;
+    step.classList.toggle('active', show);
+    step.classList.toggle('hidden', !show);
   });
   const progressBar = document.getElementById('progressBar');
   if (progressBar) progressBar.style.width = '0%';


### PR DESCRIPTION
## Summary
- Center accordions with a max-width and block display
- Introduce reusable `.hidden` class and remove CSS `display: none`
- Use `.hidden` toggling in JS to show steps and modals

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a57efc45e4832ebc66173d030bf159