### PR TITLE
Ensure Step 2 loads class data from JSON

### DIFF
--- a/src/data.js
+++ b/src/data.js
@@ -1,5 +1,26 @@
 export const DATA = {};
 
+/**
+ * Fetches class data from the JSON index if it hasn't been loaded yet.
+ * The resulting array of class objects is stored on `DATA.classes`.
+ */
+export async function loadClasses() {
+  // Avoid re-fetching if classes are already present
+  if (Array.isArray(DATA.classes) && DATA.classes.length) return;
+
+  const indexRes = await fetch('data/classes.json');
+  if (!indexRes.ok) throw new Error('Failed loading classes');
+  const index = await indexRes.json();
+
+  DATA.classes = [];
+  for (const path of Object.values(index.items || {})) {
+    const res = await fetch(path);
+    if (!res.ok) throw new Error(`Failed loading class at ${path}`);
+    const cls = await res.json();
+    DATA.classes.push(cls);
+  }
+}
+
 export const CharacterState = {
   name: "",
   level: 1,

--- a/src/main.js
+++ b/src/main.js
@@ -1,4 +1,4 @@
-import { DATA, CharacterState } from "./data.js";
+import { DATA, CharacterState, loadClasses } from "./data.js";
 import { loadStep2 } from "./step2.js";
 
 let currentStep = 1;
@@ -69,20 +69,7 @@ function showStep(step) {
 
 async function loadData() {
   // Load each class file referenced in data/classes.json
-  const classIndexRes = await fetch("data/classes.json");
-  if (!classIndexRes.ok) {
-    throw new Error("Failed loading classes");
-  }
-  const classIndex = await classIndexRes.json();
-  DATA.classes = [];
-  for (const path of Object.values(classIndex.items || {})) {
-    const res = await fetch(path);
-    if (!res.ok) {
-      throw new Error(`Failed loading class at ${path}`);
-    }
-    const cls = await res.json();
-    DATA.classes.push(cls);
-  }
+  await loadClasses();
 
   // Retain existing logic for other data types
   const sources = {

--- a/src/step2.js
+++ b/src/step2.js
@@ -1,4 +1,4 @@
-import { DATA, CharacterState } from './data.js';
+import { DATA, CharacterState, loadClasses } from './data.js';
 
 function createElement(tag, text) {
   const el = document.createElement(tag);
@@ -9,10 +9,19 @@ function createElement(tag, text) {
 /**
  * Inizializza lo Step 2: Selezione Classe
  */
-export function loadStep2() {
+export async function loadStep2() {
   const classListContainer = document.getElementById('classList');
   if (!classListContainer) return;
   classListContainer.innerHTML = '';
+
+  // Ensure the class data has been loaded before rendering
+  try {
+    await loadClasses();
+  } catch (err) {
+    console.error('Dati classi non disponibili.', err);
+    return;
+  }
+
   const classes = Array.isArray(DATA.classes) ? DATA.classes : [];
   if (!classes.length) {
     console.error('Dati classi non disponibili.');


### PR DESCRIPTION
## Summary
- add reusable `loadClasses` helper to fetch class data
- ensure Step 2 waits for class data before rendering
- simplify data loading by reusing helper

## Testing
- `npm test` *(fails: No tests found)*

------
https://chatgpt.com/codex/tasks/task_e_68a87b086d9c832eba42151bdc1f7263