### PR TITLE
refactor: centralize proficiency data

### DIFF
--- a/js/data/proficiencies.js
+++ b/js/data/proficiencies.js
@@ -47,3 +47,43 @@ export const ALL_TOOLS = [
   "Vehicle (Land)",
   "Vehicle (Water)",
 ];
+
+export const ALL_LANGUAGES = [
+  "Common",
+  "Dwarvish",
+  "Elvish",
+  "Giant",
+  "Gnomish",
+  "Goblin",
+  "Halfling",
+  "Orc",
+  "Abyssal",
+  "Celestial",
+  "Draconic",
+  "Deep Speech",
+  "Infernal",
+  "Primordial",
+  "Sylvan",
+  "Undercommon",
+];
+
+export const ALL_SKILLS = [
+  "Acrobatics",
+  "Animal Handling",
+  "Arcana",
+  "Athletics",
+  "Deception",
+  "History",
+  "Insight",
+  "Intimidation",
+  "Investigation",
+  "Medicine",
+  "Nature",
+  "Perception",
+  "Performance",
+  "Persuasion",
+  "Religion",
+  "Sleight of Hand",
+  "Stealth",
+  "Survival",
+];

--- a/js/extrasSelections.js
+++ b/js/extrasSelections.js
@@ -1,20 +1,18 @@
-import { loadLanguages } from './common.js';
 import { buildChoiceSelectors } from './selectionUtils.js';
+import { ALL_LANGUAGES } from './data/proficiencies.js';
 
 export function handleExtraLanguages(data, containerId) {
   const container = document.getElementById(containerId);
   if (!container) return;
   container.innerHTML = '';
   if (data.languages && data.languages.choice > 0) {
-    loadLanguages(langs => {
-      const availableLangs = langs.filter(lang => !data.languages.fixed.includes(lang));
-      const wrapper = document.createElement('div');
-      const title = document.createElement('h4');
-      title.textContent = 'Lingue Extra';
-      wrapper.appendChild(title);
-      buildChoiceSelectors(wrapper, data.languages.choice, availableLangs, 'extraLanguageChoice');
-      container.appendChild(wrapper);
-    });
+    const availableLangs = ALL_LANGUAGES.filter(lang => !data.languages.fixed.includes(lang));
+    const wrapper = document.createElement('div');
+    const title = document.createElement('h4');
+    title.textContent = 'Lingue Extra';
+    wrapper.appendChild(title);
+    buildChoiceSelectors(wrapper, data.languages.choice, availableLangs, 'extraLanguageChoice');
+    container.appendChild(wrapper);
   }
 }
 

--- a/js/main.js
+++ b/js/main.js
@@ -1,5 +1,5 @@
 import { showStep, loadFormData } from './ui.js';
-import { loadDropdownData, loadLanguages, renderEntityList } from './common.js';
+import { loadDropdownData, renderEntityList } from './common.js';
 import { createHeader, createParagraph } from './domHelpers.js';
 import {
   updateSubclasses,
@@ -7,7 +7,6 @@ import {
   displayRaceTraits,
   generateFinalJson,
   initializeValues,
-  setAvailableLanguages,
   renderFinalRecap
 } from './script.js';
 import { resetSelectedData } from './state.js';
@@ -116,9 +115,6 @@ document.addEventListener('DOMContentLoaded', () => {
   renderClassList();
   renderRaceList();
   renderBackgroundList();
-  loadLanguages(langs => {
-    setAvailableLanguages(langs);
-  });
 
   ['step1','step2','step3','step4','step5','step6','step7'].forEach((stepId, idx) => {
     const btn = document.getElementById(`btnStep${idx + 1}`);

--- a/js/raceData.js
+++ b/js/raceData.js
@@ -1,23 +1,4 @@
-export const ALL_SKILLS = [
-  "Acrobatics",
-  "Animal Handling",
-  "Arcana",
-  "Athletics",
-  "Deception",
-  "History",
-  "Insight",
-  "Intimidation",
-  "Investigation",
-  "Medicine",
-  "Nature",
-  "Perception",
-  "Performance",
-  "Persuasion",
-  "Religion",
-  "Sleight of Hand",
-  "Stealth",
-  "Survival"
-];
+import { ALL_SKILLS } from './data/proficiencies.js';
 
 function flattenEntries(entries) {
   if (!Array.isArray(entries)) return "";

--- a/js/script.js
+++ b/js/script.js
@@ -1,17 +1,13 @@
-import { loadLanguages, handleError, renderTables } from './common.js';
+import { handleError, renderTables } from './common.js';
 import { loadSpells, filterSpells, handleSpellcasting } from './spellcasting.js';
-import { convertRaceData, ALL_SKILLS } from './raceData.js';
+import { convertRaceData } from './raceData.js';
+import { ARTISAN_TOOLS, MUSICAL_INSTRUMENTS, ALL_TOOLS, ALL_LANGUAGES, ALL_SKILLS } from './data/proficiencies.js';
 import { getSelectedData, setSelectedData, saveSelectedData } from './state.js';
 import { createHeader, createParagraph, createList } from './domHelpers.js';
-import { ARTISAN_TOOLS, MUSICAL_INSTRUMENTS, ALL_TOOLS } from './proficiencies.js';
 import { handleVariantExtraSelections, handleVariantFeatureChoices } from './variantFeatures.js';
 import { handleExtraLanguages, handleExtraSkills, handleExtraTools, handleExtraAncestry, gatherRaceTraitSelections } from './extrasSelections.js';
 import { openExtrasModal, updateExtraSelectionsView, showExtraSelection, extraCategoryAliases, extraCategoryDescriptions } from './extrasModal.js';
 
-export let availableLanguages = [];
-export function setAvailableLanguages(langs) {
-  availableLanguages = langs;
-}
 
 let selectedData = getSelectedData();
 
@@ -128,12 +124,12 @@ function gatherExtraSelections(data, context, level = 1) {
   if (context === "race") {
     if (data.languages && (data.languages.fixed.length > 0 || data.languages.choice > 0)) {
       const fixedLangs = new Set(data.languages.fixed.map(l => l.toLowerCase()));
-      let availableLangs = availableLanguages
+      let availableLangs = ALL_LANGUAGES
         .filter(lang => !fixedLangs.has(lang.toLowerCase()))
         .filter(lang => !takenLangs.has(lang.toLowerCase()));
       let note = '';
       if (availableLangs.length === 0) {
-        availableLangs = availableLanguages.filter(lang => !takenLangs.has(lang.toLowerCase()));
+        availableLangs = ALL_LANGUAGES.filter(lang => !takenLangs.has(lang.toLowerCase()));
         note = ' (tutte le lingue disponibili)';
       }
       const fixedDesc = data.languages.fixed.length
@@ -190,7 +186,7 @@ function gatherExtraSelections(data, context, level = 1) {
         if (key === "Languages") {
           opts = opts.filter(o => !takenLangs.has(o.toLowerCase()) || selectedLower.includes(o.toLowerCase()));
           if (opts.length === 0) {
-            opts = availableLanguages.filter(o => !takenLangs.has(o.toLowerCase()) || selectedLower.includes(o.toLowerCase()));
+            opts = ALL_LANGUAGES.filter(o => !takenLangs.has(o.toLowerCase()) || selectedLower.includes(o.toLowerCase()));
             note = ' (tutte le lingue disponibili)';
           }
         } else if (key === "Skill Proficiency") {

--- a/js/step4.js
+++ b/js/step4.js
@@ -1,14 +1,12 @@
 // Step 4: Background selection and feat handling
-import { loadDropdownData, loadLanguages } from './common.js';
+import { loadDropdownData } from './common.js';
 import {
   initFeatureSelectionHandlers,
   convertDetailsToAccordion,
   initializeAccordion,
   getTakenProficiencies,
-  availableLanguages,
 } from './script.js';
-import { ALL_TOOLS } from './proficiencies.js';
-import { ALL_SKILLS } from './raceData.js';
+import { ALL_TOOLS, ALL_LANGUAGES, ALL_SKILLS } from './data/proficiencies.js';
 import { buildChoiceSelectors } from './selectionUtils.js';
 
 let featPathIndex = {};
@@ -214,7 +212,7 @@ document.addEventListener("DOMContentLoaded", async () => {
           let filtered = (opts || []).filter(o => !takenLangs.has(o));
           let note = '';
           if (filtered.length === 0) {
-            filtered = availableLanguages.filter(o => !takenLangs.has(o));
+            filtered = ALL_LANGUAGES.filter(o => !takenLangs.has(o));
             note = ' (tutte le lingue disponibili)';
           }
           const p = document.createElement("p");
@@ -239,7 +237,7 @@ document.addEventListener("DOMContentLoaded", async () => {
           makeAccordion(langDiv);
         };
         if (data.languages.any) {
-          loadLanguages(buildSelectors);
+          buildSelectors(ALL_LANGUAGES);
         } else {
           buildSelectors(data.languages.options || []);
         }

--- a/js/variantFeatures.js
+++ b/js/variantFeatures.js
@@ -2,6 +2,7 @@ import { loadSpells, filterSpells } from './spellcasting.js';
 import { getSelectedData, saveSelectedData } from './state.js';
 import { checkTraitCompletion } from './script.js';
 import { buildChoiceSelectors } from './selectionUtils.js';
+import { ALL_SKILLS } from './data/proficiencies.js';
 
 const variantExtraMapping = {
   "Drow Magic": {
@@ -10,11 +11,7 @@ const variantExtraMapping = {
   "Skill Versatility": {
     type: "skills",
     count: 2,
-    options: [
-      "Acrobatics", "Animal Handling", "Arcana", "Athletics", "Deception", "History",
-      "Insight", "Intimidation", "Investigation", "Medicine", "Nature", "Perception",
-      "Performance", "Persuasion", "Religion", "Sleight of Hand", "Stealth", "Survival",
-    ],
+    options: ALL_SKILLS,
   },
   "Swim": { type: "none" },
   "Cantrip (Wizard)": {


### PR DESCRIPTION
## Summary
- centralize tool, language, and skill lists in `js/data/proficiencies.js`
- reuse shared proficiency data in scripts for background and extra selections
- remove dynamic language loading and rely on static lists

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a5d572f990832ebdced9c5e90ab884