### PR TITLE
Add retry handling for data fetch failures

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -2,6 +2,7 @@ import {
   DATA,
   CharacterState,
   loadClasses,
+  fetchJsonWithRetry,
   logCharacterState,
   adjustResource,
   updateSpellSlots,
@@ -93,11 +94,7 @@ async function loadData() {
   };
 
   for (const [key, path] of Object.entries(sources)) {
-    const res = await fetch(path);
-    if (!res.ok) {
-      throw new Error(`Failed loading ${key}`);
-    }
-    const json = await res.json();
+    const json = await fetchJsonWithRetry(path, key);
     DATA[key] = json.items || json.languages;
   }
 }


### PR DESCRIPTION
## Summary
- add `fetchJsonWithRetry` helper to prompt users when data downloads fail
- apply retry-aware fetches for classes, feats, races, backgrounds, and languages

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ac1d2dc9ec832e996dbc137936b2b0