### PR TITLE
Fix background skill filtering

### DIFF
--- a/js/step4.js
+++ b/js/step4.js
@@ -167,7 +167,7 @@ document.addEventListener("DOMContentLoaded", async () => {
         (data.skillChoices && data.skillChoices.options) ? data.skillChoices.options : ALL_SKILLS;
       if (data.skillChoices) {
         const num = data.skillChoices.choose || 0;
-        const taken = getTakenProficiencies('skills');
+        const taken = getTakenProficiencies('skills', undefined, { excludeBackground: true }, 'background');
         let opts = (data.skillChoices.options || []).filter(o => !taken.has(o.toLowerCase()));
         let note = '';
         if (opts.length === 0) {


### PR DESCRIPTION
## Summary
- ensure background skill choices ignore current background selections when filtering taken skills

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a85793f0c8832e8fa34d5f614cd92f