### PR TITLE
Trigger equipment update after class selection

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -209,14 +209,7 @@ document.addEventListener('DOMContentLoaded', () => {
     const classSelect = document.getElementById('classSelect');
     if (classSelect) {
       classSelect.value = pendingClassPath;
-      classSelectionConfirmed = false;
-      if (window.selectedData) {
-        Object.keys(window.selectedData).forEach(k => delete window.selectedData[k]);
-        sessionStorage.setItem('selectedData', JSON.stringify(window.selectedData));
-      }
-      updateSubclasses();
-      const confirmBtn = document.getElementById('confirmClassSelection');
-      if (confirmBtn) confirmBtn.style.display = 'inline-block';
+      classSelect.dispatchEvent(new Event('change'));
     }
     closeClassModal();
   });


### PR DESCRIPTION
## Summary
- trigger class select change event when class chosen from modal so equipment options refresh

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a59381e69c832ebf502209c07e9a1a