### PR TITLE
Fix Step 2 class list rendering

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -334,6 +334,8 @@ document.addEventListener("DOMContentLoaded", () => {
     .then(() => {
       populateRaceList();
       populateBackgroundList();
+      // Ensure class list is rendered once data becomes available
+      loadStep2();
       const raceSel = document.getElementById("raceSelect");
       raceSel?.addEventListener("change", handleRaceChange);
       const bgSel = document.getElementById("backgroundSelect");

--- a/src/step2.js
+++ b/src/step2.js
@@ -13,13 +13,13 @@ export function loadStep2() {
   const classListContainer = document.getElementById('classList');
   if (!classListContainer) return;
   classListContainer.innerHTML = '';
-
-  if (!DATA.classes) {
+  const classes = Array.isArray(DATA.classes) ? DATA.classes : [];
+  if (!classes.length) {
     console.error('Dati classi non disponibili.');
     return;
   }
 
-  DATA.classes.forEach(cls => {
+  classes.forEach(cls => {
     const classCard = document.createElement('div');
     classCard.className = 'class-card';
     if (CharacterState.class && CharacterState.class.name === cls.name) {


### PR DESCRIPTION
## Summary
- Populate class list after data finishes loading so Step 2 always has classes available
- Guard against missing class data when rendering Step 2

## Testing
- `npm test -- --passWithNoTests`


------
https://chatgpt.com/codex/tasks/task_e_68a8792ead00832e97bd999a0ebc038e