### PR TITLE
feat: add link to expand multiclass selection

### DIFF
--- a/index.html
+++ b/index.html
@@ -99,6 +99,7 @@
         <div id="classFeatures" class="accordion hidden"></div>
         <div id="classActions" class="form-group hidden">
           <button id="changeClassButton" class="btn">Cambia Classe</button>
+          <p id="addClassPrompt" class="hidden"><a href="#" id="addClassLink">Add another class?</a></p>
           <button id="confirmClassButton" class="btn btn-primary">Conferma Classe</button>
         </div>
       </div>

--- a/src/step2.js
+++ b/src/step2.js
@@ -357,7 +357,7 @@ function handleASISelection(sel, container, saved = null) {
   }
 }
 
-function confirmClassSelection() {
+function confirmClassSelection(silent = false) {
   const features = document.getElementById('classFeatures');
   if (!features || !currentClass) return;
 
@@ -478,7 +478,7 @@ function confirmClassSelection() {
 
   CharacterState.classes.push(currentClass);
   logCharacterState();
-  alert('Classe confermata!');
+  if (!silent) alert('Classe confermata!');
   currentClass = null;
   savedSelections.skills = [];
   savedSelections.subclass = '';
@@ -497,6 +497,8 @@ export async function loadStep2() {
   const levelContainer = document.getElementById('levelContainer');
   const levelSelect = document.getElementById('levelSelect');
   const summary = document.getElementById('selectedClass');
+  const addClassPrompt = document.getElementById('addClassPrompt');
+  const addClassLink = document.getElementById('addClassLink');
   if (!classListContainer || !featuresContainer) return;
   classListContainer.innerHTML = '';
   featuresContainer.innerHTML = '';
@@ -526,6 +528,13 @@ export async function loadStep2() {
     featuresContainer.classList.remove('hidden');
     classActions?.classList.remove('hidden');
     levelContainer?.classList.remove('hidden');
+    addClassPrompt?.classList.remove('hidden');
+    if (addClassLink) {
+      addClassLink.onclick = e => {
+        e.preventDefault();
+        confirmClassSelection(true);
+      };
+    }
     if (levelSelect) {
       levelSelect.value = currentClass.level || '1';
       levelSelect.onchange = () => {
@@ -547,6 +556,7 @@ export async function loadStep2() {
     featuresContainer.classList.add('hidden');
     classActions?.classList.add('hidden');
     levelContainer?.classList.add('hidden');
+    addClassPrompt?.classList.add('hidden');
   }
 
   const classes = Array.isArray(DATA.classes) ? DATA.classes : [];


### PR DESCRIPTION
## Summary
- Offer "Add another class?" prompt above class confirmation
- Support silent class confirmation through new argument

## Testing
- `npm test -- --passWithNoTests`


------
https://chatgpt.com/codex/tasks/task_e_68ab1de9b1d4832e8132ee65ad73f7db