### PR TITLE
Use shared items key for dataset mappings

### DIFF
--- a/data/backgrounds.json
+++ b/data/backgrounds.json
@@ -1,5 +1,5 @@
 {
-  "backgrounds": {
+  "items": {
     "Acolyte": "data/backgrounds/acolyte.json",
     "Anthropologist": "data/backgrounds/anthropologist.json",
     "Archaeologist": "data/backgrounds/archaeologist.json",

--- a/data/classes.json
+++ b/data/classes.json
@@ -1,5 +1,5 @@
 {
-    "classes": {
+    "items": {
         "Artificer": "data/classes/artificer.json",
         "Barbarian": "data/classes/barbarian.json",
         "Bard": "data/classes/bard.json",

--- a/data/races.json
+++ b/data/races.json
@@ -1,5 +1,5 @@
 {
-    "races": {
+    "items": {
         "Aarakocra": "data/races/aarakocra.json",
         "Aasimar (Fallen)": "data/races/aasimarfallen.json",
         "Aasimar (Protector)": "data/races/aasimarprotector.json",

--- a/js/common.js
+++ b/js/common.js
@@ -3,19 +3,19 @@
 // -------------------------
 // Caricamento dati e popolamento dropdown
 // -------------------------
-export async function loadDropdownData(jsonPath, selectId, key) {
+export async function loadDropdownData(jsonPath, selectId) {
   try {
     const response = await fetch(jsonPath);
     if (!response.ok) throw new Error('Network response was not ok');
     const data = await response.json();
     console.log(`📜 Dati ricevuti da ${jsonPath}:`, data);
-    if (!data[key]) {
-      handleError(`Chiave ${key} non trovata in ${jsonPath}`);
+    if (!data.items) {
+      handleError(`Chiave items non trovata in ${jsonPath}`);
       return;
     }
-    const options = Object.keys(data[key]).map(name => ({
-      name: name,
-      path: data[key][name]
+    const options = Object.entries(data.items).map(([name, path]) => ({
+      name,
+      path
     }));
     populateDropdown(selectId, options);
   } catch (error) {
@@ -41,13 +41,13 @@ export function populateDropdown(selectId, options) {
 // -------------------------
 // Funzione generica per il rendering di liste di entità
 // -------------------------
-export async function renderEntityList(jsonPath, key, containerId, modalFn) {
+export async function renderEntityList(jsonPath, containerId, modalFn) {
   try {
     const res = await fetch(jsonPath);
     if (!res.ok) throw new Error('Network response was not ok');
     const data = await res.json();
-    if (!data[key]) {
-      handleError(`Chiave ${key} non trovata in ${jsonPath}`);
+    if (!data.items) {
+      handleError(`Chiave items non trovata in ${jsonPath}`);
       return;
     }
     const list = document.getElementById(containerId);
@@ -55,7 +55,7 @@ export async function renderEntityList(jsonPath, key, containerId, modalFn) {
       handleError(`Elemento #${containerId} non trovato!`);
       return;
     }
-    Object.entries(data[key]).forEach(([name, path]) => {
+    Object.entries(data.items).forEach(([name, path]) => {
       const btn = document.createElement("button");
       btn.className = "btn btn-primary";
       btn.textContent = name;

--- a/js/main.js
+++ b/js/main.js
@@ -20,11 +20,11 @@ let pendingRacePath = '';
 let pendingBackgroundPath = '';
 
 function renderClassList() {
-  renderEntityList('data/classes.json', 'classes', 'classList', showClassModal);
+  renderEntityList('data/classes.json', 'classList', showClassModal);
 }
 
 function renderRaceList() {
-  renderEntityList('data/races.json', 'races', 'raceList', showRaceModal);
+  renderEntityList('data/races.json', 'raceList', showRaceModal);
 }
 
 async function showRaceModal(name, path) {
@@ -50,7 +50,7 @@ function closeRaceModal() {
 }
 
 function renderBackgroundList() {
-  renderEntityList('data/backgrounds.json', 'backgrounds', 'backgroundList', showBackgroundModal);
+  renderEntityList('data/backgrounds.json', 'backgroundList', showBackgroundModal);
 }
 
 async function showBackgroundModal(name, path) {
@@ -110,8 +110,8 @@ function closeClassModal() {
 document.addEventListener('DOMContentLoaded', () => {
   console.log('✅ Main.js caricato!');
 
-  loadDropdownData('data/races.json', 'raceSelect', 'races');
-  loadDropdownData('data/classes.json', 'classSelect', 'classes');
+  loadDropdownData('data/races.json', 'raceSelect');
+  loadDropdownData('data/classes.json', 'classSelect');
   renderClassList();
   renderRaceList();
   renderBackgroundList();

--- a/js/step4.js
+++ b/js/step4.js
@@ -91,7 +91,7 @@ document.addEventListener("DOMContentLoaded", async () => {
 
   window.backgroundData = { name: "", skills: [], tools: [], languages: [], feat: "" };
 
-  loadDropdownData("data/backgrounds.json", "backgroundSelect", "backgrounds");
+  loadDropdownData("data/backgrounds.json", "backgroundSelect");
   try {
     const resp = await fetch("data/feats.json");
     if (!resp.ok) throw new Error('Failed to load feats');

--- a/scripts/generate_backgrounds.py
+++ b/scripts/generate_backgrounds.py
@@ -258,4 +258,4 @@ for name, data in backgrounds.items():
 # Write backgrounds.json mapping
 mapping = {name: f"data/backgrounds/{name.lower().replace(' ', '_').replace('/', '').replace("'", "")}.json" for name in backgrounds}
 with open('data/backgrounds.json', 'w', encoding='utf-8') as f:
-    json.dump({"backgrounds": mapping}, f, ensure_ascii=False, indent=2)
+    json.dump({"items": mapping}, f, ensure_ascii=False, indent=2)


### PR DESCRIPTION
## Summary
- unifies top-level keys in backgrounds, classes, and races JSON files under `items`
- updates common data-loading utilities to assume the shared key and simplifies their signatures
- adjusts call sites and background generator to follow the new structure

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a5eb9dd7f4832ebbb6ac005734b8a1