### PR TITLE
Handle background proficiency conflicts and persist replacements

### DIFF
--- a/js/script.js
+++ b/js/script.js
@@ -145,13 +145,10 @@ function getTakenProficiencies(type, incoming) {
   if (!incoming) return originalTaken;
 
   const lowerIncoming = incoming.map(i => i.toLowerCase());
-  const takenWithoutIncoming = new Set(
-    [...originalTaken].filter(v => !lowerIncoming.includes(v))
-  );
   const conflicts = incoming.filter((v, idx) =>
-    takenWithoutIncoming.has(lowerIncoming[idx])
+    originalTaken.has(lowerIncoming[idx])
   );
-  const taken = new Set([...takenWithoutIncoming, ...lowerIncoming]);
+  const taken = new Set([...originalTaken, ...lowerIncoming]);
   return { taken, conflicts };
 }
 


### PR DESCRIPTION
## Summary
- Detect background proficiency conflicts before applying them
- Allow replacement choices for duplicate skills or tools and save selections
- Persist background data, including replacements, via sessionStorage
- Fix duplicate proficiency detection so conflicts like History offer replacement options

## Testing
- ⚠️ `npm test` *(missing script)*
- ✅ `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a60ed58f18832ebbd94fca8c2e09e3