### PR TITLE
Compute proficiency bonus from total level

### DIFF
--- a/__tests__/proficiency.test.js
+++ b/__tests__/proficiency.test.js
@@ -1,0 +1,25 @@
+import { CharacterState, updateProficiencyBonus } from '../src/data.js';
+
+describe('updateProficiencyBonus', () => {
+  beforeEach(() => {
+    CharacterState.classes = [];
+    CharacterState.system.attributes.prof = 0;
+  });
+
+  test.each([
+    [1, 2],
+    [4, 2],
+    [5, 3],
+    [8, 3],
+    [9, 4],
+    [12, 4],
+    [13, 5],
+    [16, 5],
+    [17, 6],
+    [20, 6],
+  ])('total level %i results in prof %i', (lvl, expected) => {
+    CharacterState.classes = [{ level: lvl }];
+    updateProficiencyBonus();
+    expect(CharacterState.system.attributes.prof).toBe(expected);
+  });
+});

--- a/src/data.js
+++ b/src/data.js
@@ -225,6 +225,20 @@ export function updateSpellSlots() {
 }
 
 /**
+ * Update the proficiency bonus based on total character level.
+ * Levels 1-4: +2, 5-8: +3, 9-12: +4, 13-16: +5, 17+: +6.
+ */
+export function updateProficiencyBonus() {
+  const level = totalLevel();
+  let prof = 2;
+  if (level >= 17) prof = 6;
+  else if (level >= 13) prof = 5;
+  else if (level >= 9) prof = 4;
+  else if (level >= 5) prof = 3;
+  CharacterState.system.attributes.prof = prof;
+}
+
+/**
  * Increment or decrement one of the resource pools.
  * @param {string} key - One of `primary`, `secondary` or `tertiary`.
  * @param {number} delta - Amount to change the resource by.

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -15,6 +15,7 @@
   "subclass": "Subclass",
   "skillProficiencies": "Skill Proficiencies",
   "selectedClasses": "Selected classes: {classes} (Total level {level})",
+  "proficiencyBonus": "Proficiency bonus: +{value}",
   "edit": "Edit",
   "remove": "Remove",
   "selectAbility": "Select ability",

--- a/src/i18n/it.json
+++ b/src/i18n/it.json
@@ -15,6 +15,7 @@
   "subclass": "Sottoclasse",
   "skillProficiencies": "Competenze nelle abilità",
   "selectedClasses": "Classi selezionate: {classes} (Totale livello {level})",
+  "proficiencyBonus": "Bonus di competenza: +{value}",
   "edit": "Modifica",
   "remove": "Rimuovi",
   "selectAbility": "Seleziona caratteristica",

--- a/src/step2.js
+++ b/src/step2.js
@@ -6,6 +6,7 @@ import {
   loadFeats,
   totalLevel,
   updateSpellSlots,
+  updateProficiencyBonus,
 } from './data.js';
 import { t } from './i18n.js';
 
@@ -93,6 +94,8 @@ function rebuildFromClasses() {
     CharacterState.system.abilities[ab].value = val;
   }
   updateSpellSlots();
+  updateProficiencyBonus();
+  renderSelectedClasses();
 }
 
 function trimSelections(maxLevel) {
@@ -582,6 +585,14 @@ function renderSelectedClasses() {
       createElement(
         'p',
         t('selectedClasses', { classes: summaryText, level: totalLevel() })
+      )
+    );
+    container.appendChild(
+      createElement(
+        'p',
+        t('proficiencyBonus', {
+          value: CharacterState.system.attributes.prof,
+        })
       )
     );
   }


### PR DESCRIPTION
## Summary
- add `updateProficiencyBonus` to set attributes.prof according to character level
- update class rebuilding to recalc and render proficiency bonus
- show proficiency bonus in selected class summary
- test proficiency scaling

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68ac30e04b1c832ebe381b48bb21b779