### PR TITLE
Align equipment step styling with other steps

### DIFF
--- a/js/step5.js
+++ b/js/step5.js
@@ -57,7 +57,7 @@ function renderEquipment() {
     if (Array.isArray(classInfo.choices)) {
       classInfo.choices.forEach((choice, idx) => {
         const detail = document.createElement('details');
-        detail.className = 'feature-block needs-selection incomplete';
+        detail.className = 'feature-block needs-selection incomplete user-choice';
         detail.innerHTML = `<summary>${choice.label || 'Choose'}</summary>`;
         const options = [];
         (choice.options || []).forEach(opt => {
@@ -78,6 +78,7 @@ function renderEquipment() {
           const select = document.createElement('select');
           select.name = `equipChoice_${idx}`;
           select.id = `equipChoice_${idx}`;
+          select.className = 'form-control';
           const placeholder = document.createElement('option');
           placeholder.value = '';
           placeholder.textContent = '-- select --';
@@ -111,6 +112,7 @@ function renderEquipment() {
               detail.appendChild(input);
               detail.appendChild(lab);
               const select = document.createElement('select');
+              select.className = 'form-control';
               const placeholder = document.createElement('option');
               placeholder.value = '';
               placeholder.textContent = '-- select --';


### PR DESCRIPTION
## Summary
- Highlight equipment choices using existing 'user-choice' styling
- Use standard form-control styling for equipment selects

## Testing
- `npm test` *(fails: Jest encountered an unexpected token in tests/characterCreation.test.js)*

------
https://chatgpt.com/codex/tasks/task_e_68a79d6492e0832e93768112138a6109