### PR TITLE
Re-render proficiency replacements on change

### DIFF
--- a/js/classFeatures.js
+++ b/js/classFeatures.js
@@ -100,19 +100,41 @@ export async function renderClassFeatures() {
     details.appendChild(summary);
     profTexts.forEach(t => details.appendChild(createParagraph(t)));
 
-    renderProficiencyReplacements(
+    const renderReplacement = (type, fixed, allOptions, featureKey, label) => {
+      const container = document.createElement('div');
+      details.appendChild(container);
+      const render = () => {
+        container.innerHTML = '';
+        renderProficiencyReplacements(
+          type,
+          fixed,
+          allOptions,
+          container,
+          {
+            featureKey,
+            label,
+            selectedData: getSelectedData(),
+            getTakenOptions: { excludeClass: true },
+            changeHandler: () => setTimeout(render, 0),
+          }
+        );
+      };
+      render();
+    };
+
+    renderReplacement(
       'languages',
       data.language_proficiencies?.fixed,
       ALL_LANGUAGES,
-      details,
-      { featureKey: 'Languages', label: 'Linguaggi', selectedData }
+      'Languages',
+      'Linguaggi'
     );
-    renderProficiencyReplacements(
+    renderReplacement(
       'skills',
       data.skill_proficiencies?.fixed,
       ALL_SKILLS,
-      details,
-      { featureKey: 'Skill Proficiency', label: 'Abilità', selectedData }
+      'Skill Proficiency',
+      'Abilità'
     );
     featuresDiv.appendChild(details);
   }

--- a/js/raceTraits.js
+++ b/js/raceTraits.js
@@ -182,18 +182,25 @@ export async function displayRaceTraits() {
         detail.appendChild(summary);
         raceTraitsDiv.appendChild(detail);
       }
-      renderProficiencyReplacements(
-        type,
-        fixedList,
-        allOptions,
-        detail,
-        {
-          featureKey,
-          label: labels[featureKey],
-          selectedData,
-          getTakenOptions: { excludeRace: true },
-        }
-      );
+      const container = document.createElement('div');
+      detail.appendChild(container);
+      const render = () => {
+        container.innerHTML = '';
+        renderProficiencyReplacements(
+          type,
+          fixedList,
+          allOptions,
+          container,
+          {
+            featureKey,
+            label: labels[featureKey],
+            selectedData: getSelectedData(),
+            getTakenOptions: { excludeRace: true },
+            changeHandler: () => setTimeout(render, 0),
+          }
+        );
+      };
+      render();
     };
 
     addSubs('languages', raceData.languages?.fixed, ALL_LANGUAGES, 'Languages', /language/i);


### PR DESCRIPTION
## Summary
- Re-render class proficiency replacement selects whenever a choice changes so new options exclude taken proficiencies
- Do the same for race proficiency replacements

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a6e1f9bbf0832e8a7103c1b9b9a4c9