### PR TITLE
Fix class skill option filtering

### DIFF
--- a/js/script.js
+++ b/js/script.js
@@ -295,8 +295,22 @@ function gatherExtraSelections(data, context, level = 1) {
   } else {
     exclusion = {};
   }
+  let fixedSkills;
+  if (context === 'class') {
+    fixedSkills = new Set(
+      (window.currentClassData?.skill_proficiencies?.fixed || []).map(s =>
+        s.toLowerCase()
+      )
+    );
+  }
   const takenLangs = getTakenProficiencies('languages', undefined, exclusion);
-  const takenSkills = getTakenProficiencies('skills', undefined, exclusion);
+  const takenSkills = getTakenProficiencies(
+    'skills',
+    undefined,
+    exclusion,
+    context === 'class' ? 'class' : undefined,
+    context === 'class' ? { classFixed: fixedSkills } : undefined
+  );
   const takenTools = getTakenProficiencies('tools', undefined, exclusion);
 
   if (context === "race") {
@@ -341,9 +355,6 @@ function gatherExtraSelections(data, context, level = 1) {
 
     // Class choices should present the full option list, only removing the
     // class's own fixed proficiencies so the user doesn't pick them again.
-    const fixedSkills = new Set(
-      (window.currentClassData?.skill_proficiencies?.fixed || []).map(s => s.toLowerCase())
-    );
     const fixedLangs = new Set(
       (window.currentClassData?.language_proficiencies?.fixed || []).map(l => l.toLowerCase())
     );

--- a/tests/characterCreation.test.js
+++ b/tests/characterCreation.test.js
@@ -199,6 +199,32 @@ describe('character creation flow', () => {
     expect(skillChoice.selection).not.toContain('Perception');
   });
 
+  test('class selection includes skills granted by race/background', () => {
+    applyStep('race', { proficiencies: { skills: ['Stealth'] } });
+    applyStep('background', { proficiencies: { skills: ['History'] } });
+
+    window.currentClassData = {
+      skill_proficiencies: { fixed: ['Perception'] },
+    };
+
+    const data = {
+      choices: [
+        {
+          name: 'Skill Proficiency',
+          selection: ['Stealth', 'History', 'Nature', 'Arcana', 'Perception'],
+          count: 2,
+        },
+      ],
+    };
+
+    const selections = gatherExtraSelections(data, 'class', 1);
+    const skillChoice = selections.find(c => c.name === 'Skill Proficiency');
+    expect(skillChoice.selection).toEqual(
+      expect.arrayContaining(['Stealth', 'History', 'Nature', 'Arcana'])
+    );
+    expect(skillChoice.selection).not.toContain('Perception');
+  });
+
   test('race filters out previously known proficiencies', () => {
     applyStep('class', { proficiencies: { languages: ['Common', 'Elvish'] } });
     const raceData = {


### PR DESCRIPTION
## Summary
- ensure gatherExtraSelections passes class context and classFixed set to getTakenProficiencies
- add regression test for class selections with race/background skills

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a84061bb38832ebaea3ded76a50a08