### PR TITLE
Add character creation integration test

### DIFF
--- a/tests/characterCreation.test.js
+++ b/tests/characterCreation.test.js
@@ -1,0 +1,133 @@
+import { jest } from '@jest/globals';
+
+function createSessionStorage() {
+  let store = {};
+  return {
+    getItem: jest.fn(key => (key in store ? store[key] : null)),
+    setItem: jest.fn((key, value) => {
+      store[key] = String(value);
+    }),
+    removeItem: jest.fn(key => {
+      delete store[key];
+    }),
+    clear: jest.fn(() => {
+      store = {};
+    }),
+  };
+}
+
+describe('character creation flow', () => {
+  let applyStep;
+  let getState;
+  let resetState;
+  let setSelectedData;
+  let getSelectedData;
+  let filterSpells;
+  let getTakenProficiencies;
+  let renderProficiencyReplacements;
+  let ALL_SKILLS;
+  let storage;
+
+  beforeEach(async () => {
+    jest.resetModules();
+    storage = createSessionStorage();
+    Object.defineProperty(window, 'sessionStorage', {
+      value: storage,
+      configurable: true,
+    });
+    await jest.unstable_mockModule('jspdf', () => ({ jsPDF: jest.fn() }));
+    await jest.unstable_mockModule('html2canvas', () => ({ default: jest.fn() }));
+    ({ applyStep } = await import('../js/stepEngine.js'));
+    ({ getState, resetState } = await import('../js/characterState.js'));
+    ({ setSelectedData, getSelectedData } = await import('../js/state.js'));
+    ({ filterSpells } = await import('../js/spellcasting.js'));
+    ({ getTakenProficiencies } = await import('../js/script.js'));
+    ({ renderProficiencyReplacements } = await import('../js/selectionUtils.js'));
+    ({ ALL_SKILLS } = await import('../js/data/proficiencies.js'));
+    resetState();
+    setSelectedData({});
+  });
+
+  test('complete selection without duplicates', () => {
+    const mergeSelectedData = update => setSelectedData({ ...getSelectedData(), ...update });
+
+    // Class step: skills and cantrips
+    applyStep('class', { proficiencies: { skills: ['History', 'Medicine'] } });
+    mergeSelectedData({
+      'Skill Proficiency': ['History', 'Medicine'],
+      Cantrips: ['Ray of Frost', 'Fire Bolt'],
+    });
+
+    // Race step: languages and racial cantrip
+    applyStep('race', { proficiencies: { languages: ['Common', 'Elvish', 'Dwarvish'] } });
+    mergeSelectedData({ Languages: ['Common', 'Elvish', 'Dwarvish'] });
+    const spells = [
+      { name: 'Ray of Frost', level: 0, spell_list: ['Wizard'] },
+      { name: 'Fire Bolt', level: 0, spell_list: ['Wizard'] },
+      { name: 'Light', level: 0, spell_list: ['Wizard'] },
+    ];
+    const takenCantrips = new Set(
+      getSelectedData().Cantrips.map(c => c.toLowerCase())
+    );
+    const available = filterSpells(spells, 'level=0|class=Wizard').filter(
+      s => !takenCantrips.has(s.name.toLowerCase())
+    );
+    expect(available.map(s => s.name)).toEqual(['Light']);
+    mergeSelectedData({ Cantrips: [...getSelectedData().Cantrips, 'Light'] });
+
+    // Background step: handle duplicate history and choose replacement
+    const baseSkills = ['Arcana', 'History'];
+    const { conflicts } = getTakenProficiencies('skills', baseSkills);
+    expect(conflicts.map(c => c.key)).toEqual(['History']);
+    const container = document.createElement('div');
+    const chosen = [];
+    const selects = renderProficiencyReplacements(
+      'skills',
+      baseSkills,
+      ALL_SKILLS,
+      container,
+      {
+        label: 'Skill',
+        source: 'background',
+        changeHandler: vals => {
+          chosen.splice(0, chosen.length, ...vals.filter(Boolean));
+        },
+      }
+    );
+    expect(selects).toHaveLength(1);
+    selects[0].value = 'Religion';
+    selects[0].dispatchEvent(new Event('change'));
+    const finalSkills = ['Arcana', ...chosen];
+    applyStep('background', { proficiencies: { skills: finalSkills } });
+    mergeSelectedData({
+      'Skill Proficiency': ['History', 'Medicine', ...finalSkills],
+    });
+
+    // Final state and selections
+    const state = getState();
+    const expected = [
+      { type: 'skills', key: 'History', sources: ['class'] },
+      { type: 'skills', key: 'Medicine', sources: ['class'] },
+      { type: 'languages', key: 'Common', sources: ['race'] },
+      { type: 'languages', key: 'Elvish', sources: ['race'] },
+      { type: 'languages', key: 'Dwarvish', sources: ['race'] },
+      { type: 'skills', key: 'Arcana', sources: ['background'] },
+      { type: 'skills', key: 'Religion', sources: ['background'] },
+    ];
+    expected.forEach(p => expect(state.proficiencies).toContainEqual(p));
+    expect(state.proficiencies).toHaveLength(expected.length);
+
+    const finalData = getSelectedData();
+    expect(finalData).toEqual({
+      Cantrips: ['Ray of Frost', 'Fire Bolt', 'Light'],
+      Languages: ['Common', 'Elvish', 'Dwarvish'],
+      'Skill Proficiency': ['History', 'Medicine', 'Arcana', 'Religion'],
+    });
+    expect(new Set(finalData.Cantrips).size).toBe(finalData.Cantrips.length);
+    expect(new Set(finalData.Languages).size).toBe(finalData.Languages.length);
+    expect(new Set(finalData['Skill Proficiency']).size).toBe(
+      finalData['Skill Proficiency'].length
+    );
+  });
+});
+


### PR DESCRIPTION
## Summary
- add integration test for class, race, and background selection workflow
- verify duplicate proficiency replacement and cantrip filtering

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a7721ac4cc832e90ceea587922d4ec