### PR TITLE
Improve class selection styling

### DIFF
--- a/css/site-theme.css
+++ b/css/site-theme.css
@@ -282,11 +282,31 @@ th {
 }
 
 .class-card {
-  border: 1px solid #ccc;
-  padding: 10px;
+  border: 1px solid var(--accent-color);
+  border-radius: 8px;
+  padding: 15px;
   margin-bottom: 10px;
+  background-color: #fff;
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+  flex: 1 0 250px;
+  cursor: pointer;
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.class-card:hover {
+  transform: translateY(-2px);
+  box-shadow: 0 4px 8px rgba(0, 0, 0, 0.2);
 }
 
 .class-card.selected {
-  border-color: #007bff;
+  border-color: var(--primary-color);
+  box-shadow: 0 0 0 3px var(--primary-color);
+}
+
+.class-card h3 {
+  margin-top: 0;
+}
+
+.class-card button {
+  margin-top: 10px;
 }

--- a/src/step2.js
+++ b/src/step2.js
@@ -34,12 +34,17 @@ export async function loadStep2() {
     if (CharacterState.class && CharacterState.class.name === cls.name) {
       classCard.classList.add('selected');
     }
+    classCard.addEventListener('click', () => showClassModal(cls));
 
     const title = createElement('h3', cls.name);
     const desc = createElement('p', cls.description || 'Nessuna descrizione disponibile.');
 
     const detailsBtn = createElement('button', 'Dettagli');
-    detailsBtn.addEventListener('click', () => showClassModal(cls));
+    detailsBtn.className = 'btn btn-primary';
+    detailsBtn.addEventListener('click', e => {
+      e.stopPropagation();
+      showClassModal(cls);
+    });
 
     classCard.appendChild(title);
     classCard.appendChild(desc);


### PR DESCRIPTION
## Summary
- Style class selection cards with rounded, elevated design and hover effects
- Make class cards clickable and polish details button styling

## Testing
- `npm test` *(fails: No tests found)*
- `npm run build` *(fails: Cannot find module 'rollup.config.js')*


------
https://chatgpt.com/codex/tasks/task_e_68a87f36aadc832ea9d75e41f35c62a4