### PR TITLE
feat: log character state on user actions

### DIFF
--- a/src/data.js
+++ b/src/data.js
@@ -40,3 +40,8 @@ export const CharacterState = {
     cha: 8,
   },
 };
+
+export function logCharacterState() {
+  // Log a cloned copy to avoid reactive updates in the console
+  console.log("CharacterState", JSON.parse(JSON.stringify(CharacterState)));
+}

--- a/src/main.js
+++ b/src/main.js
@@ -1,4 +1,4 @@
-import { DATA, CharacterState, loadClasses } from "./data.js";
+import { DATA, CharacterState, loadClasses, logCharacterState } from "./data.js";
 import { loadStep2 } from "./step2.js";
 
 let currentStep = 1;
@@ -124,6 +124,7 @@ function addUniqueProficiency(type, value, container) {
   const list = CharacterState[type];
   if (!list.includes(value)) {
     list.push(value);
+    logCharacterState();
     return;
   }
   // handle duplicate with replacement
@@ -144,6 +145,7 @@ function addUniqueProficiency(type, value, container) {
     if (sel.value && !list.includes(sel.value)) {
       list.push(sel.value);
       sel.disabled = true;
+      logCharacterState();
     }
   });
   label.appendChild(sel);
@@ -223,6 +225,7 @@ function confirmRaceSelection() {
   const btn4 = document.getElementById("btnStep4");
   if (btn4) btn4.disabled = false;
   showStep(4);
+  logCharacterState();
 }
 
 // --- Step 4: Background selection handlers ---
@@ -301,6 +304,7 @@ function confirmBackgroundSelection() {
     }
   }
   showStep(5);
+  logCharacterState();
 }
 
 document.addEventListener("DOMContentLoaded", () => {

--- a/src/step2.js
+++ b/src/step2.js
@@ -1,4 +1,4 @@
-import { DATA, CharacterState, loadClasses } from './data.js';
+import { DATA, CharacterState, loadClasses, logCharacterState } from './data.js';
 
 function createElement(tag, text) {
   const el = document.createElement(tag);
@@ -132,6 +132,7 @@ function confirmClassSelection() {
     });
   }
 
+  logCharacterState();
   alert('Classe confermata!');
 }
 
@@ -174,6 +175,7 @@ export async function loadStep2() {
         CharacterState.skills = [];
         const btnStep3 = document.getElementById('btnStep3');
         if (btnStep3) btnStep3.disabled = true;
+        logCharacterState();
         loadStep2();
       };
     }
@@ -288,6 +290,6 @@ function selectClass(cls) {
 
   const btnStep3 = document.getElementById('btnStep3');
   if (btnStep3) btnStep3.disabled = false;
-
+  logCharacterState();
   loadStep2();
 }


### PR DESCRIPTION
## Summary
- log character state via new `logCharacterState` helper
- record user choices when adding proficiencies or confirming race, background, and class selections

## Testing
- `npm test -- --passWithNoTests`
- `npm run build` *(fails: Cannot find module 'rollup.config.js')*


------
https://chatgpt.com/codex/tasks/task_e_68a8863e8754832e984c77c88c95c119