### PR TITLE
Load class data individually

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -68,8 +68,24 @@ function showStep(step) {
 }
 
 async function loadData() {
+  // Load each class file referenced in data/classes.json
+  const classIndexRes = await fetch("data/classes.json");
+  if (!classIndexRes.ok) {
+    throw new Error("Failed loading classes");
+  }
+  const classIndex = await classIndexRes.json();
+  DATA.classes = [];
+  for (const path of Object.values(classIndex.items || {})) {
+    const res = await fetch(path);
+    if (!res.ok) {
+      throw new Error(`Failed loading class at ${path}`);
+    }
+    const cls = await res.json();
+    DATA.classes.push(cls);
+  }
+
+  // Retain existing logic for other data types
   const sources = {
-    classes: "data/classes.json",
     races: "data/races.json",
     backgrounds: "data/backgrounds.json",
     languages: "data/languages.json",

--- a/src/step2.js
+++ b/src/step2.js
@@ -14,7 +14,7 @@ export function loadStep2() {
   if (!classListContainer) return;
   classListContainer.innerHTML = '';
 
-  if (!DATA.classes || !Array.isArray(DATA.classes)) {
+  if (!DATA.classes) {
     console.error('Dati classi non disponibili.');
     return;
   }


### PR DESCRIPTION
## Summary
- Fetch each class file from data/classes.json and build DATA.classes as an array of class objects
- Simplify step 2 data check now that class data is always an array

## Testing
- `npm test -- --passWithNoTests`


------
https://chatgpt.com/codex/tasks/task_e_68a877f19680832e8ecc5ab5b8916ff7