### PR TITLE
feat: introduce multiclass character support

### DIFF
--- a/src/data.js
+++ b/src/data.js
@@ -34,8 +34,7 @@ export async function loadFeats() {
 
 export const CharacterState = {
   name: "",
-  level: 1,
-  class: null,
+  classes: [],
   race: null,
   background: null,
   skills: [],
@@ -53,6 +52,13 @@ export const CharacterState = {
     cha: 8,
   },
 };
+
+export function totalLevel() {
+  return (CharacterState.classes || []).reduce(
+    (sum, cls) => sum + (cls.level || 0),
+    0
+  );
+}
 
 export function logCharacterState() {
   // Log a cloned copy to avoid reactive updates in the console


### PR DESCRIPTION
## Summary
- store selected classes in CharacterState with helper to compute total level
- allow adding multiple classes and levels while skipping duplicates
- save class choices and merge proficiencies into global character state

## Testing
- `npm test -- --passWithNoTests`

------
https://chatgpt.com/codex/tasks/task_e_68ab00c7579c832eb6dbf4924833165e