### PR TITLE
Align race selection UI with class accordion style

### DIFF
--- a/index.html
+++ b/index.html
@@ -100,7 +100,6 @@
         </select>
         <br>
         <div id="raceTraits"></div>
-        <div id="raceExtraTraitsContainer" class="accordion hidden"></div>
         <button id="confirmRaceSelection" class="btn btn-primary">Seleziona Razza</button>
       </div>
       <!-- Step 4: Background -->


### PR DESCRIPTION
## Summary
- Render race languages, skills, and tools using the same accordion layout as class selections
- Remove unused race extra traits container from the markup

## Testing
- `node --check js/script.js`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a5930f0384832e93f489f53a429788