### PR TITLE
chore: add debug logs for skill selection

### DIFF
--- a/js/script.js
+++ b/js/script.js
@@ -144,6 +144,7 @@ function getTakenSelections(type, opts = {}) {
     }
   }
 
+  console.debug(`[getTakenSelections] returning set for type=${type}:`, Array.from(taken));
   return taken;
 }
 
@@ -365,6 +366,7 @@ function gatherExtraSelections(data, context, level = 1) {
         if (key === 'Tool Proficiency') return; // tool choices handled in equipment
         const selected = (selectedData[key] || []).filter(v => v);
         let opts = choice.selection || choice.options || [];
+        console.debug('[gatherExtraSelections] opts before fallback/filter:', opts);
         console.debug('[gatherExtraSelections] raw options for', key, opts);
 
         if (key === 'Skill Proficiency') {


### PR DESCRIPTION
## Summary
- log taken selections before returning them
- log class choice options before filtering

## Testing
- `npm test 2>&1 | tail -n 20`


------
https://chatgpt.com/codex/tasks/task_e_68a84d4a3728832ea1d0d49efbab31bf