### PR TITLE
Add conflict resolution and accessible proficiency prompts

### DIFF
--- a/js/classFeatures.js
+++ b/js/classFeatures.js
@@ -116,6 +116,7 @@ export async function renderClassFeatures() {
             selectedData: getSelectedData(),
             getTakenOptions: { excludeClass: true },
             changeHandler: () => setTimeout(render, 0),
+            source: 'class',
           }
         );
       };

--- a/js/raceTraits.js
+++ b/js/raceTraits.js
@@ -197,6 +197,7 @@ export async function displayRaceTraits() {
             selectedData: getSelectedData(),
             getTakenOptions: { excludeRace: true },
             changeHandler: () => setTimeout(render, 0),
+            source: 'race',
           }
         );
       };

--- a/js/selectionUtils.js
+++ b/js/selectionUtils.js
@@ -1,4 +1,4 @@
-import { getTakenProficiencies } from './script.js';
+import { getTakenProficiencies, registerConflict, resolveConflict } from './script.js';
 
 export function buildChoiceSelectors(container, count, options, className, changeHandler) {
   const selects = [];
@@ -40,7 +40,8 @@ export function renderProficiencyReplacements(
     selectClass = '',
     changeHandler,
     getTakenOptions = {},
-  } = {}
+    source,
+    } = {}
 ) {
     if (!container || !Array.isArray(fixedList) || fixedList.length === 0) return [];
     const { owned, conflicts } = getTakenProficiencies(type, fixedList, getTakenOptions);
@@ -57,36 +58,47 @@ export function renderProficiencyReplacements(
       : featureKey
       ? container.querySelectorAll(`select[data-feature="${featureKey}"]`).length
       : 0;
-  const selects = [];
-  const p = document.createElement('p');
-  p.innerHTML = `<strong>${label} duplicate, scegli sostituti:</strong>`;
-  container.appendChild(p);
-    conflicts.forEach((conflict, i) => {
-      const lab = document.createElement('label');
-      const sourceInfo = conflict.ownedFrom?.length ? ` (${conflict.ownedFrom.join(', ')})` : '';
-      lab.textContent = `${conflict.key}${sourceInfo}: `;
-      const sel = document.createElement('select');
-      if (featureKey) {
-        sel.dataset.feature = featureKey;
-        sel.dataset.index = si + i;
-      }
-    if (selectClass) sel.className = selectClass;
-    const def = document.createElement('option');
-    def.value = '';
-    def.textContent = 'Seleziona...';
-    sel.appendChild(def);
-    opts.forEach(o => {
-      const option = document.createElement('option');
-      option.value = o;
-      option.textContent = o;
-      sel.appendChild(option);
-    });
-    const saved = featureKey ? selectedData[featureKey]?.[si + i] || '' : '';
-    if (saved) sel.value = saved;
-    lab.appendChild(sel);
-    container.appendChild(lab);
-    selects.push(sel);
-  });
+    const selects = [];
+    const p = document.createElement('p');
+    const descId = `${type}-conflict-desc-${Date.now()}`;
+    p.id = descId;
+    p.tabIndex = 0;
+    p.innerHTML = `<strong>${label} duplicate, scegli sostituti:</strong>`;
+    container.appendChild(p);
+      conflicts.forEach((conflict, i) => {
+        const lab = document.createElement('label');
+        const sourceInfo = conflict.ownedFrom?.length ? ` (${conflict.ownedFrom.join(', ')})` : '';
+        const selectId = `${type}-conflict-${si + i}`;
+        lab.setAttribute('for', selectId);
+        lab.textContent = `${conflict.key}${sourceInfo}: `;
+        const sel = document.createElement('select');
+        sel.id = selectId;
+        sel.setAttribute('aria-describedby', descId);
+        sel.tabIndex = 0;
+        if (featureKey) {
+          sel.dataset.feature = featureKey;
+          sel.dataset.index = si + i;
+        }
+        const grantId = `${source || 'unknown'}:${type}:${conflict.key}:${i}`;
+        sel.dataset.grantId = grantId;
+        registerConflict(grantId, { ...conflict, type, source });
+        if (selectClass) sel.className = selectClass;
+        const def = document.createElement('option');
+        def.value = '';
+        def.textContent = 'Seleziona...';
+        sel.appendChild(def);
+        opts.forEach(o => {
+          const option = document.createElement('option');
+          option.value = o;
+          option.textContent = o;
+          sel.appendChild(option);
+        });
+        const saved = featureKey ? selectedData[featureKey]?.[si + i] || '' : '';
+        if (saved) sel.value = saved;
+        lab.appendChild(sel);
+        container.appendChild(lab);
+        selects.push(sel);
+      });
   const update = () => {
     const chosen = new Set(selects.map(s => s.value).filter(Boolean));
     selects.forEach(sel => {
@@ -101,7 +113,18 @@ export function renderProficiencyReplacements(
     });
     if (changeHandler) changeHandler(selects.map(s => s.value));
   };
-  selects.forEach(sel => sel.addEventListener('change', update));
+  selects.forEach(sel =>
+    sel.addEventListener('change', () => {
+      const val = sel.value;
+      if (val) {
+        const resolved = resolveConflict(sel.dataset.grantId, val);
+        sel.classList.toggle('resolved', resolved);
+      } else {
+        sel.classList.remove('resolved');
+      }
+      update();
+    })
+  );
   update();
   return selects;
 }

--- a/js/step4.js
+++ b/js/step4.js
@@ -102,6 +102,7 @@ function renderDuplicateSelectors(type, detailsEl, baseList, allOptions) {
     label,
     selectClass,
     getTakenOptions: { excludeBackground: true },
+    source: 'background',
     changeHandler: values => {
       const chosen = values.filter(Boolean);
       window.backgroundData[type] = base.concat(chosen);


### PR DESCRIPTION
## Summary
- Track conflicts via registry and add `resolveConflict` to validate replacements, update state, and log swaps
- Register and resolve proficiency conflicts from UI with accessible prompts and keyboard-friendly selectors
- Pass source context for replacements across class, race, and background flows

## Testing
- ⚠️ `npm test` (missing script: test)
- ⚠️ `npm run build` (RollupError: Node tried to load configuration as CommonJS)


------
https://chatgpt.com/codex/tasks/task_e_68a6f8e05794832ea6b6a99aa53259ed