### PR TITLE
feat: add step undo functionality

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -10,6 +10,7 @@ import {
   renderFinalRecap
 } from './script.js';
 import { resetSelectedData } from './state.js';
+import { undoToStep } from './characterState.js';
 import './step4.js';
 import './step5.js';
 import './step7.js';
@@ -139,10 +140,24 @@ document.addEventListener('DOMContentLoaded', () => {
     }
   );
 
-  ['step1','step2','step3','step4','step5','step6','step7'].forEach((stepId, idx) => {
+  const stepIds = ['step1','step2','step3','step4','step5','step6','step7'];
+  const stepMapForUndo = {
+    step2: 'class',
+    step3: 'race',
+    step4: 'background',
+    step5: 'equipment',
+    step6: 'abilities',
+  };
+  stepIds.forEach((stepId, idx) => {
     const btn = document.getElementById(`btnStep${idx + 1}`);
     if (btn) btn.addEventListener('click', () => {
       if (!validateStepsUpTo(idx)) return;
+      const currentId = localStorage.getItem('currentStep') || 'step1';
+      const currentIdx = stepIds.indexOf(currentId);
+      if (idx < currentIdx) {
+        const undoId = stepMapForUndo[stepId];
+        if (undoId) undoToStep(undoId);
+      }
       showStep(stepId);
       if (stepId === 'step7') renderFinalRecap();
     });

--- a/js/stepEngine.js
+++ b/js/stepEngine.js
@@ -1,4 +1,4 @@
-import { getState, saveState } from './characterState.js';
+import { getState, saveState, recordStep } from './characterState.js';
 
 /**
  * Applies the grants of a step to the character state and reports any conflicts.
@@ -41,5 +41,6 @@ export function applyStep(step, grants = {}, choices = {}) {
   }
 
   saveState();
+  recordStep(step, grants, choices);
   return { characterState: state, conflicts };
 }


### PR DESCRIPTION
## Summary
- track completed steps and swap resolutions in character state
- allow undoing to a previous step and replaying remaining steps
- wire step navigation to invoke undo when going backwards

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build` *(fails: Duplicate export 'registerConflict')*

------
https://chatgpt.com/codex/tasks/task_e_68a710deb5e8832e859eaa90e492fdc4