### PR TITLE
Refactor select option updates with cached elements

### DIFF
--- a/__tests__/step2.test.js
+++ b/__tests__/step2.test.js
@@ -1,0 +1,81 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import { updateSkillSelectOptions, updateChoiceSelectOptions } from '../src/step2.js';
+import { CharacterState } from '../src/data.js';
+
+describe('duplicate selection prevention', () => {
+  beforeEach(() => {
+    CharacterState.system.skills = [];
+  });
+
+  function createSelect(options) {
+    const sel = document.createElement('select');
+    const blank = document.createElement('option');
+    blank.value = '';
+    sel.appendChild(blank);
+    options.forEach(opt => {
+      const o = document.createElement('option');
+      o.value = opt;
+      o.textContent = opt;
+      sel.appendChild(o);
+    });
+    return sel;
+  }
+
+  test('updateSkillSelectOptions disables taken skills', () => {
+    const skillSelect1 = createSelect(['Acrobatics', 'Athletics']);
+    const skillSelect2 = createSelect(['Acrobatics', 'Athletics']);
+    const choiceSelect = createSelect(['Acrobatics', 'Athletics']);
+    skillSelect1.value = 'Acrobatics';
+    choiceSelect.value = 'Athletics';
+    const skillSelects = [skillSelect1, skillSelect2];
+    const choiceSkillSelects = [choiceSelect];
+
+    updateSkillSelectOptions(skillSelects, choiceSkillSelects);
+
+    expect(
+      skillSelect2.querySelector("option[value='Acrobatics']").disabled
+    ).toBe(true);
+    expect(
+      skillSelect2.querySelector("option[value='Athletics']").disabled
+    ).toBe(true);
+    expect(
+      skillSelect1.querySelector("option[value='Athletics']").disabled
+    ).toBe(true);
+    expect(
+      skillSelect1.querySelector("option[value='Acrobatics']").disabled
+    ).toBe(false);
+  });
+
+  test('updateChoiceSelectOptions disables taken skills', () => {
+    const skillSelect = createSelect(['Acrobatics', 'Athletics']);
+    skillSelect.value = 'Athletics';
+    const choiceSelect1 = createSelect(['Acrobatics', 'Athletics']);
+    const choiceSelect2 = createSelect(['Acrobatics', 'Athletics']);
+    choiceSelect1.value = 'Acrobatics';
+    const skillSelects = [skillSelect];
+    const choiceSelects = [choiceSelect1, choiceSelect2];
+
+    updateChoiceSelectOptions(
+      choiceSelects,
+      'skills',
+      skillSelects,
+      choiceSelects
+    );
+
+    expect(
+      choiceSelect2.querySelector("option[value='Acrobatics']").disabled
+    ).toBe(true);
+    expect(
+      choiceSelect2.querySelector("option[value='Athletics']").disabled
+    ).toBe(true);
+    expect(
+      choiceSelect1.querySelector("option[value='Athletics']").disabled
+    ).toBe(true);
+    expect(
+      choiceSelect1.querySelector("option[value='Acrobatics']").disabled
+    ).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary
- cache skill and choice select elements
- refactor update functions to accept explicit select lists
- add tests preventing duplicate selections

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ac1e21208c832e877814cf53e0cdc8