### PR TITLE
refactor: safer DOM construction for modals and features

### DIFF
--- a/js/domHelpers.js
+++ b/js/domHelpers.js
@@ -1,0 +1,21 @@
+export function createHeader(text, level = 3) {
+  const header = document.createElement(`h${level}`);
+  header.textContent = text;
+  return header;
+}
+
+export function createParagraph(text) {
+  const p = document.createElement('p');
+  p.textContent = text;
+  return p;
+}
+
+export function createList(items, ordered = false) {
+  const list = document.createElement(ordered ? 'ol' : 'ul');
+  items.forEach(item => {
+    const li = document.createElement('li');
+    li.textContent = item;
+    list.appendChild(li);
+  });
+  return list;
+}

--- a/js/main.js
+++ b/js/main.js
@@ -1,5 +1,6 @@
 import { showStep, loadFormData } from './ui.js';
 import { loadDropdownData, loadLanguages, renderEntityList } from './common.js';
+import { createHeader, createParagraph } from './domHelpers.js';
 import {
   updateSubclasses,
   renderClassFeatures,
@@ -35,7 +36,8 @@ async function showRaceModal(name, path) {
   try {
     const res = await fetch(path);
     const data = await res.json();
-    details.innerHTML = `<h3>${data.name}</h3>`;
+    details.textContent = '';
+    details.appendChild(createHeader(data.name, 3));
   } catch (e) {
     details.textContent = 'Errore caricando i dettagli della razza.';
   }
@@ -59,9 +61,14 @@ async function showBackgroundModal(name, path) {
   try {
     const res = await fetch(path);
     const data = await res.json();
-    const skills = data.skills ? `<p><strong>Abilità:</strong> ${data.skills.join(', ')}</p>` : '';
-    const tools = data.tools && data.tools.length ? `<p><strong>Strumenti:</strong> ${data.tools.join(', ')}</p>` : '';
-    details.innerHTML = `<h3>${data.name}</h3>${skills}${tools}`;
+    details.textContent = '';
+    details.appendChild(createHeader(data.name, 3));
+    if (data.skills) {
+      details.appendChild(createParagraph(`Abilità: ${data.skills.join(', ')}`));
+    }
+    if (data.tools && data.tools.length) {
+      details.appendChild(createParagraph(`Strumenti: ${data.tools.join(', ')}`));
+    }
   } catch (e) {
     details.textContent = 'Errore caricando i dettagli del background.';
   }
@@ -91,7 +98,11 @@ async function showClassModal(name, path) {
   try {
     const res = await fetch(path);
     const data = await res.json();
-    details.innerHTML = `<h3>${data.name}</h3><p>${data.description}</p><p><strong>Hit Die:</strong> ${data.hit_die}</p><p><strong>Saving Throws:</strong> ${data.saving_throws.join(', ')}</p>`;
+    details.textContent = '';
+    details.appendChild(createHeader(data.name, 3));
+    details.appendChild(createParagraph(data.description));
+    details.appendChild(createParagraph(`Hit Die: ${data.hit_die}`));
+    details.appendChild(createParagraph(`Saving Throws: ${data.saving_throws.join(', ')}`));
   } catch (e) {
     details.textContent = 'Errore caricando i dettagli della classe.';
   }


### PR DESCRIPTION
## Summary
- add reusable DOM templating helpers for headers, paragraphs and lists
- render race, class and background modals using DOM nodes instead of innerHTML
- rebuild race and class feature sections with document.createElement and textContent for safer injection-free rendering

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a59c62cb50832e8e8cc861474d8019