### PR TITLE
Add unit tests for character state

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -1,3 +1,3 @@
-module.exports = {
+export default {
   testEnvironment: 'jsdom',
 };

--- a/js/characterState.js
+++ b/js/characterState.js
@@ -26,7 +26,9 @@ function cloneDefaultState() {
 
 import { applyStep } from './stepEngine.js';
 
-let state = loadState();
+let state;
+
+loadState();
 
 export function loadState() {
   const stored = sessionStorage.getItem('characterState');

--- a/package.json
+++ b/package.json
@@ -2,10 +2,11 @@
   "name": "foundry-character-creator",
   "version": "1.0.0",
   "private": true,
+  "type": "module",
   "scripts": {
     "build": "rollup -c",
     "dev": "rollup -c -w",
-    "test": "jest"
+    "test": "node --experimental-vm-modules ./node_modules/jest/bin/jest.js"
   },
   "devDependencies": {
     "@rollup/plugin-commonjs": "^28.0.6",

--- a/tests/characterState.test.js
+++ b/tests/characterState.test.js
@@ -1,0 +1,97 @@
+
+import { jest } from '@jest/globals';
+
+function createSessionStorage() {
+  let store = {};
+  return {
+    getItem: jest.fn(key => (key in store ? store[key] : null)),
+    setItem: jest.fn((key, value) => {
+      store[key] = String(value);
+    }),
+    removeItem: jest.fn(key => {
+      delete store[key];
+    }),
+    clear: jest.fn(() => {
+      store = {};
+    }),
+    _getStore: () => store,
+  };
+}
+
+describe('character state', () => {
+  let addProficiency;
+  let removeProficiency;
+  let resetState;
+  let getState;
+  let recordStep;
+  let logSwap;
+  let storage;
+
+  beforeEach(async () => {
+    jest.resetModules();
+    storage = createSessionStorage();
+    Object.defineProperty(window, 'sessionStorage', {
+      value: storage,
+      configurable: true,
+    });
+    ({
+      addProficiency,
+      removeProficiency,
+      resetState,
+      getState,
+      recordStep,
+      logSwap,
+    } = await import('../js/characterState.js'));
+  });
+
+  test('addProficiency ignores calls without type or key', () => {
+    addProficiency('', 'stealth');
+    addProficiency('skill', null);
+    expect(getState().proficiencies).toHaveLength(0);
+    expect(storage.setItem).not.toHaveBeenCalled();
+  });
+
+  test('addProficiency merges sources without duplicates', () => {
+    addProficiency('skill', 'stealth', 'class');
+    addProficiency('skill', 'stealth', 'class');
+    addProficiency('skill', 'stealth', 'background');
+    expect(getState().proficiencies).toEqual([
+      { type: 'skill', key: 'stealth', sources: ['class', 'background'] },
+    ]);
+  });
+
+  test('removeProficiency removes specified source and deletes entry when last source gone', () => {
+    addProficiency('skill', 'stealth', 'class');
+    addProficiency('skill', 'stealth', 'background');
+    removeProficiency('skill', 'stealth', 'class');
+    expect(getState().proficiencies).toEqual([
+      { type: 'skill', key: 'stealth', sources: ['background'] },
+    ]);
+    removeProficiency('skill', 'stealth', 'background');
+    expect(getState().proficiencies).toHaveLength(0);
+  });
+
+  test('removeProficiency does nothing when entry is missing', () => {
+    removeProficiency('skill', 'stealth');
+    expect(getState().proficiencies).toHaveLength(0);
+    expect(storage.setItem).not.toHaveBeenCalled();
+  });
+
+  test('resetState restores default structure', () => {
+    addProficiency('skill', 'stealth', 'class');
+    recordStep('step1');
+    logSwap({ step: 'step1', conflicts: { foo: 'bar' } });
+    expect(getState()).not.toEqual({
+      proficiencies: [],
+      stepsCompleted: [],
+      swapLog: [],
+    });
+    resetState();
+    expect(getState()).toEqual({
+      proficiencies: [],
+      stepsCompleted: [],
+      swapLog: [],
+    });
+  });
+});
+


### PR DESCRIPTION
## Summary
- add tests for proficiency management and state reset
- mock sessionStorage to control character state during tests
- adjust character state initialization for ES module loading

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a749d5a214832eb1e519567e5b778b