### PR TITLE
Track pact spell level

### DIFF
--- a/__tests__/export.test.js
+++ b/__tests__/export.test.js
@@ -52,7 +52,7 @@ describe("exportFoundryActor", () => {
           spell7: { value: 0, max: 0 },
           spell8: { value: 0, max: 0 },
           spell9: { value: 0, max: 0 },
-          pact: { value: 0, max: 0 },
+          pact: { value: 0, max: 0, level: 0 },
         },
         tools: [],
       },

--- a/__tests__/fixtures/sample-actor.json
+++ b/__tests__/fixtures/sample-actor.json
@@ -40,7 +40,7 @@
       "spell7": { "value": 0, "max": 0 },
       "spell8": { "value": 0, "max": 0 },
       "spell9": { "value": 0, "max": 0 },
-      "pact": { "value": 0, "max": 0 }
+      "pact": { "value": 0, "max": 0, "level": 0 }
     },
     "tools": []
   },

--- a/__tests__/spellslots.test.js
+++ b/__tests__/spellslots.test.js
@@ -1,0 +1,17 @@
+import { CharacterState, updateSpellSlots } from "../src/data.js";
+
+describe("updateSpellSlots", () => {
+  beforeEach(() => {
+    CharacterState.classes = [];
+    CharacterState.system.spells.pact.value = 0;
+    CharacterState.system.spells.pact.max = 0;
+    CharacterState.system.spells.pact.level = 0;
+  });
+
+  test("sets pact level for warlock", () => {
+    CharacterState.classes = [{ name: "Warlock", level: 5 }];
+    updateSpellSlots();
+    expect(CharacterState.system.spells.pact.level).toBe(3);
+    expect(CharacterState.system.spells.pact.max).toBe(2);
+  });
+});

--- a/src/data.js
+++ b/src/data.js
@@ -100,7 +100,7 @@ export const CharacterState = {
       spell7: { value: 0, max: 0 },
       spell8: { value: 0, max: 0 },
       spell9: { value: 0, max: 0 },
-      pact: { value: 0, max: 0 },
+      pact: { value: 0, max: 0, level: 0 },
     },
     tools: [],
   },
@@ -218,6 +218,7 @@ export function updateSpellSlots() {
 
   const pact = PACT_MAGIC[Math.min(pactLevel, 20)] || { slots: 0, level: 0 };
   CharacterState.system.spells.pact.max = pact.slots;
+  CharacterState.system.spells.pact.level = pact.level;
   CharacterState.system.spells.pact.value = Math.min(
     CharacterState.system.spells.pact.value,
     pact.slots

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -5,7 +5,7 @@
   "label": "Label",
   "spellSlots": "Spell Slots",
   "levelEntry": "Level {level}: {value}/{max}",
-  "pactEntry": "Pact: {value}/{max}",
+  "pactEntry": "Pact (Level {level}): {value}/{max}",
   "skills": "Skills",
   "tools": "Tools",
   "languages": "Languages",

--- a/src/i18n/it.json
+++ b/src/i18n/it.json
@@ -5,7 +5,7 @@
   "label": "Etichetta",
   "spellSlots": "Slot Incantesimo",
   "levelEntry": "Livello {level}: {value}/{max}",
-  "pactEntry": "Patto: {value}/{max}",
+  "pactEntry": "Patto (Livello {level}): {value}/{max}",
   "skills": "Competenze",
   "tools": "Strumenti",
   "languages": "Lingue",

--- a/src/main.js
+++ b/src/main.js
@@ -305,6 +305,7 @@ function renderFinalRecap() {
   pactSpan.textContent = t("pactEntry", {
     value: pact.value,
     max: pact.max,
+    level: pact.level,
   });
   pactSpan.style.margin = "0 4px";
   pactRow.appendChild(pactSpan);


### PR DESCRIPTION
## Summary
- Add level field to pact spell slots and populate it in `updateSpellSlots`
- Show pact slot level in the final recap and translations
- Cover pact slot level handling with new test

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ac31e05de0832ebb74c44c11b52665