### PR TITLE
feat: add modal selection for race, background, equipment

### DIFF
--- a/index.html
+++ b/index.html
@@ -93,11 +93,12 @@
       <!-- Step 3: Scelta della Razza -->
       <div id="step3" class="step hidden">
         <h2>Step 3: Scelta della Razza</h2>
-        <label for="raceSelect">Razza:</label>
-        <select id="raceSelect" class="form-control">
+        <div id="raceList" class="class-list"></div>
+        <label for="raceSelect" class="hidden">Razza:</label>
+        <select id="raceSelect" class="form-control hidden">
           <option value="">Seleziona una razza</option>
         </select>
-        <br><br>
+        <br>
         <div id="raceTraits"></div>
         <div id="raceExtraTraitsContainer" class="accordion hidden"></div>
         <button id="confirmRaceSelection" class="btn btn-primary">Seleziona Razza</button>
@@ -105,22 +106,22 @@
       <!-- Step 4: Background -->
       <div id="step4" class="step hidden">
         <h2>Step 4: Background</h2>
-        <label for="backgroundSelect">Background:</label>
-        <select id="backgroundSelect" class="form-control">
+        <div id="backgroundList" class="class-list"></div>
+        <label for="backgroundSelect" class="hidden">Background:</label>
+        <select id="backgroundSelect" class="form-control hidden">
           <option value="">Seleziona un background</option>
         </select>
         <div id="backgroundSkills"></div>
         <div id="backgroundTools"></div>
         <div id="backgroundLanguages"></div>
         <div id="backgroundFeat"></div>
+        <button id="confirmBackgroundSelection" class="btn btn-primary">Seleziona Background</button>
       </div>
       <!-- Step 5: Equipaggiamento -->
       <div id="step5" class="step hidden">
         <h2>Step 5: Equipaggiamento</h2>
-        <div id="standardEquipment"></div>
-        <div id="classEquipmentChoices"></div>
-        <div id="equipmentUpgrades"></div>
-        <button id="confirmEquipment" class="btn btn-primary">Conferma Equipaggiamento</button>
+        <div id="equipmentList" class="class-list"></div>
+        <button id="openEquipmentModal" class="btn btn-primary">Seleziona Equipaggiamento</button>
       </div>
       <!-- Step 6: Sistema Point Buy -->
       <div id="step6" class="step hidden">
@@ -258,6 +259,37 @@
       <span id="closeClassModal" class="close">&times;</span>
       <div id="classModalDetails"></div>
       <button id="addClassButton" class="btn btn-primary">Aggiungi Classe</button>
+    </div>
+  </div>
+
+  <!-- Modal per i dettagli della razza -->
+  <div id="raceModal" class="modal hidden">
+    <div class="modal-content">
+      <span id="closeRaceModal" class="close">&times;</span>
+      <div id="raceModalDetails"></div>
+      <button id="addRaceButton" class="btn btn-primary">Aggiungi Razza</button>
+    </div>
+  </div>
+
+  <!-- Modal per i dettagli del background -->
+  <div id="backgroundModal" class="modal hidden">
+    <div class="modal-content">
+      <span id="closeBackgroundModal" class="close">&times;</span>
+      <div id="backgroundModalDetails"></div>
+      <button id="addBackgroundButton" class="btn btn-primary">Aggiungi Background</button>
+    </div>
+  </div>
+
+  <!-- Modal per la selezione dell'equipaggiamento -->
+  <div id="equipmentModal" class="modal hidden">
+    <div class="modal-content">
+      <span id="closeEquipmentModal" class="close">&times;</span>
+      <div id="equipmentModalDetails">
+        <div id="standardEquipment"></div>
+        <div id="classEquipmentChoices"></div>
+        <div id="equipmentUpgrades"></div>
+        <button id="confirmEquipment" class="btn btn-primary">Conferma Equipaggiamento</button>
+      </div>
     </div>
   </div>
 </body>


### PR DESCRIPTION
## Summary
- add button-based race selection with modal details and confirmation
- enable background selection via modal and confirm step
- move equipment choices into a modal with summary display

## Testing
- `node --check js/main.js`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a5886ad14c832e9d9becb894c59be1