### PR TITLE
refactor: centralize character selection state

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -9,6 +9,7 @@ import {
   setAvailableLanguages,
   renderFinalRecap
 } from './script.js';
+import { getSelectedData, resetSelectedData } from './state.js';
 import './step4.js';
 import './step5.js';
 import './step7.js';
@@ -127,10 +128,7 @@ document.addEventListener('DOMContentLoaded', () => {
   if (classSelectElem)
     classSelectElem.addEventListener('change', () => {
       classSelectionConfirmed = false;
-      if (window.selectedData) {
-        Object.keys(window.selectedData).forEach(k => delete window.selectedData[k]);
-        sessionStorage.setItem('selectedData', JSON.stringify(window.selectedData));
-      }
+      resetSelectedData();
       const confirmBtn = document.getElementById('confirmClassSelection');
       if (confirmBtn) confirmBtn.style.display = 'inline-block';
       updateSubclasses();
@@ -238,7 +236,7 @@ document.addEventListener('DOMContentLoaded', () => {
   document.getElementById('confirmEquipment').addEventListener('click', () => {
     closeEquipmentModal();
     const list = document.getElementById('equipmentList');
-    const eq = window.selectedData?.equipment;
+    const eq = getSelectedData().equipment;
     if (list && eq) {
       const items = [...(eq.standard || []), ...(eq.class || []), ...(eq.upgrades || [])];
       list.innerHTML = items.length

--- a/js/script.js
+++ b/js/script.js
@@ -1,6 +1,7 @@
 import { loadLanguages, handleError, renderTables } from './common.js';
 import { loadSpells, filterSpells, handleSpellcasting } from './spellcasting.js';
 import { convertRaceData } from './raceData.js';
+import { getSelectedData, setSelectedData, saveSelectedData } from './state.js';
 
 // ==================== MAPPING PER LE EXTRA VARIANT FEATURES ====================
 const variantExtraMapping = {
@@ -289,10 +290,7 @@ function gatherRaceTraitSelections() {
 // ==================== POPUP FOR EXTRA SELECTIONS ====================
 
 // Global variables for the extra selections popup
-let selectedData = sessionStorage.getItem("selectedData")
-  ? JSON.parse(sessionStorage.getItem("selectedData"))
-  : {};
-window.selectedData = selectedData;
+let selectedData = getSelectedData();
 
 // These variables are referenced throughout the extra selections workflow.
 // In earlier refactors they were implicitly assumed to exist which caused
@@ -425,7 +423,7 @@ function saveFeatureSelection(select) {
   if (!feature) return;
   if (!selectedData[feature]) selectedData[feature] = [];
   selectedData[feature][index] = select.value || undefined;
-  sessionStorage.setItem('selectedData', JSON.stringify(selectedData));
+  saveSelectedData();
 }
 
 function convertDetailsToAccordion(container) {
@@ -551,7 +549,7 @@ function openExtrasModal(selections, context = "race") {
           selectedData[category] = [];
         }
         selectedData[category][index] = e.target.value;
-        sessionStorage.setItem("selectedData", JSON.stringify(selectedData));
+        saveSelectedData();
         updateExtraSelectionsView();
       });
     }
@@ -567,10 +565,8 @@ function openExtrasModal(selections, context = "race") {
 function updateExtraSelectionsView() {
   console.log("🔄 Recupero selezioni extra salvate...");
 
-  // ✅ Assicuriamoci di recuperare i dati dallo storage
-  selectedData = sessionStorage.getItem("selectedData")
-    ? JSON.parse(sessionStorage.getItem("selectedData"))
-    : selectedData;
+  // ✅ Recupera i dati attuali dallo stato
+  selectedData = getSelectedData();
 
   function updateContainer(id, title, dataKey) {
     const container = document.getElementById(id);
@@ -655,7 +651,7 @@ function showExtraSelection() {
 
         console.log(`📝 Salvato: ${category} -> ${selectedData[category]}`);
 
-        sessionStorage.setItem("selectedData", JSON.stringify(selectedData));
+        saveSelectedData();
         updateExtraSelectionsView();
       });
     });
@@ -702,7 +698,7 @@ function showExtraSelection() {
       sessionStorage.removeItem("popupOpened");
 
       // ✅ Salviamo le selezioni extra PRIMA di eventuali refresh
-      sessionStorage.setItem("selectedData", JSON.stringify(selectedData));
+      saveSelectedData();
       console.log("📝 Selezioni salvate prima dell'update:", selectedData);
 
       if (extraModalContext === "race") {
@@ -728,7 +724,8 @@ updateExtraSelectionsView();
 
 document.getElementById("raceSelect").addEventListener("change", () => {
   console.log("🔄 Razza cambiata, reset delle selezioni extra...");
-  selectedData = {}; // Reset delle selezioni extra
+  setSelectedData({}); // Reset delle selezioni extra
+  selectedData = getSelectedData();
   document.getElementById("languageSelection").innerHTML = "";
   document.getElementById("skillSelectionContainer").innerHTML = "";
   document.getElementById("toolSelectionContainer").innerHTML = "";
@@ -1159,9 +1156,7 @@ function renderFinalRecap() {
   const recapDiv = document.getElementById("finalRecap");
   if (!recapDiv) return;
 
-  selectedData = sessionStorage.getItem("selectedData")
-    ? JSON.parse(sessionStorage.getItem("selectedData"))
-    : selectedData;
+  selectedData = getSelectedData();
   const userName = document.getElementById("userName")?.value || "";
   const characterName = document.getElementById("characterName")?.value || "";
   const className = document.getElementById("classSelect").selectedOptions[0]?.text || "";

--- a/js/state.js
+++ b/js/state.js
@@ -1,0 +1,21 @@
+let selectedData = sessionStorage.getItem('selectedData')
+  ? JSON.parse(sessionStorage.getItem('selectedData'))
+  : {};
+
+export function getSelectedData() {
+  return selectedData;
+}
+
+export function setSelectedData(data) {
+  selectedData = data;
+  saveSelectedData();
+}
+
+export function saveSelectedData() {
+  sessionStorage.setItem('selectedData', JSON.stringify(selectedData));
+}
+
+export function resetSelectedData() {
+  selectedData = {};
+  saveSelectedData();
+}

--- a/js/step5.js
+++ b/js/step5.js
@@ -1,3 +1,4 @@
+import { getSelectedData, saveSelectedData } from './state.js';
 // Step 5: Equipment selection
 let equipmentData = null;
 
@@ -111,10 +112,6 @@ document.addEventListener('DOMContentLoaded', () => {
   const step = document.getElementById('step5');
   if (!step) return;
 
-  if (!window.selectedData) {
-    window.selectedData = {};
-  }
-
   fetch('data/equipment.json')
     .then(r => r.json())
     .then(data => {
@@ -140,12 +137,13 @@ document.addEventListener('DOMContentLoaded', () => {
       document
         .querySelectorAll('#equipmentUpgrades input:checked')
         .forEach(el => upgrades.push(el.value));
-      window.selectedData.equipment = {
+      const selectedData = getSelectedData();
+      selectedData.equipment = {
         standard: equipmentData.standard,
         class: chosen,
         upgrades: upgrades
       };
-      sessionStorage.setItem('selectedData', JSON.stringify(window.selectedData));
+      saveSelectedData();
     });
   }
 });


### PR DESCRIPTION
## Summary
- add `state.js` module managing character selection data
- update scripts to use state getters/setters instead of `window.selectedData`
- clear selections via module to avoid accidental global mutations

## Testing
- `npm test` *(fails: ENOENT package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a59b29e5dc832e8d748b8177530c6a