### PR TITLE
refactor: centralize proficiency conflict resolution

### DIFF
--- a/js/raceTraits.js
+++ b/js/raceTraits.js
@@ -18,6 +18,7 @@ import {
 } from './script.js';
 import { convertDetailsToAccordion, initializeAccordion } from './ui/accordion.js';
 import { ALL_LANGUAGES, ALL_TOOLS, ALL_SKILLS } from './data/proficiencies.js';
+import { renderProficiencyReplacements } from './selectionUtils.js';
 
 export async function displayRaceTraits() {
   console.log('🛠 Esecuzione displayRaceTraits()...');
@@ -168,10 +169,9 @@ export async function displayRaceTraits() {
       }
     });
 
-    const addSubstitutionSelectors = (type, fixedList, allOptions, featureKey, matcher) => {
+    const labels = { Languages: 'Linguaggi', 'Skill Proficiency': 'Abilità', 'Tool Proficiency': 'Strumenti' };
+    const addSubs = (type, fixedList, allOptions, featureKey, matcher) => {
       if (!fixedList || fixedList.length === 0) return;
-      const { taken, conflicts } = getTakenProficiencies(type, fixedList, { excludeRace: true });
-      if (!conflicts.length) return;
       let detail = Array.from(raceTraitsDiv.querySelectorAll('details'))
         .find(det => matcher.test(det.querySelector('summary')?.textContent || ''));
       if (!detail) {
@@ -182,51 +182,23 @@ export async function displayRaceTraits() {
         detail.appendChild(summary);
         raceTraitsDiv.appendChild(detail);
       }
-      const startIndex = detail.querySelectorAll(`select[data-feature="${featureKey}"]`).length;
-      const opts = allOptions.filter(o => !taken.has(o.toLowerCase()));
-      const selects = [];
-      const p = document.createElement('p');
-      const labels = { Languages: 'Linguaggi', 'Skill Proficiency': 'Abilità', 'Tool Proficiency': 'Strumenti' };
-      p.innerHTML = `<strong>${labels[featureKey]} duplicate, scegli sostituti:</strong>`;
-      detail.appendChild(p);
-      conflicts.forEach((conflict, i) => {
-        const label = document.createElement('label');
-        label.textContent = `${conflict}: `;
-        const select = document.createElement('select');
-        select.dataset.feature = featureKey;
-        select.dataset.index = startIndex + i;
-        const def = document.createElement('option');
-        def.value = '';
-        def.textContent = 'Seleziona...';
-        select.appendChild(def);
-        opts.forEach(o => {
-          const option = document.createElement('option');
-          option.value = o;
-          option.textContent = o;
-          select.appendChild(option);
-        });
-        const saved = selectedData[featureKey]?.[startIndex + i] || '';
-        if (saved) select.value = saved;
-        label.appendChild(select);
-        detail.appendChild(label);
-        selects.push(select);
-      });
-      const update = () => {
-        const chosen = new Set(selects.map(s => s.value).filter(Boolean));
-        selects.forEach(sel => {
-          const curr = sel.value;
-          sel.innerHTML = '<option value="">Seleziona...</option>' +
-            opts.map(o => `<option value="${o}" ${chosen.has(o) && o !== curr ? 'disabled' : ''}>${o}</option>`).join('');
-          sel.value = curr;
-        });
-      };
-      selects.forEach(sel => sel.addEventListener('change', update));
-      update();
+      renderProficiencyReplacements(
+        type,
+        fixedList,
+        allOptions,
+        detail,
+        {
+          featureKey,
+          label: labels[featureKey],
+          selectedData,
+          getTakenOptions: { excludeRace: true },
+        }
+      );
     };
 
-    addSubstitutionSelectors('languages', raceData.languages?.fixed, ALL_LANGUAGES, 'Languages', /language/i);
-    addSubstitutionSelectors('skills', raceData.skill_choices?.fixed, ALL_SKILLS, 'Skill Proficiency', /skill/i);
-    addSubstitutionSelectors('tools', raceData.tool_choices?.fixed, ALL_TOOLS, 'Tool Proficiency', /tool/i);
+    addSubs('languages', raceData.languages?.fixed, ALL_LANGUAGES, 'Languages', /language/i);
+    addSubs('skills', raceData.skill_choices?.fixed, ALL_SKILLS, 'Skill Proficiency', /skill/i);
+    addSubs('tools', raceData.tool_choices?.fixed, ALL_TOOLS, 'Tool Proficiency', /tool/i);
 
     // Variant feature choices
     if (raceData.variant_feature_choices) {

--- a/js/selectionUtils.js
+++ b/js/selectionUtils.js
@@ -1,3 +1,5 @@
+import { getTakenProficiencies } from './script.js';
+
 export function buildChoiceSelectors(container, count, options, className, changeHandler) {
   const selects = [];
   for (let i = 0; i < count; i++) {
@@ -20,6 +22,84 @@ export function buildChoiceSelectors(container, count, options, className, chang
     if (changeHandler) changeHandler();
   };
 
+  selects.forEach(sel => sel.addEventListener('change', update));
+  update();
+  return selects;
+}
+
+export function renderProficiencyReplacements(
+  type,
+  fixedList,
+  allOptions,
+  container,
+  {
+    featureKey,
+    label,
+    selectedData = {},
+    startIndex,
+    selectClass = '',
+    changeHandler,
+    getTakenOptions = {},
+  } = {}
+) {
+  if (!container || !Array.isArray(fixedList) || fixedList.length === 0) return [];
+  const { taken, conflicts } = getTakenProficiencies(type, fixedList, getTakenOptions);
+  if (!conflicts.length) return [];
+  const base = fixedList.filter(s => !conflicts.includes(s));
+  let opts = allOptions.filter(o => !taken.has(o.toLowerCase()));
+  if (opts.length === 0) {
+    const baseLower = base.map(b => b.toLowerCase());
+    opts = allOptions.filter(o => !baseLower.includes(o.toLowerCase()));
+  }
+  const si =
+    startIndex !== undefined
+      ? startIndex
+      : featureKey
+      ? container.querySelectorAll(`select[data-feature="${featureKey}"]`).length
+      : 0;
+  const selects = [];
+  const p = document.createElement('p');
+  p.innerHTML = `<strong>${label} duplicate, scegli sostituti:</strong>`;
+  container.appendChild(p);
+  conflicts.forEach((conflict, i) => {
+    const lab = document.createElement('label');
+    lab.textContent = `${conflict}: `;
+    const sel = document.createElement('select');
+    if (featureKey) {
+      sel.dataset.feature = featureKey;
+      sel.dataset.index = si + i;
+    }
+    if (selectClass) sel.className = selectClass;
+    const def = document.createElement('option');
+    def.value = '';
+    def.textContent = 'Seleziona...';
+    sel.appendChild(def);
+    opts.forEach(o => {
+      const option = document.createElement('option');
+      option.value = o;
+      option.textContent = o;
+      sel.appendChild(option);
+    });
+    const saved = featureKey ? selectedData[featureKey]?.[si + i] || '' : '';
+    if (saved) sel.value = saved;
+    lab.appendChild(sel);
+    container.appendChild(lab);
+    selects.push(sel);
+  });
+  const update = () => {
+    const chosen = new Set(selects.map(s => s.value).filter(Boolean));
+    selects.forEach(sel => {
+      const curr = sel.value;
+      sel.innerHTML = '<option value="">Seleziona...</option>' +
+        opts
+          .map(
+            o => `<option value="${o}" ${chosen.has(o) && o !== curr ? 'disabled' : ''}>${o}</option>`
+          )
+          .join('');
+      sel.value = curr;
+    });
+    if (changeHandler) changeHandler(selects.map(s => s.value));
+  };
   selects.forEach(sel => sel.addEventListener('change', update));
   update();
   return selects;


### PR DESCRIPTION
## Summary
- consolidate proficiency conflict handling in renderProficiencyReplacements utility
- reuse new utility across class features, race traits, and background step

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a6dd71c258832ea36935fbbe95d80c