### PR TITLE
fix: restore Artificer tool proficiency selection

### DIFF
--- a/data/classes/artificer.json
+++ b/data/classes/artificer.json
@@ -24,11 +24,31 @@
     "simple weapons",
     "firearms"
   ],
-  "tool_proficiencies": [
-    "thieves' tools",
-    "tinker's tools",
-    "one type of artisan's tools of your choice"
-  ],
+  "tool_proficiencies": {
+    "fixed": [
+      "thieves' tools",
+      "tinker's tools"
+    ],
+    "choose": 1,
+    "options": [
+      "Alchemist's Supplies",
+      "Brewer's Supplies",
+      "Calligrapher's Tools",
+      "Carpenter's Tools",
+      "Cartographer's Tools",
+      "Cobbler's Tools",
+      "Cook's Utensils",
+      "Glassblower's Tools",
+      "Jeweler's Tools",
+      "Leatherworker's Tools",
+      "Mason's Tools",
+      "Painter's Supplies",
+      "Potter's Tools",
+      "Smith's Tools",
+      "Weaver's Tools",
+      "Woodcarver's Tools"
+    ]
+  },
   "armor_proficiencies": [
     "light armor",
     "medium armor",


### PR DESCRIPTION
## Summary
- restore text and selection for Artificer tool proficiencies by representing fixed and optional tools separately

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a5e98fd928832e9cf627f5505871b1