### PR TITLE
Add spell slot calculation and resource management

### DIFF
--- a/__tests__/export.test.js
+++ b/__tests__/export.test.js
@@ -37,9 +37,9 @@ describe("exportFoundryActor", () => {
           languages: { value: [] },
         },
         resources: {
-          primary: { value: 0, max: 0 },
-          secondary: { value: 0, max: 0 },
-          tertiary: { value: 0, max: 0 },
+          primary: { value: 0, max: 0, sr: false, lr: false, label: "" },
+          secondary: { value: 0, max: 0, sr: false, lr: false, label: "" },
+          tertiary: { value: 0, max: 0, sr: false, lr: false, label: "" },
         },
         spells: {
           cantrips: [],

--- a/__tests__/fixtures/sample-actor.json
+++ b/__tests__/fixtures/sample-actor.json
@@ -25,9 +25,9 @@
       "languages": { "value": [] }
     },
     "resources": {
-      "primary": { "value": 0, "max": 0 },
-      "secondary": { "value": 0, "max": 0 },
-      "tertiary": { "value": 0, "max": 0 }
+      "primary": { "value": 0, "max": 0, "sr": false, "lr": false, "label": "" },
+      "secondary": { "value": 0, "max": 0, "sr": false, "lr": false, "label": "" },
+      "tertiary": { "value": 0, "max": 0, "sr": false, "lr": false, "label": "" }
     },
     "spells": {
       "cantrips": [],

--- a/src/data.js
+++ b/src/data.js
@@ -66,10 +66,13 @@ export const CharacterState = {
       senses: { darkvision: 0 },
       languages: { value: [] },
     },
+    // Resource pools closely matching the structure used by Foundry's
+    // dnd5e system.  Each resource tracks a label, current and maximum
+    // value and whether it refreshes on a short or long rest.
     resources: {
-      primary: { value: 0, max: 0 },
-      secondary: { value: 0, max: 0 },
-      tertiary: { value: 0, max: 0 },
+      primary: { value: 0, max: 0, sr: false, lr: false, label: "" },
+      secondary: { value: 0, max: 0, sr: false, lr: false, label: "" },
+      tertiary: { value: 0, max: 0, sr: false, lr: false, label: "" },
     },
     spells: {
       cantrips: [],
@@ -98,6 +101,123 @@ export function totalLevel() {
     (sum, cls) => sum + (cls.level || 0),
     0
   );
+}
+
+// --- Helper utilities ----------------------------------------------------
+
+// Map of class names to their spellcasting progression. This is a simplified
+// subset that covers the core classes and is sufficient for character
+// creation. Classes not listed are treated as non-casters.
+const CLASS_PROGRESSION = {
+  Artificer: "half",
+  Bard: "full",
+  Cleric: "full",
+  Druid: "full",
+  Paladin: "half",
+  Ranger: "half",
+  Sorcerer: "full",
+  Wizard: "full",
+  Warlock: "pact",
+};
+
+// Multiclass spell slot table from the Player's Handbook p.165. Index by
+// effective caster level to obtain the number of slots for each spell level.
+const SPELL_SLOTS_BY_LEVEL = [
+  {},
+  { 1: 2 },
+  { 1: 3 },
+  { 1: 4, 2: 2 },
+  { 1: 4, 2: 3 },
+  { 1: 4, 2: 3, 3: 2 },
+  { 1: 4, 2: 3, 3: 3 },
+  { 1: 4, 2: 3, 3: 3, 4: 1 },
+  { 1: 4, 2: 3, 3: 3, 4: 2 },
+  { 1: 4, 2: 3, 3: 3, 4: 3, 5: 1 },
+  { 1: 4, 2: 3, 3: 3, 4: 3, 5: 2 },
+  { 1: 4, 2: 3, 3: 3, 4: 3, 5: 2, 6: 1 },
+  { 1: 4, 2: 3, 3: 3, 4: 3, 5: 2, 6: 1 },
+  { 1: 4, 2: 3, 3: 3, 4: 3, 5: 2, 6: 1, 7: 1 },
+  { 1: 4, 2: 3, 3: 3, 4: 3, 5: 2, 6: 1, 7: 1 },
+  { 1: 4, 2: 3, 3: 3, 4: 3, 5: 2, 6: 1, 7: 1, 8: 1 },
+  { 1: 4, 2: 3, 3: 3, 4: 3, 5: 2, 6: 1, 7: 1, 8: 1 },
+  { 1: 4, 2: 3, 3: 3, 4: 3, 5: 2, 6: 1, 7: 1, 8: 1, 9: 1 },
+  { 1: 4, 2: 3, 3: 3, 4: 3, 5: 3, 6: 1, 7: 1, 8: 1, 9: 1 },
+  { 1: 4, 2: 3, 3: 3, 4: 3, 5: 3, 6: 2, 7: 1, 8: 1, 9: 1 },
+  { 1: 4, 2: 3, 3: 3, 4: 3, 5: 3, 6: 2, 7: 2, 8: 1, 9: 1 },
+];
+
+// Warlock pact magic table. Each entry provides the number of pact slots and
+// their level for the corresponding warlock level.
+const PACT_MAGIC = [
+  { slots: 0, level: 0 },
+  { slots: 1, level: 1 },
+  { slots: 2, level: 1 },
+  { slots: 2, level: 2 },
+  { slots: 2, level: 2 },
+  { slots: 2, level: 3 },
+  { slots: 2, level: 3 },
+  { slots: 2, level: 4 },
+  { slots: 2, level: 4 },
+  { slots: 2, level: 5 },
+  { slots: 2, level: 5 },
+  { slots: 3, level: 5 },
+  { slots: 3, level: 5 },
+  { slots: 3, level: 5 },
+  { slots: 3, level: 5 },
+  { slots: 3, level: 5 },
+  { slots: 3, level: 5 },
+  { slots: 4, level: 5 },
+  { slots: 4, level: 5 },
+  { slots: 4, level: 5 },
+  { slots: 4, level: 5 },
+];
+
+/**
+ * Calculate spell slot totals based on the currently selected classes and
+ * their levels. This function mutates `CharacterState.system.spells` so that
+ * each spell level slot has matching `value` and `max` fields.
+ */
+export function updateSpellSlots() {
+  let casterLevel = 0;
+  let pactLevel = 0;
+
+  (CharacterState.classes || []).forEach((cls) => {
+    const lvl = cls.level || 0;
+    const prog = cls.spellcasting?.progression || CLASS_PROGRESSION[cls.name];
+    if (prog === "full") casterLevel += lvl;
+    else if (prog === "half") casterLevel += Math.floor(lvl / 2);
+    else if (prog === "artificer") casterLevel += Math.ceil(lvl / 2);
+    else if (prog === "third") casterLevel += Math.floor(lvl / 3);
+    else if (prog === "pact") pactLevel += lvl;
+  });
+
+  const slots = SPELL_SLOTS_BY_LEVEL[Math.min(casterLevel, 20)] || {};
+  for (let i = 1; i <= 9; i++) {
+    const max = slots[i] || 0;
+    const spell = CharacterState.system.spells[`spell${i}`];
+    if (spell) {
+      spell.max = max;
+      spell.value = Math.min(spell.value, max); // keep within bounds
+    }
+  }
+
+  const pact = PACT_MAGIC[Math.min(pactLevel, 20)] || { slots: 0, level: 0 };
+  CharacterState.system.spells.pact.max = pact.slots;
+  CharacterState.system.spells.pact.value = Math.min(
+    CharacterState.system.spells.pact.value,
+    pact.slots
+  );
+}
+
+/**
+ * Increment or decrement one of the resource pools.
+ * @param {string} key - One of `primary`, `secondary` or `tertiary`.
+ * @param {number} delta - Amount to change the resource by.
+ */
+export function adjustResource(key, delta) {
+  const res = CharacterState.system.resources[key];
+  if (!res) return;
+  res.value = Math.max(0, Math.min((res.max ?? 0), res.value + delta));
 }
 
 export function logCharacterState() {

--- a/src/main.js
+++ b/src/main.js
@@ -1,4 +1,11 @@
-import { DATA, CharacterState, loadClasses, logCharacterState } from "./data.js";
+import {
+  DATA,
+  CharacterState,
+  loadClasses,
+  logCharacterState,
+  adjustResource,
+  updateSpellSlots,
+} from "./data.js";
 import { loadStep2 } from "./step2.js";
 import { exportFoundryActor } from "./export.js";
 
@@ -70,6 +77,7 @@ function showStep(step) {
     bar.style.width = `${((step - 1) / 6) * 100}%`;
   }
   currentStep = step;
+  if (step === 7) renderFinalRecap();
 }
 
 async function loadData() {
@@ -165,6 +173,143 @@ function addUniqueProficiency(type, value, container) {
 
 function capitalize(str) {
   return str.charAt(0).toUpperCase() + str.slice(1);
+}
+
+// Render a summary of resources and spell slots on the final step. Users can
+// tweak resource values directly from here using the helper functions in
+// data.js.
+function renderFinalRecap() {
+  const container = document.getElementById("finalRecap");
+  if (!container) return;
+  updateSpellSlots();
+  container.innerHTML = "";
+
+  // Resources ---------------------------------------------------------------
+  const resSection = document.createElement("div");
+  const resTitle = document.createElement("h3");
+  resTitle.textContent = "Resources";
+  resSection.appendChild(resTitle);
+  ["primary", "secondary", "tertiary"].forEach((key) => {
+    const res = CharacterState.system.resources[key];
+    const row = document.createElement("div");
+
+    const labelInput = document.createElement("input");
+    labelInput.placeholder = "Label";
+    labelInput.value = res.label || "";
+    labelInput.addEventListener("input", () => {
+      res.label = labelInput.value;
+    });
+    row.appendChild(labelInput);
+
+    const dec = document.createElement("button");
+    dec.textContent = "-";
+    dec.addEventListener("click", () => {
+      adjustResource(key, -1);
+      renderFinalRecap();
+    });
+    row.appendChild(dec);
+
+    const span = document.createElement("span");
+    span.textContent = `${res.value}/${res.max}`;
+    span.style.margin = "0 4px";
+    row.appendChild(span);
+
+    const inc = document.createElement("button");
+    inc.textContent = "+";
+    inc.addEventListener("click", () => {
+      adjustResource(key, 1);
+      renderFinalRecap();
+    });
+    row.appendChild(inc);
+
+    const maxInput = document.createElement("input");
+    maxInput.type = "number";
+    maxInput.value = res.max;
+    maxInput.style.width = "4em";
+    maxInput.addEventListener("change", () => {
+      res.max = parseInt(maxInput.value, 10) || 0;
+      if (res.value > res.max) res.value = res.max;
+      renderFinalRecap();
+    });
+    row.appendChild(maxInput);
+
+    const srLabel = document.createElement("label");
+    const sr = document.createElement("input");
+    sr.type = "checkbox";
+    sr.checked = !!res.sr;
+    sr.addEventListener("change", () => {
+      res.sr = sr.checked;
+    });
+    srLabel.appendChild(sr);
+    srLabel.appendChild(document.createTextNode(" SR"));
+    row.appendChild(srLabel);
+
+    const lrLabel = document.createElement("label");
+    const lr = document.createElement("input");
+    lr.type = "checkbox";
+    lr.checked = !!res.lr;
+    lr.addEventListener("change", () => {
+      res.lr = lr.checked;
+    });
+    lrLabel.appendChild(lr);
+    lrLabel.appendChild(document.createTextNode(" LR"));
+    row.appendChild(lrLabel);
+
+    resSection.appendChild(row);
+  });
+  container.appendChild(resSection);
+
+  // Spell slots ------------------------------------------------------------
+  const spellSection = document.createElement("div");
+  const spellTitle = document.createElement("h3");
+  spellTitle.textContent = "Spell Slots";
+  spellSection.appendChild(spellTitle);
+  for (let i = 1; i <= 9; i++) {
+    const slot = CharacterState.system.spells[`spell${i}`];
+    const row = document.createElement("div");
+    const dec = document.createElement("button");
+    dec.textContent = "-";
+    dec.addEventListener("click", () => {
+      if (slot.value > 0) slot.value--;
+      renderFinalRecap();
+    });
+    row.appendChild(dec);
+    const span = document.createElement("span");
+    span.textContent = `Level ${i}: ${slot.value}/${slot.max}`;
+    span.style.margin = "0 4px";
+    row.appendChild(span);
+    const inc = document.createElement("button");
+    inc.textContent = "+";
+    inc.addEventListener("click", () => {
+      if (slot.value < slot.max) slot.value++;
+      renderFinalRecap();
+    });
+    row.appendChild(inc);
+    spellSection.appendChild(row);
+  }
+  const pact = CharacterState.system.spells.pact;
+  const pactRow = document.createElement("div");
+  const pactDec = document.createElement("button");
+  pactDec.textContent = "-";
+  pactDec.addEventListener("click", () => {
+    if (pact.value > 0) pact.value--;
+    renderFinalRecap();
+  });
+  pactRow.appendChild(pactDec);
+  const pactSpan = document.createElement("span");
+  pactSpan.textContent = `Pact: ${pact.value}/${pact.max}`;
+  pactSpan.style.margin = "0 4px";
+  pactRow.appendChild(pactSpan);
+  const pactInc = document.createElement("button");
+  pactInc.textContent = "+";
+  pactInc.addEventListener("click", () => {
+    if (pact.value < pact.max) pact.value++;
+    renderFinalRecap();
+  });
+  pactRow.appendChild(pactInc);
+  spellSection.appendChild(pactRow);
+
+  container.appendChild(spellSection);
 }
 
 // --- Step 3: Race selection handlers ---

--- a/src/step2.js
+++ b/src/step2.js
@@ -1,4 +1,12 @@
-import { DATA, CharacterState, loadClasses, logCharacterState, loadFeats, totalLevel } from './data.js';
+import {
+  DATA,
+  CharacterState,
+  loadClasses,
+  logCharacterState,
+  loadFeats,
+  totalLevel,
+  updateSpellSlots,
+} from './data.js';
 
 // Temporary store for user selections while editing class features
 const savedSelections = { skills: [], subclass: '', choices: {} };
@@ -554,6 +562,7 @@ function confirmClassSelection(silent = false) {
   }
 
   CharacterState.classes.push(currentClass);
+  updateSpellSlots();
   logCharacterState();
   if (!silent) alert('Classe confermata!');
   currentClass = null;


### PR DESCRIPTION
## Summary
- expand character state with Foundry-like resources and spell slot tracking
- compute multiclass spell slots and manage resource adjustments
- show resource pools and spell slots in final recap UI

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ac183f85d8832ea75c95d4eb779e9c