### PR TITLE
Generate class cantrip selections from spells list

### DIFF
--- a/data/classes/artificer.json
+++ b/data/classes/artificer.json
@@ -4,7 +4,10 @@
   "hit_die": "d8",
   "hp_at_1st_level": "8 + your Constitution modifier",
   "hp_at_higher_levels": "1d8 (or 5) + your Constitution modifier per Artificer level after 1st",
-  "saving_throws": ["Constitution", "Intelligence"],
+  "saving_throws": [
+    "Constitution",
+    "Intelligence"
+  ],
   "skill_proficiencies": {
     "choose": 2,
     "options": [
@@ -17,14 +20,34 @@
       "Sleight of Hand"
     ]
   },
-  "weapon_proficiencies": ["simple weapons", "firearms"],
-  "tool_proficiencies": ["thieves' tools", "tinker's tools", "one type of artisan's tools of your choice"],
-  "armor_proficiencies": ["light armor", "medium armor", "shields"],
+  "weapon_proficiencies": [
+    "simple weapons",
+    "firearms"
+  ],
+  "tool_proficiencies": [
+    "thieves' tools",
+    "tinker's tools",
+    "one type of artisan's tools of your choice"
+  ],
+  "armor_proficiencies": [
+    "light armor",
+    "medium armor",
+    "shields"
+  ],
   "multiclassing": {
-    "prerequisites": {"Intelligence": 13},
+    "prerequisites": {
+      "Intelligence": 13
+    },
     "proficiencies": {
-      "tools": ["thieves' tools", "tinker's tools"],
-      "armor": ["light armor", "medium armor", "shields"]
+      "tools": [
+        "thieves' tools",
+        "tinker's tools"
+      ],
+      "armor": [
+        "light armor",
+        "medium armor",
+        "shields"
+      ]
     }
   },
   "features_by_level": {
@@ -198,6 +221,27 @@
     }
   ],
   "choices": [
+    {
+      "level": 1,
+      "name": "Cantrip",
+      "description": "Choose 2 artificer cantrips to learn",
+      "count": 2,
+      "type": "cantrips",
+      "selection": [
+        "Fire Bolt",
+        "Guidance",
+        "Light",
+        "Mage Hand",
+        "Prestidigitation",
+        "Ray of Frost",
+        "Resistance",
+        "Shocking Grasp",
+        "Spare the Dying",
+        "Sword Burst",
+        "Thorn Whip",
+        "Thunderclap"
+      ]
+    },
     {
       "level": 2,
       "name": "Infusion",

--- a/data/classes/bard.json
+++ b/data/classes/bard.json
@@ -4,7 +4,10 @@
   "hit_die": "d8",
   "hp_at_1st_level": "8 + your Constitution modifier",
   "hp_at_higher_levels": "1d8 (or 5) + your Constitution modifier per Bard level after 1st",
-  "saving_throws": ["Dexterity", "Charisma"],
+  "saving_throws": [
+    "Dexterity",
+    "Charisma"
+  ],
   "skill_proficiencies": {
     "choose": 3,
     "options": [
@@ -28,15 +31,33 @@
       "Survival"
     ]
   },
-  "weapon_proficiencies": ["simple weapons", "hand crossbows", "longswords", "rapiers", "shortswords"],
-  "tool_proficiencies": ["three musical instruments of your choice"],
-  "armor_proficiencies": ["light armor"],
+  "weapon_proficiencies": [
+    "simple weapons",
+    "hand crossbows",
+    "longswords",
+    "rapiers",
+    "shortswords"
+  ],
+  "tool_proficiencies": [
+    "three musical instruments of your choice"
+  ],
+  "armor_proficiencies": [
+    "light armor"
+  ],
   "multiclassing": {
-    "prerequisites": {"Charisma": 13},
+    "prerequisites": {
+      "Charisma": 13
+    },
     "proficiencies": {
-      "skills": ["Choose any one skill"],
-      "tools": ["one musical instrument of your choice"],
-      "armor": ["light armor"]
+      "skills": [
+        "Choose any one skill"
+      ],
+      "tools": [
+        "one musical instrument of your choice"
+      ],
+      "armor": [
+        "light armor"
+      ]
     }
   },
   "features_by_level": {
@@ -267,6 +288,21 @@
     }
   ],
   "choices": [
+    {
+      "level": 1,
+      "name": "Cantrip",
+      "description": "Choose 2 bard cantrips to learn",
+      "count": 2,
+      "type": "cantrips",
+      "selection": [
+        "Light",
+        "Mage Hand",
+        "Prestidigitation",
+        "Thunderclap",
+        "True Strike",
+        "Vicious Mockery"
+      ]
+    },
     {
       "level": 3,
       "name": "Expertise",

--- a/data/classes/cleric.json
+++ b/data/classes/cleric.json
@@ -4,16 +4,39 @@
   "hit_die": "d8",
   "hp_at_1st_level": "8 + your Constitution modifier",
   "hp_at_higher_levels": "1d8 (or 5) + your Constitution modifier per Cleric level after 1st",
-  "saving_throws": ["Wisdom", "Charisma"],
+  "saving_throws": [
+    "Wisdom",
+    "Charisma"
+  ],
   "skill_proficiencies": {
     "choose": 2,
-    "options": ["History", "Insight", "Medicine", "Persuasion", "Religion"]
+    "options": [
+      "History",
+      "Insight",
+      "Medicine",
+      "Persuasion",
+      "Religion"
+    ]
   },
-  "weapon_proficiencies": ["simple weapons"],
-  "armor_proficiencies": ["light armor", "medium armor", "shields"],
+  "weapon_proficiencies": [
+    "simple weapons"
+  ],
+  "armor_proficiencies": [
+    "light armor",
+    "medium armor",
+    "shields"
+  ],
   "multiclassing": {
-    "prerequisites": {"Wisdom": 13},
-    "proficiencies": {"armor": ["light armor", "medium armor", "shields"]}
+    "prerequisites": {
+      "Wisdom": 13
+    },
+    "proficiencies": {
+      "armor": [
+        "light armor",
+        "medium armor",
+        "shields"
+      ]
+    }
   },
   "features_by_level": {
     "1": [
@@ -314,6 +337,23 @@
         "Medicine",
         "Persuasion",
         "Religion"
+      ]
+    },
+    {
+      "level": 1,
+      "name": "Cantrip",
+      "description": "Choose 3 cleric cantrips to learn",
+      "count": 3,
+      "type": "cantrips",
+      "selection": [
+        "Guidance",
+        "Light",
+        "Resistance",
+        "Sacred Flame",
+        "Spare the Dying",
+        "Thaumaturgy",
+        "Toll the Dead",
+        "Word of Radiance"
       ]
     },
     {

--- a/data/classes/druid.json
+++ b/data/classes/druid.json
@@ -4,7 +4,10 @@
   "hit_die": "d8",
   "hp_at_1st_level": "8 + your Constitution modifier",
   "hp_at_higher_levels": "1d8 (or 5) + your Constitution modifier per Druid level after 1st",
-  "saving_throws": ["Intelligence", "Wisdom"],
+  "saving_throws": [
+    "Intelligence",
+    "Wisdom"
+  ],
   "skill_proficiencies": {
     "choose": 2,
     "options": [
@@ -30,11 +33,25 @@
     "slings",
     "spears"
   ],
-  "tool_proficiencies": ["Herbalism kit"],
-  "armor_proficiencies": ["light armor", "medium armor", "shields (non-metal)"],
+  "tool_proficiencies": [
+    "Herbalism kit"
+  ],
+  "armor_proficiencies": [
+    "light armor",
+    "medium armor",
+    "shields (non-metal)"
+  ],
   "multiclassing": {
-    "prerequisites": {"Wisdom": 13},
-    "proficiencies": {"armor": ["light armor", "medium armor", "shields (non-metal)"]}
+    "prerequisites": {
+      "Wisdom": 13
+    },
+    "proficiencies": {
+      "armor": [
+        "light armor",
+        "medium armor",
+        "shields (non-metal)"
+      ]
+    }
   },
   "features_by_level": {
     "1": [
@@ -244,14 +261,17 @@
     {
       "level": 1,
       "name": "Cantrip",
-      "description": "Choose two druid cantrips to learn",
+      "description": "Choose 2 druid cantrips to learn",
       "count": 2,
       "type": "cantrips",
       "selection": [
         "Guidance",
         "Produce Flame",
+        "Resistance",
+        "Shape Water",
         "Shillelagh",
-        "Thorn Whip"
+        "Thorn Whip",
+        "Thunderclap"
       ]
     },
     {

--- a/data/classes/sorcerer.json
+++ b/data/classes/sorcerer.json
@@ -1,16 +1,36 @@
 {
   "name": "Sorcerer",
-  "description": "A spellcaster who draws on inherent magic from a gift or bloodline.",
+  "description": "A spellcaster who draws arcane power from an innate magical source and shapes it through force of will.",
   "hit_die": "d6",
   "hp_at_1st_level": "6 + your Constitution modifier",
   "hp_at_higher_levels": "1d6 (or 4) + your Constitution modifier per Sorcerer level after 1st",
-  "saving_throws": ["Constitution", "Charisma"],
+  "saving_throws": [
+    "Constitution",
+    "Charisma"
+  ],
   "skill_proficiencies": {
     "choose": 2,
-    "options": ["Arcana", "Deception", "Insight", "Intimidation", "Persuasion", "Religion"]
+    "options": [
+      "Arcana",
+      "Deception",
+      "Insight",
+      "Intimidation",
+      "Persuasion",
+      "Religion"
+    ]
   },
-  "weapon_proficiencies": ["daggers", "darts", "slings", "quarterstaffs", "light crossbows"],
-  "multiclassing": {"prerequisites": {"Charisma": 13}},
+  "weapon_proficiencies": [
+    "daggers",
+    "darts",
+    "slings",
+    "quarterstaffs",
+    "light crossbows"
+  ],
+  "multiclassing": {
+    "prerequisites": {
+      "Charisma": 13
+    }
+  },
   "subclasses": [
     {
       "name": "Aberrant Mind",
@@ -108,7 +128,6 @@
       ]
     }
   ],
-  "description": "A spellcaster who draws arcane power from an innate magical source and shapes it through force of will.",
   "features_by_level": {
     "1": [
       {
@@ -214,6 +233,25 @@
     ]
   },
   "choices": [
+    {
+      "level": 1,
+      "name": "Cantrip",
+      "description": "Choose 4 sorcerer cantrips to learn",
+      "count": 4,
+      "type": "cantrips",
+      "selection": [
+        "Fire Bolt",
+        "Light",
+        "Mage Hand",
+        "Prestidigitation",
+        "Ray of Frost",
+        "Shape Water",
+        "Shocking Grasp",
+        "Sword Burst",
+        "Thunderclap",
+        "True Strike"
+      ]
+    },
     {
       "level": 3,
       "name": "Metamagic",
@@ -333,4 +371,3 @@
     }
   ]
 }
-

--- a/data/classes/warlock.json
+++ b/data/classes/warlock.json
@@ -4,16 +4,40 @@
   "hit_die": "d8",
   "hp_at_1st_level": "8 + your Constitution modifier",
   "hp_at_higher_levels": "1d8 (or 5) + your Constitution modifier per Warlock level after 1st",
-  "saving_throws": ["Wisdom", "Charisma"],
+  "saving_throws": [
+    "Wisdom",
+    "Charisma"
+  ],
   "skill_proficiencies": {
     "choose": 2,
-    "options": ["Arcana", "Deception", "History", "Intimidation", "Investigation", "Nature", "Religion"]
+    "options": [
+      "Arcana",
+      "Deception",
+      "History",
+      "Intimidation",
+      "Investigation",
+      "Nature",
+      "Religion"
+    ]
   },
-  "weapon_proficiencies": ["simple weapons"],
-  "armor_proficiencies": ["light armor"],
+  "weapon_proficiencies": [
+    "simple weapons"
+  ],
+  "armor_proficiencies": [
+    "light armor"
+  ],
   "multiclassing": {
-    "prerequisites": {"Charisma": 13},
-    "proficiencies": {"weapons": ["simple weapons"], "armor": ["light armor"]}
+    "prerequisites": {
+      "Charisma": 13
+    },
+    "proficiencies": {
+      "weapons": [
+        "simple weapons"
+      ],
+      "armor": [
+        "light armor"
+      ]
+    }
   },
   "features_by_level": {
     "1": [
@@ -209,6 +233,21 @@
     }
   ],
   "choices": [
+    {
+      "level": 1,
+      "name": "Cantrip",
+      "description": "Choose 2 warlock cantrips to learn",
+      "count": 2,
+      "type": "cantrips",
+      "selection": [
+        "Eldritch Blast",
+        "Mage Hand",
+        "Prestidigitation",
+        "Sword Burst",
+        "Thunderclap",
+        "Toll the Dead"
+      ]
+    },
     {
       "level": 2,
       "name": "Eldritch Invocations",

--- a/data/classes/wizard.json
+++ b/data/classes/wizard.json
@@ -1,16 +1,36 @@
 {
   "name": "Wizard",
-  "description": "A scholarly magic-user capable of manipulating the structures of reality.",
+  "description": "Description for Wizard class.",
   "hit_die": "d6",
   "hp_at_1st_level": "6 + your Constitution modifier",
   "hp_at_higher_levels": "1d6 (or 4) + your Constitution modifier per Wizard level after 1st",
-  "saving_throws": ["Intelligence", "Wisdom"],
+  "saving_throws": [
+    "Intelligence",
+    "Wisdom"
+  ],
   "skill_proficiencies": {
     "choose": 2,
-    "options": ["Arcana", "History", "Insight", "Investigation", "Medicine", "Religion"]
+    "options": [
+      "Arcana",
+      "History",
+      "Insight",
+      "Investigation",
+      "Medicine",
+      "Religion"
+    ]
   },
-  "weapon_proficiencies": ["daggers", "darts", "slings", "quarterstaffs", "light crossbows"],
-  "multiclassing": {"prerequisites": {"Intelligence": 13}},
+  "weapon_proficiencies": [
+    "daggers",
+    "darts",
+    "slings",
+    "quarterstaffs",
+    "light crossbows"
+  ],
+  "multiclassing": {
+    "prerequisites": {
+      "Intelligence": 13
+    }
+  },
   "subclasses": [
     {
       "name": "School of Abjuration",
@@ -93,7 +113,6 @@
       ]
     }
   ],
-  "description": "Description for Wizard class.",
   "features_by_level": {
     "1": [
       {
@@ -112,14 +131,21 @@
     {
       "level": 1,
       "name": "Cantrip",
-      "description": "Choose two wizard cantrips to learn",
-      "count": 2,
+      "description": "Choose 3 wizard cantrips to learn",
+      "count": 3,
       "type": "cantrips",
       "selection": [
+        "Fire Bolt",
+        "Light",
         "Mage Hand",
         "Prestidigitation",
         "Ray of Frost",
-        "Light"
+        "Shape Water",
+        "Shocking Grasp",
+        "Sword Burst",
+        "Thunderclap",
+        "Toll the Dead",
+        "True Strike"
       ]
     },
     {

--- a/scripts/update_cantrip_choices.py
+++ b/scripts/update_cantrip_choices.py
@@ -1,0 +1,52 @@
+#!/usr/bin/env python3
+import json
+
+STARTING_CANTRIPS = {
+    "Artificer": 2,
+    "Bard": 2,
+    "Cleric": 3,
+    "Druid": 2,
+    "Sorcerer": 4,
+    "Warlock": 2,
+    "Wizard": 3,
+}
+
+CLASS_FILES = {cls: f"data/classes/{cls.lower()}.json" for cls in STARTING_CANTRIPS}
+
+def main():
+    with open("data/spells.json", "r", encoding="utf-8") as f:
+        spells = json.load(f)
+
+    cantrips_by_class = {cls: [] for cls in STARTING_CANTRIPS}
+    for spell in spells:
+        if spell.get("level") == 0:
+            for cls in spell.get("spell_list", []):
+                if cls in cantrips_by_class:
+                    cantrips_by_class[cls].append(spell["name"])
+
+    for cls, cantrips in cantrips_by_class.items():
+        cantrips.sort()
+        path = CLASS_FILES[cls]
+        with open(path, "r", encoding="utf-8") as f:
+            data = json.load(f)
+        choices = data.get("choices", [])
+        choices = [c for c in choices if not (c.get("type") == "cantrips" and c.get("level") == 1)]
+        count = STARTING_CANTRIPS[cls]
+        choice = {
+            "level": 1,
+            "name": "Cantrip",
+            "description": f"Choose {count} {cls.lower()} cantrips to learn",
+            "count": count,
+            "type": "cantrips",
+            "selection": cantrips,
+        }
+        choices.append(choice)
+        choices.sort(key=lambda c: c.get("level", 0))
+        data["choices"] = choices
+        with open(path, "w", encoding="utf-8") as f:
+            json.dump(data, f, ensure_ascii=False, indent=2)
+            f.write("\n")
+    print("Updated cantrip choices for classes.")
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- Add script to build cantrip choice blocks from `spells.json`
- Populate caster classes with full level-1 cantrip lists

## Testing
- `python scripts/update_cantrip_choices.py`
- `python scripts/validate_cantrips.py`


------
https://chatgpt.com/codex/tasks/task_e_68a5bc4c3488832e965698954278c3fe