### PR TITLE
Refactor fetch calls to async/await with error handling

### DIFF
--- a/js/common.js
+++ b/js/common.js
@@ -3,22 +3,24 @@
 // -------------------------
 // Caricamento dati e popolamento dropdown
 // -------------------------
-export function loadDropdownData(jsonPath, selectId, key) {
-  fetch(jsonPath)
-    .then(response => response.json())
-    .then(data => {
-      console.log(`📜 Dati ricevuti da ${jsonPath}:`, data);
-      if (!data[key]) {
-        handleError(`Chiave ${key} non trovata in ${jsonPath}`);
-        return;
-      }
-      const options = Object.keys(data[key]).map(name => ({
-        name: name,
-        path: data[key][name]
-      }));
-      populateDropdown(selectId, options);
-    })
-    .catch(error => handleError(`Errore caricando ${jsonPath}: ${error}`));
+export async function loadDropdownData(jsonPath, selectId, key) {
+  try {
+    const response = await fetch(jsonPath);
+    if (!response.ok) throw new Error('Network response was not ok');
+    const data = await response.json();
+    console.log(`📜 Dati ricevuti da ${jsonPath}:`, data);
+    if (!data[key]) {
+      handleError(`Chiave ${key} non trovata in ${jsonPath}`);
+      return;
+    }
+    const options = Object.keys(data[key]).map(name => ({
+      name: name,
+      path: data[key][name]
+    }));
+    populateDropdown(selectId, options);
+  } catch (error) {
+    handleError(`Errore caricando ${jsonPath}: ${error}`);
+  }
 }
 
 export function populateDropdown(selectId, options) {
@@ -42,6 +44,7 @@ export function populateDropdown(selectId, options) {
 export async function renderEntityList(jsonPath, key, containerId, modalFn) {
   try {
     const res = await fetch(jsonPath);
+    if (!res.ok) throw new Error('Network response was not ok');
     const data = await res.json();
     if (!data[key]) {
       handleError(`Chiave ${key} non trovata in ${jsonPath}`);
@@ -67,17 +70,19 @@ export async function renderEntityList(jsonPath, key, containerId, modalFn) {
 // -------------------------
 // Funzione per caricare le lingue da un file JSON
 // -------------------------
-export function loadLanguages(callback) {
-  fetch("data/languages.json")
-    .then(response => response.json())
-    .then(data => {
-      if (data.languages) {
-        callback(data.languages);
-      } else {
-        handleError("Nessuna lingua trovata nel file JSON.");
-      }
-    })
-    .catch(error => handleError(`Errore caricando le lingue: ${error}`));
+export async function loadLanguages(callback) {
+  try {
+    const response = await fetch("data/languages.json");
+    if (!response.ok) throw new Error('Failed to load languages');
+    const data = await response.json();
+    if (data.languages) {
+      callback(data.languages);
+    } else {
+      handleError("Nessuna lingua trovata nel file JSON.");
+    }
+  } catch (error) {
+    handleError(`Errore caricando le lingue: ${error}`);
+  }
 }
 
 // -------------------------

--- a/js/main.js
+++ b/js/main.js
@@ -35,6 +35,7 @@ async function showRaceModal(name, path) {
   if (!modal || !details) return;
   try {
     const res = await fetch(path);
+    if (!res.ok) throw new Error('Network response was not ok');
     const data = await res.json();
     details.textContent = '';
     details.appendChild(createHeader(data.name, 3));
@@ -60,6 +61,7 @@ async function showBackgroundModal(name, path) {
   if (!modal || !details) return;
   try {
     const res = await fetch(path);
+    if (!res.ok) throw new Error('Network response was not ok');
     const data = await res.json();
     details.textContent = '';
     details.appendChild(createHeader(data.name, 3));
@@ -97,6 +99,7 @@ async function showClassModal(name, path) {
   if (!modal || !details) return;
   try {
     const res = await fetch(path);
+    if (!res.ok) throw new Error('Network response was not ok');
     const data = await res.json();
     details.textContent = '';
     details.appendChild(createHeader(data.name, 3));

--- a/js/script.js
+++ b/js/script.js
@@ -738,7 +738,7 @@ document.getElementById("raceSelect").addEventListener("change", () => {
 
 
 // ==================== DISPLAY DEI TRATTI DELLA RAZZA ====================
-function displayRaceTraits() {
+async function displayRaceTraits() {
   console.log("🛠 Esecuzione displayRaceTraits()...");
   const racePath = document.getElementById("raceSelect").value;
   const raceTraitsDiv = document.getElementById("raceTraits");
@@ -754,13 +754,14 @@ function displayRaceTraits() {
   }
 
   console.log(`📜 Caricamento tratti per ${racePath}...`);
-  fetch(racePath)
-    .then(response => response.json())
-    .then(data => {
-      console.log("📜 Dati razza caricati:", data);
-      const raceData = convertRaceData(data);
-      raceTraitsDiv.textContent = '';
-      raceTraitsDiv.appendChild(createHeader(`Tratti di ${raceData.name}`, 3));
+  try {
+    const response = await fetch(racePath);
+    if (!response.ok) throw new Error('Network response was not ok');
+    const data = await response.json();
+    console.log("📜 Dati razza caricati:", data);
+    const raceData = convertRaceData(data);
+    raceTraitsDiv.textContent = '';
+    raceTraitsDiv.appendChild(createHeader(`Tratti di ${raceData.name}`, 3));
 
       // Speed
       let speedText = 'Velocità: Non disponibile';
@@ -949,12 +950,13 @@ function displayRaceTraits() {
 
       resetRacialBonuses();
       window.currentRaceData = raceData;
-    })
-    .catch(error => handleError(`Errore caricando i tratti della razza: ${error}`));
+  } catch (error) {
+    handleError(`Errore caricando i tratti della razza: ${error}`);
+  }
 }
 
 // ==================== UPDATE SUBCLASSES (STEP 5) ====================
-function updateSubclasses() {
+async function updateSubclasses() {
   const classPath = document.getElementById("classSelect").value;
   const featuresDiv = document.getElementById("classFeatures");
   if (!classPath) {
@@ -965,13 +967,15 @@ function updateSubclasses() {
     }
     return;
   }
-  fetch(classPath)
-    .then(response => response.json())
-    .then(data => {
-      window.currentClassData = data;
-      renderClassFeatures();
-    })
-    .catch(error => handleError(`Errore caricando le sottoclasse: ${error}`));
+  try {
+    const response = await fetch(classPath);
+    if (!response.ok) throw new Error('Network response was not ok');
+    const data = await response.json();
+    window.currentClassData = data;
+    renderClassFeatures();
+  } catch (error) {
+    handleError(`Errore caricando le sottoclasse: ${error}`);
+  }
 }
 
 function getSubclassFilename(name) {
@@ -1122,6 +1126,7 @@ async function renderClassFeatures() {
     try {
       const file = getSubclassFilename(subclassName);
       const resp = await fetch(`data/subclasses/${file}`);
+      if (!resp.ok) throw new Error('Network response was not ok');
       subData = await resp.json();
       if (subData.description) {
         featuresDiv.appendChild(createParagraph(subData.description));

--- a/js/spellcasting.js
+++ b/js/spellcasting.js
@@ -1,11 +1,13 @@
-export function loadSpells(callback) {
-  fetch('data/spells.json')
-    .then(response => response.json())
-    .then(data => {
-      console.log('📖 Spells loaded:', data);
-      callback(data);
-    })
-    .catch(error => console.error('❌ Error loading spells:', error));
+export async function loadSpells(callback) {
+  try {
+    const response = await fetch('data/spells.json');
+    if (!response.ok) throw new Error('Failed to load spells');
+    const data = await response.json();
+    console.log('📖 Spells loaded:', data);
+    callback(data);
+  } catch (error) {
+    console.error('❌ Error loading spells:', error);
+  }
 }
 
 export function filterSpells(spells, filterString) {

--- a/js/step4.js
+++ b/js/step4.js
@@ -49,21 +49,30 @@ function applyFeatAbilityChoices() {
   updateFinalScores();
 }
 
-document.addEventListener("DOMContentLoaded", () => {
+document.addEventListener("DOMContentLoaded", async () => {
   const step = document.getElementById("step4");
   if (!step) return;
 
   window.backgroundData = { name: "", skills: [], tools: [], languages: [], feat: "" };
 
   loadDropdownData("data/backgrounds.json", "backgroundSelect", "backgrounds");
-  fetch("data/feats.json").then(r => r.json()).then(d => { featPathIndex = d.feats || {}; });
+  try {
+    const resp = await fetch("data/feats.json");
+    if (!resp.ok) throw new Error('Failed to load feats');
+    const d = await resp.json();
+    featPathIndex = d.feats || {};
+  } catch (err) {
+    console.error("Errore caricando i talenti:", err);
+  }
 
   document.getElementById("backgroundSelect").addEventListener("change", async e => {
     const val = e.target.value;
     if (!val) return;
-    const res = await fetch(val);
-    const data = await res.json();
-    backgroundData.name = data.name;
+    try {
+      const res = await fetch(val);
+      if (!res.ok) throw new Error('Network response was not ok');
+      const data = await res.json();
+      backgroundData.name = data.name;
 
     const skillDiv = document.getElementById("backgroundSkills");
     skillDiv.innerHTML = "";
@@ -95,127 +104,128 @@ document.addEventListener("DOMContentLoaded", () => {
         }
       );
     }
-    skillDiv.appendChild(skillDetails);
-    initFeatureSelectionHandlers(skillDiv);
-    makeAccordion(skillDiv);
+      skillDiv.appendChild(skillDetails);
+      initFeatureSelectionHandlers(skillDiv);
+      makeAccordion(skillDiv);
 
-    const toolDiv = document.getElementById("backgroundTools");
-    toolDiv.innerHTML = "";
-    const toolDetails = document.createElement("details");
-    toolDetails.className = "feature-block";
-    toolDetails.innerHTML = "<summary>Strumenti</summary>";
-    backgroundData.tools = Array.isArray(data.tools) ? data.tools.slice() : [];
-    if (Array.isArray(data.tools) && data.tools.length > 0) {
-      const p = document.createElement("p");
-      p.innerHTML = `<strong>Strumenti:</strong> ${data.tools.join(", ")}`;
-      toolDetails.appendChild(p);
-    }
-    const toolChangeHandler = () => {
-      const chosen = Array.from(document.querySelectorAll(".backgroundToolChoice"))
-        .map(s => s.value)
-        .filter(Boolean);
-      const base = Array.isArray(data.tools) ? data.tools.slice() : [];
-      backgroundData.tools = base.concat(chosen);
-    };
-    if (data.tools && data.tools.choose) {
-      const num = data.tools.choose;
-      const opts = data.tools.options || [];
-      const p = document.createElement("p");
-      p.innerHTML = `<strong>Scegli ${num} strumento:</strong>`;
-      toolDetails.appendChild(p);
-      buildChoiceSelectors(toolDetails, num, opts, "backgroundToolChoice", toolChangeHandler);
-    }
-    if (data.toolChoices) {
-      const num = data.toolChoices.choose || 0;
-      const opts = data.toolChoices.options || [];
-      const p = document.createElement("p");
-      p.innerHTML = `<strong>Scegli ${num} strumento:</strong>`;
-      toolDetails.appendChild(p);
-      buildChoiceSelectors(toolDetails, num, opts, "backgroundToolChoice", toolChangeHandler);
-    }
-    toolDiv.appendChild(toolDetails);
-    initFeatureSelectionHandlers(toolDiv);
-    makeAccordion(toolDiv);
-
-    const langDiv = document.getElementById("backgroundLanguages");
-    langDiv.innerHTML = "";
-    const langDetails = document.createElement("details");
-    langDetails.className = "feature-block";
-    langDetails.innerHTML = "<summary>Linguaggi</summary>";
-    backgroundData.languages = Array.isArray(data.languages) ? data.languages.slice() : [];
-    if (Array.isArray(data.languages) && data.languages.length > 0) {
-      const p = document.createElement("p");
-      p.innerHTML = `<strong>Linguaggi:</strong> ${data.languages.join(", ")}`;
-      langDetails.appendChild(p);
-      langDiv.appendChild(langDetails);
-      initFeatureSelectionHandlers(langDiv);
-      makeAccordion(langDiv);
-    } else if (data.languages && data.languages.choose) {
-      const num = data.languages.choose;
-      const buildSelectors = opts => {
+      const toolDiv = document.getElementById("backgroundTools");
+      toolDiv.innerHTML = "";
+      const toolDetails = document.createElement("details");
+      toolDetails.className = "feature-block";
+      toolDetails.innerHTML = "<summary>Strumenti</summary>";
+      backgroundData.tools = Array.isArray(data.tools) ? data.tools.slice() : [];
+      if (Array.isArray(data.tools) && data.tools.length > 0) {
         const p = document.createElement("p");
-        p.innerHTML = `<strong>Scegli ${num} linguaggi:</strong>`;
+        p.innerHTML = `<strong>Strumenti:</strong> ${data.tools.join(", ")}`;
+        toolDetails.appendChild(p);
+      }
+      const toolChangeHandler = () => {
+        const chosen = Array.from(document.querySelectorAll(".backgroundToolChoice"))
+          .map(s => s.value)
+          .filter(Boolean);
+        const base = Array.isArray(data.tools) ? data.tools.slice() : [];
+        backgroundData.tools = base.concat(chosen);
+      };
+      if (data.tools && data.tools.choose) {
+        const num = data.tools.choose;
+        const opts = data.tools.options || [];
+        const p = document.createElement("p");
+        p.innerHTML = `<strong>Scegli ${num} strumento:</strong>`;
+        toolDetails.appendChild(p);
+        buildChoiceSelectors(toolDetails, num, opts, "backgroundToolChoice", toolChangeHandler);
+      }
+      if (data.toolChoices) {
+        const num = data.toolChoices.choose || 0;
+        const opts = data.toolChoices.options || [];
+        const p = document.createElement("p");
+        p.innerHTML = `<strong>Scegli ${num} strumento:</strong>`;
+        toolDetails.appendChild(p);
+        buildChoiceSelectors(toolDetails, num, opts, "backgroundToolChoice", toolChangeHandler);
+      }
+      toolDiv.appendChild(toolDetails);
+      initFeatureSelectionHandlers(toolDiv);
+      makeAccordion(toolDiv);
+
+      const langDiv = document.getElementById("backgroundLanguages");
+      langDiv.innerHTML = "";
+      const langDetails = document.createElement("details");
+      langDetails.className = "feature-block";
+      langDetails.innerHTML = "<summary>Linguaggi</summary>";
+      backgroundData.languages = Array.isArray(data.languages) ? data.languages.slice() : [];
+      if (Array.isArray(data.languages) && data.languages.length > 0) {
+        const p = document.createElement("p");
+        p.innerHTML = `<strong>Linguaggi:</strong> ${data.languages.join(", ")}`;
         langDetails.appendChild(p);
-        buildChoiceSelectors(
-          langDetails,
-          num,
-          opts,
-          "backgroundLanguageChoice",
-          () => {
-            const chosen = Array.from(
-              document.querySelectorAll(".backgroundLanguageChoice")
-            )
-              .map(s => s.value)
-              .filter(Boolean);
-            backgroundData.languages = chosen;
-          }
-        );
         langDiv.appendChild(langDetails);
         initFeatureSelectionHandlers(langDiv);
         makeAccordion(langDiv);
-      };
-      if (data.languages.any) {
-        loadLanguages(buildSelectors);
-      } else {
-        buildSelectors(data.languages.options || []);
-      }
-    } else {
-      langDiv.appendChild(langDetails);
-      initFeatureSelectionHandlers(langDiv);
-      makeAccordion(langDiv);
-    }
-
-    const featDiv = document.getElementById("backgroundFeat");
-    featDiv.innerHTML = "";
-    backgroundData.feat = "";
-    currentFeatData = null;
-    const featDetails = document.createElement("details");
-    featDetails.className = "feature-block";
-    featDetails.innerHTML = "<summary>Talento</summary>";
-    if (Array.isArray(data.featOptions) && data.featOptions.length > 0) {
-      const label = document.createElement("label");
-      label.htmlFor = "backgroundFeatSelect";
-      label.textContent = "Feat:";
-      const select = document.createElement("select");
-      select.id = "backgroundFeatSelect";
-      select.innerHTML = `<option value="">Seleziona un talento</option>` +
-        data.featOptions
-          .map(name => `<option value="${name}">${name}</option>`)
-          .join("");
-      const abilDiv = document.createElement("div");
-      abilDiv.id = "featAbilityChoices";
-      select.addEventListener("change", () => {
-        currentFeatData = null;
-        abilDiv.innerHTML = "";
-        backgroundData.feat = select.value || "";
-        resetBackgroundTalentFields();
-        if (!select.value || !featPathIndex[select.value]) {
-          updateFinalScores();
-          return;
+      } else if (data.languages && data.languages.choose) {
+        const num = data.languages.choose;
+        const buildSelectors = opts => {
+          const p = document.createElement("p");
+          p.innerHTML = `<strong>Scegli ${num} linguaggi:</strong>`;
+          langDetails.appendChild(p);
+          buildChoiceSelectors(
+            langDetails,
+            num,
+            opts,
+            "backgroundLanguageChoice",
+            () => {
+              const chosen = Array.from(
+                document.querySelectorAll(".backgroundLanguageChoice")
+              )
+                .map(s => s.value)
+                .filter(Boolean);
+              backgroundData.languages = chosen;
+            }
+          );
+          langDiv.appendChild(langDetails);
+          initFeatureSelectionHandlers(langDiv);
+          makeAccordion(langDiv);
+        };
+        if (data.languages.any) {
+          loadLanguages(buildSelectors);
+        } else {
+          buildSelectors(data.languages.options || []);
         }
-        fetch(featPathIndex[select.value])
-          .then(r => r.json())
-          .then(feat => {
+      } else {
+        langDiv.appendChild(langDetails);
+        initFeatureSelectionHandlers(langDiv);
+        makeAccordion(langDiv);
+      }
+
+      const featDiv = document.getElementById("backgroundFeat");
+      featDiv.innerHTML = "";
+      backgroundData.feat = "";
+      currentFeatData = null;
+      const featDetails = document.createElement("details");
+      featDetails.className = "feature-block";
+      featDetails.innerHTML = "<summary>Talento</summary>";
+      if (Array.isArray(data.featOptions) && data.featOptions.length > 0) {
+        const label = document.createElement("label");
+        label.htmlFor = "backgroundFeatSelect";
+        label.textContent = "Feat:";
+        const select = document.createElement("select");
+        select.id = "backgroundFeatSelect";
+        select.innerHTML = `<option value="">Seleziona un talento</option>` +
+          data.featOptions
+            .map(name => `<option value="${name}">${name}</option>`)
+            .join("");
+        const abilDiv = document.createElement("div");
+        abilDiv.id = "featAbilityChoices";
+        select.addEventListener("change", async () => {
+          currentFeatData = null;
+          abilDiv.innerHTML = "";
+          backgroundData.feat = select.value || "";
+          resetBackgroundTalentFields();
+          if (!select.value || !featPathIndex[select.value]) {
+            updateFinalScores();
+            return;
+          }
+          try {
+            const resp = await fetch(featPathIndex[select.value]);
+            if (!resp.ok) throw new Error('Failed to load feat');
+            const feat = await resp.json();
             const fixed = [];
             if (feat.ability) {
               feat.ability.forEach(ab => {
@@ -234,15 +244,20 @@ document.addEventListener("DOMContentLoaded", () => {
             }
             currentFeatData = { fixedAbilities: fixed };
             applyFeatAbilityChoices();
-          });
-      });
-      featDetails.appendChild(label);
-      featDetails.appendChild(select);
-      featDetails.appendChild(abilDiv);
+          } catch (err) {
+            console.error("Errore caricando il talento:", err);
+          }
+        });
+        featDetails.appendChild(label);
+        featDetails.appendChild(select);
+        featDetails.appendChild(abilDiv);
+      }
+      featDiv.appendChild(featDetails);
+      initFeatureSelectionHandlers(featDiv);
+      makeAccordion(featDiv);
+    } catch (err) {
+      handleError(`Errore caricando il background: ${err}`);
     }
-    featDiv.appendChild(featDetails);
-    initFeatureSelectionHandlers(featDiv);
-    makeAccordion(featDiv);
   });
 });
 

--- a/js/step5.js
+++ b/js/step5.js
@@ -108,20 +108,23 @@ function renderEquipment() {
   }
 }
 
-document.addEventListener('DOMContentLoaded', () => {
+document.addEventListener('DOMContentLoaded', async () => {
   const step = document.getElementById('step5');
   if (!step) return;
 
-  fetch('data/equipment.json')
-    .then(r => r.json())
-    .then(data => {
-      equipmentData = data;
-      renderEquipment();
-      const classSel = document.getElementById('classSelect');
-      const levelSel = document.getElementById('levelSelect');
-      if (classSel) classSel.addEventListener('change', renderEquipment);
-      if (levelSel) levelSel.addEventListener('change', renderEquipment);
-    });
+  try {
+    const res = await fetch('data/equipment.json');
+    if (!res.ok) throw new Error('Failed to load equipment data');
+    const data = await res.json();
+    equipmentData = data;
+    renderEquipment();
+    const classSel = document.getElementById('classSelect');
+    const levelSel = document.getElementById('levelSelect');
+    if (classSel) classSel.addEventListener('change', renderEquipment);
+    if (levelSel) levelSel.addEventListener('change', renderEquipment);
+  } catch (err) {
+    console.error('Error loading equipment:', err);
+  }
 
   const confirmBtn = document.getElementById('confirmEquipment');
   if (confirmBtn) {


### PR DESCRIPTION
## Summary
- refactor equipment loading and other fetch chains to use async/await
- add response.ok checks and try/catch to API calls
- align spell and feat loading with new async pattern

## Testing
- `npm test` *(fails: ENOENT: no such file or directory, open 'package.json')*

------
https://chatgpt.com/codex/tasks/task_e_68a59e48d45c832e8e068776c2f9b439