### PR TITLE
Prevent duplicate cantrip options

### DIFF
--- a/js/spellcasting.js
+++ b/js/spellcasting.js
@@ -1,3 +1,5 @@
+import { getSelectedData } from './state.js';
+
 export async function loadSpells(callback) {
   try {
     const response = await fetch('data/spells.json');
@@ -82,8 +84,13 @@ export function handleSpellcasting(data, container) {
 
         if (spellLevel && spellClass) {
           loadSpells(spellList => {
+            const existingCantrips = (getSelectedData()["Cantrips"] || []).map(c => c.toLowerCase());
             const filteredSpells = spellList
-              .filter(spell => parseInt(spell.level) === parseInt(spellLevel) && spell.spell_list.includes(spellClass))
+              .filter(spell =>
+                parseInt(spell.level) === parseInt(spellLevel) &&
+                spell.spell_list.includes(spellClass) &&
+                !existingCantrips.includes(spell.name.toLowerCase())
+              )
               .map(spell => `<option value="${spell.name}">${spell.name}</option>`)
               .join('');
             const wrapper = document.createElement('div');


### PR DESCRIPTION
## Summary
- avoid showing cantrips already selected

## Testing
- `node --check js/spellcasting.js`
- `npm test` *(fails: ENOENT package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a5c3f6c5cc832ea5c999594f0890ee