### PR TITLE
feat: export character to foundry json

### DIFF
--- a/__tests__/export.test.js
+++ b/__tests__/export.test.js
@@ -1,0 +1,65 @@
+import { exportFoundryActor } from "../src/export.js";
+import fs from "fs";
+
+const template = JSON.parse(
+  fs.readFileSync(new URL("./fixtures/sample-actor.json", import.meta.url))
+);
+
+describe("exportFoundryActor", () => {
+  test("matches sample template", () => {
+    const state = {
+      name: "Hero",
+      type: "character",
+      classes: [{ name: "Fighter", level: 1 }],
+      feats: ["Lucky"],
+      equipment: [{ name: "Dagger", type: "weapon" }],
+      system: {
+        abilities: {
+          str: { value: 10 },
+          dex: { value: 10 },
+          con: { value: 10 },
+          int: { value: 10 },
+          wis: { value: 10 },
+          cha: { value: 10 },
+        },
+        skills: [],
+        currency: { pp: 0, gp: 0, ep: 0, sp: 0, cp: 0 },
+        attributes: {
+          ac: 10,
+          hp: { value: 10, max: 10 },
+          init: { value: 0 },
+          prof: 2,
+        },
+        details: { background: "", race: "", alignment: "" },
+        traits: {
+          size: "med",
+          senses: { darkvision: 0 },
+          languages: { value: [] },
+        },
+        resources: {
+          primary: { value: 0, max: 0 },
+          secondary: { value: 0, max: 0 },
+          tertiary: { value: 0, max: 0 },
+        },
+        spells: {
+          cantrips: [],
+          spell1: { value: 0, max: 0 },
+          spell2: { value: 0, max: 0 },
+          spell3: { value: 0, max: 0 },
+          spell4: { value: 0, max: 0 },
+          spell5: { value: 0, max: 0 },
+          spell6: { value: 0, max: 0 },
+          spell7: { value: 0, max: 0 },
+          spell8: { value: 0, max: 0 },
+          spell9: { value: 0, max: 0 },
+          pact: { value: 0, max: 0 },
+        },
+        tools: [],
+      },
+      prototypeToken: { name: "", actorLink: true, disposition: 1 },
+    };
+
+    const exported = exportFoundryActor(state);
+    expect(exported).toEqual(template);
+  });
+});

--- a/__tests__/fixtures/sample-actor.json
+++ b/__tests__/fixtures/sample-actor.json
@@ -1,0 +1,53 @@
+{
+  "name": "Hero",
+  "type": "character",
+  "system": {
+    "abilities": {
+      "str": { "value": 10 },
+      "dex": { "value": 10 },
+      "con": { "value": 10 },
+      "int": { "value": 10 },
+      "wis": { "value": 10 },
+      "cha": { "value": 10 }
+    },
+    "skills": [],
+    "currency": { "pp": 0, "gp": 0, "ep": 0, "sp": 0, "cp": 0 },
+    "attributes": {
+      "ac": 10,
+      "hp": { "value": 10, "max": 10 },
+      "init": { "value": 0 },
+      "prof": 2
+    },
+    "details": { "background": "", "race": "", "alignment": "" },
+    "traits": {
+      "size": "med",
+      "senses": { "darkvision": 0 },
+      "languages": { "value": [] }
+    },
+    "resources": {
+      "primary": { "value": 0, "max": 0 },
+      "secondary": { "value": 0, "max": 0 },
+      "tertiary": { "value": 0, "max": 0 }
+    },
+    "spells": {
+      "cantrips": [],
+      "spell1": { "value": 0, "max": 0 },
+      "spell2": { "value": 0, "max": 0 },
+      "spell3": { "value": 0, "max": 0 },
+      "spell4": { "value": 0, "max": 0 },
+      "spell5": { "value": 0, "max": 0 },
+      "spell6": { "value": 0, "max": 0 },
+      "spell7": { "value": 0, "max": 0 },
+      "spell8": { "value": 0, "max": 0 },
+      "spell9": { "value": 0, "max": 0 },
+      "pact": { "value": 0, "max": 0 }
+    },
+    "tools": []
+  },
+  "items": [
+    { "name": "Fighter", "type": "class", "system": { "level": 1, "subclass": "" } },
+    { "name": "Lucky", "type": "feat", "system": {} },
+    { "name": "Dagger", "type": "weapon", "system": {} }
+  ],
+  "prototypeToken": { "name": "", "actorLink": true, "disposition": 1 }
+}

--- a/index.html
+++ b/index.html
@@ -279,7 +279,7 @@
         <h2>Step 7: Recap & Esportazione</h2>
         <div id="finalRecap" class="form-group"></div>
         <div class="form-group">
-          <button id="generateJson" class="btn btn-primary">Genera JSON</button>
+          <button id="downloadJson" class="btn btn-primary">Download JSON</button>
         </div>
         <div class="form-group">
           <button id="generatePdf" class="btn btn-primary">Genera PDF</button>

--- a/src/export.js
+++ b/src/export.js
@@ -1,0 +1,39 @@
+export function exportFoundryActor(state) {
+  const clone = (v) => JSON.parse(JSON.stringify(v));
+  const actor = {
+    name: state.name,
+    type: state.type,
+    system: clone(state.system),
+    items: [],
+    prototypeToken: clone(state.prototypeToken),
+  };
+
+  (state.classes || []).forEach((cls) => {
+    actor.items.push({
+      name: cls.name,
+      type: "class",
+      system: {
+        level: cls.level,
+        subclass: cls.subclass || "",
+      },
+    });
+  });
+
+  (state.feats || []).forEach((feat) => {
+    actor.items.push({
+      name: typeof feat === "string" ? feat : feat.name,
+      type: "feat",
+      system: typeof feat === "string" ? {} : feat.system || {},
+    });
+  });
+
+  (state.equipment || []).forEach((item) => {
+    actor.items.push({
+      name: item.name,
+      type: item.type || "loot",
+      system: item.system || {},
+    });
+  });
+
+  return actor;
+}

--- a/src/main.js
+++ b/src/main.js
@@ -1,5 +1,6 @@
 import { DATA, CharacterState, loadClasses, logCharacterState } from "./data.js";
 import { loadStep2 } from "./step2.js";
+import { exportFoundryActor } from "./export.js";
 
 let currentStep = 1;
 
@@ -353,6 +354,19 @@ document.addEventListener("DOMContentLoaded", () => {
   document
     .getElementById("confirmBackgroundSelection")
     ?.addEventListener("click", confirmBackgroundSelection);
+
+  document.getElementById("downloadJson")?.addEventListener("click", () => {
+    const actor = exportFoundryActor(CharacterState);
+    const blob = new Blob([JSON.stringify(actor, null, 2)], {
+      type: "application/json",
+    });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement("a");
+    a.href = url;
+    a.download = `${CharacterState.name || "character"}.json`;
+    a.click();
+    URL.revokeObjectURL(url);
+  });
 });
 
 export { showStep, loadData };


### PR DESCRIPTION
## Summary
- add `exportFoundryActor` to convert `CharacterState` to Foundry actor JSON
- wire up new **Download JSON** button in step 7 to trigger export
- test export against a sample template

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ac15882e60832eae96e231dda9e718