### PR TITLE
Persist class and race proficiencies for duplicate handling

### DIFF
--- a/js/classFeatures.js
+++ b/js/classFeatures.js
@@ -4,7 +4,7 @@ import { gatherExtraSelections, initFeatureSelectionHandlers, saveFeatureSelecti
 import { setExtraSelections } from './extrasState.js';
 import { extraCategoryAliases } from './extrasModal.js';
 import { convertDetailsToAccordion, initializeAccordion } from './ui/accordion.js';
-import { getSelectedData } from './state.js';
+import { getSelectedData, setSelectedData } from './state.js';
 import { ALL_LANGUAGES, ALL_SKILLS } from './data/proficiencies.js';
 import { renderProficiencyReplacements } from './selectionUtils.js';
 
@@ -115,7 +115,12 @@ export async function renderClassFeatures() {
             label,
             selectedData: getSelectedData(),
             getTakenOptions: { excludeClass: true },
-            changeHandler: () => setTimeout(render, 0),
+            changeHandler: values => {
+              const d = getSelectedData();
+              d[featureKey] = values;
+              setSelectedData(d);
+              setTimeout(render, 0);
+            },
             source: 'class',
           }
         );

--- a/js/main.js
+++ b/js/main.js
@@ -9,7 +9,8 @@ import {
   initializeValues,
   renderFinalRecap
 } from './script.js';
-import { resetSelectedData } from './state.js';
+import { resetSelectedData, getSelectedData } from './state.js';
+import { applyStep } from './stepEngine.js';
 import { undoToStep } from './characterState.js';
 import './step4.js';
 import './step5.js';
@@ -274,6 +275,21 @@ document.addEventListener('DOMContentLoaded', () => {
       return;
     }
     classSelectionConfirmed = true;
+    const sel = getSelectedData();
+    const grants = { proficiencies: { skills: [], tools: [], languages: [], cantrips: [] } };
+    const data = window.currentClassData || {};
+    if (data.skill_proficiencies?.fixed) grants.proficiencies.skills.push(...data.skill_proficiencies.fixed);
+    if (data.tool_proficiencies?.fixed) grants.proficiencies.tools.push(...data.tool_proficiencies.fixed);
+    if (data.language_proficiencies?.fixed) grants.proficiencies.languages.push(...data.language_proficiencies.fixed);
+    if (data.spellcasting?.fixed_cantrips) grants.proficiencies.cantrips.push(...data.spellcasting.fixed_cantrips);
+    if (sel['Skill Proficiency']) grants.proficiencies.skills.push(...sel['Skill Proficiency'].filter(Boolean));
+    if (sel['Tool Proficiency']) grants.proficiencies.tools.push(...sel['Tool Proficiency'].filter(Boolean));
+    if (sel['Languages']) grants.proficiencies.languages.push(...sel['Languages'].filter(Boolean));
+    if (sel['Cantrips']) grants.proficiencies.cantrips.push(...sel['Cantrips'].filter(Boolean));
+    for (const key of Object.keys(grants.proficiencies)) {
+      grants.proficiencies[key] = [...new Set(grants.proficiencies[key])].filter(Boolean);
+    }
+    applyStep('class', grants);
     await renderClassFeatures();
     const confirmBtn = document.getElementById('confirmClassSelection');
     if (confirmBtn) confirmBtn.style.display = 'none';
@@ -290,6 +306,22 @@ document.addEventListener('DOMContentLoaded', () => {
       return;
     }
     raceSelectionConfirmed = true;
+    const sel = getSelectedData();
+    const grants = { proficiencies: { skills: [], tools: [], languages: [], cantrips: [] } };
+    const data = window.currentRaceData || {};
+    if (data.languages?.fixed) grants.proficiencies.languages.push(...data.languages.fixed);
+    if (data.skill_choices?.fixed) grants.proficiencies.skills.push(...data.skill_choices.fixed);
+    if (data.tool_choices?.fixed) grants.proficiencies.tools.push(...data.tool_choices.fixed);
+    if (data.spellcasting?.fixed_cantrips) grants.proficiencies.cantrips.push(...data.spellcasting.fixed_cantrips);
+    if (data.spellcasting?.fixed_spell) grants.proficiencies.cantrips.push(data.spellcasting.fixed_spell);
+    if (sel['Skill Proficiency']) grants.proficiencies.skills.push(...sel['Skill Proficiency'].filter(Boolean));
+    if (sel['Tool Proficiency']) grants.proficiencies.tools.push(...sel['Tool Proficiency'].filter(Boolean));
+    if (sel['Languages']) grants.proficiencies.languages.push(...sel['Languages'].filter(Boolean));
+    if (sel['Cantrips']) grants.proficiencies.cantrips.push(...sel['Cantrips'].filter(Boolean));
+    for (const key of Object.keys(grants.proficiencies)) {
+      grants.proficiencies[key] = [...new Set(grants.proficiencies[key])].filter(Boolean);
+    }
+    applyStep('race', grants);
     document.getElementById('confirmRaceSelection').style.display = 'none';
   });
 

--- a/js/raceTraits.js
+++ b/js/raceTraits.js
@@ -196,7 +196,12 @@ export async function displayRaceTraits() {
             label: labels[featureKey],
             selectedData: getSelectedData(),
             getTakenOptions: { excludeRace: true },
-            changeHandler: () => setTimeout(render, 0),
+            changeHandler: values => {
+              const d = getSelectedData();
+              d[featureKey] = values;
+              setSelectedData(d);
+              setTimeout(render, 0);
+            },
             source: 'race',
           }
         );

--- a/js/script.js
+++ b/js/script.js
@@ -230,9 +230,17 @@ export function resolveConflict(grantId, replacement) {
 function gatherExtraSelections(data, context, level = 1) {
   const selections = [];
 
-  const takenLangs = getTakenProficiencies('languages');
-  const takenSkills = getTakenProficiencies('skills');
-  const takenTools = getTakenProficiencies('tools');
+  // Exclude proficiencies granted by the current context so already
+  // selected options remain available when re-rendering the same step.
+  const exclusion = {
+    excludeClass: context === 'class',
+    excludeRace: context === 'race',
+    excludeBackground: context === 'background',
+  };
+
+  const takenLangs = getTakenProficiencies('languages', undefined, exclusion);
+  const takenSkills = getTakenProficiencies('skills', undefined, exclusion);
+  const takenTools = getTakenProficiencies('tools', undefined, exclusion);
 
   if (context === "race") {
     if (data.languages && (data.languages.fixed.length > 0 || data.languages.choice > 0)) {

--- a/tests/characterCreation.test.js
+++ b/tests/characterCreation.test.js
@@ -24,6 +24,7 @@ describe('character creation flow', () => {
   let getSelectedData;
   let filterSpells;
   let getTakenProficiencies;
+  let gatherExtraSelections;
   let renderProficiencyReplacements;
   let ALL_SKILLS;
   let storage;
@@ -41,7 +42,7 @@ describe('character creation flow', () => {
     ({ getState, resetState } = await import('../js/characterState.js'));
     ({ setSelectedData, getSelectedData } = await import('../js/state.js'));
     ({ filterSpells } = await import('../js/spellcasting.js'));
-    ({ getTakenProficiencies } = await import('../js/script.js'));
+    ({ getTakenProficiencies, gatherExtraSelections } = await import('../js/script.js'));
     ({ renderProficiencyReplacements } = await import('../js/selectionUtils.js'));
     ({ ALL_SKILLS } = await import('../js/data/proficiencies.js'));
     resetState();
@@ -127,6 +128,29 @@ describe('character creation flow', () => {
     expect(new Set(finalData.Languages).size).toBe(finalData.Languages.length);
     expect(new Set(finalData['Skill Proficiency']).size).toBe(
       finalData['Skill Proficiency'].length
+    );
+  });
+
+  test('class selections retain chosen skills after confirmation', () => {
+    // Confirm class with History and Nature
+    applyStep('class', { proficiencies: { skills: ['History', 'Nature'] } });
+    setSelectedData({ 'Skill Proficiency': ['History', 'Nature'] });
+
+    // Gather selections for class again and ensure choices include taken skills
+    const data = {
+      choices: [
+        {
+          name: 'Skill Proficiency',
+          selection: ['Arcana', 'History', 'Nature', 'Medicine'],
+          count: 2,
+        },
+      ],
+    };
+
+    const selections = gatherExtraSelections(data, 'class', 1);
+    const skillChoice = selections.find(c => c.name === 'Skill Proficiency');
+    expect(skillChoice.selection).toEqual(
+      expect.arrayContaining(['History', 'Nature'])
     );
   });
 });


### PR DESCRIPTION
## Summary
- Apply class and race proficiencies to character state when confirmed
- Save replacement selections for class and race duplicates
- Deduplicate proficiencies before committing
- Exclude step's own proficiencies when gathering selections so chosen skills remain visible

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a78339feb0832e98d98ce3cb789a92