### PR TITLE
Embed equipment selection directly in step

### DIFF
--- a/index.html
+++ b/index.html
@@ -128,8 +128,8 @@
       <!-- Step 5: Equipaggiamento -->
       <div id="step5" class="step hidden">
         <h2>Step 5: Equipaggiamento</h2>
-        <div id="equipmentList" class="class-list"></div>
-        <button id="openEquipmentModal" class="btn btn-primary">Seleziona Equipaggiamento</button>
+        <div id="equipmentSelections"></div>
+        <button id="confirmEquipment" class="btn btn-primary">Conferma Equipaggiamento</button>
       </div>
       <!-- Step 6: Sistema Point Buy -->
       <div id="step6" class="step hidden">
@@ -288,17 +288,5 @@
     </div>
   </div>
 
-  <!-- Modal per la selezione dell'equipaggiamento -->
-  <div id="equipmentModal" class="modal hidden">
-    <div class="modal-content">
-      <span id="closeEquipmentModal" class="close">&times;</span>
-      <div id="equipmentModalDetails">
-        <div id="standardEquipment"></div>
-        <div id="classEquipmentChoices"></div>
-        <div id="equipmentUpgrades"></div>
-        <button id="confirmEquipment" class="btn btn-primary">Conferma Equipaggiamento</button>
-      </div>
-    </div>
-  </div>
 </body>
 </html>

--- a/js/main.js
+++ b/js/main.js
@@ -10,7 +10,7 @@ import {
   setAvailableLanguages,
   renderFinalRecap
 } from './script.js';
-import { getSelectedData, resetSelectedData } from './state.js';
+import { resetSelectedData } from './state.js';
 import './step4.js';
 import './step5.js';
 import './step7.js';
@@ -82,15 +82,6 @@ function closeBackgroundModal() {
   if (modal) modal.classList.add('hidden');
 }
 
-function openEquipmentModal() {
-  const modal = document.getElementById('equipmentModal');
-  if (modal) modal.classList.remove('hidden');
-}
-
-function closeEquipmentModal() {
-  const modal = document.getElementById('equipmentModal');
-  if (modal) modal.classList.add('hidden');
-}
 
 async function showClassModal(name, path) {
   pendingClassPath = path;
@@ -174,7 +165,6 @@ document.addEventListener('DOMContentLoaded', () => {
   document.getElementById('closeClassModal').addEventListener('click', closeClassModal);
   document.getElementById('closeRaceModal').addEventListener('click', closeRaceModal);
   document.getElementById('closeBackgroundModal').addEventListener('click', closeBackgroundModal);
-  document.getElementById('closeEquipmentModal').addEventListener('click', closeEquipmentModal);
   document.getElementById('addClassButton').addEventListener('click', () => {
     const classSelect = document.getElementById('classSelect');
     if (classSelect) {
@@ -205,8 +195,6 @@ document.addEventListener('DOMContentLoaded', () => {
     }
     closeBackgroundModal();
   });
-
-  document.getElementById('openEquipmentModal').addEventListener('click', openEquipmentModal);
 
   document.getElementById('confirmClassSelection').addEventListener('click', async () => {
     const classSelect = document.getElementById('classSelect');
@@ -245,18 +233,6 @@ document.addEventListener('DOMContentLoaded', () => {
       return;
     }
     document.getElementById('confirmBackgroundSelection').style.display = 'none';
-  });
-
-  document.getElementById('confirmEquipment').addEventListener('click', () => {
-    closeEquipmentModal();
-    const list = document.getElementById('equipmentList');
-    const eq = getSelectedData().equipment;
-    if (list && eq) {
-      const items = [...(eq.standard || []), ...(eq.class || []), ...(eq.upgrades || [])];
-      list.innerHTML = items.length
-        ? `<p><strong>Equipaggiamento scelto:</strong> ${items.join(', ')}</p>`
-        : '';
-    }
   });
 
 });


### PR DESCRIPTION
## Summary
- Replace equipment modal with inline accordion-based selections
- Remove equipment modal handlers from main script
- Save equipment choices from step page

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a5a2fd7d50832ebc1a8754471c69aa