### PR TITLE
Display selected class features with choice indicators

### DIFF
--- a/index.html
+++ b/index.html
@@ -96,6 +96,7 @@
         </div>
         <div id="classList" class="class-list"></div>
         <p id="selectedClass"></p>
+        <div id="classFeatures" class="accordion hidden"></div>
       </div>
       <!-- Step 3: Scelta della Razza -->
       <div id="step3" class="step hidden">


### PR DESCRIPTION
## Summary
- Render selected class features as accordions after choosing a class
- Highlight choice-requiring features (skills, tools, subclasses, level choices) with distinct accordion styling
- Hide class list when a class is chosen and show detailed feature list

## Testing
- `npm test` (fails: No tests found)


------
https://chatgpt.com/codex/tasks/task_e_68a881977220832e84a9b3d6bf33e449