### PR TITLE
test: cover multiclass progression

### DIFF
--- a/__tests__/proficiency.test.js
+++ b/__tests__/proficiency.test.js
@@ -22,4 +22,13 @@ describe('updateProficiencyBonus', () => {
     updateProficiencyBonus();
     expect(CharacterState.system.attributes.prof).toBe(expected);
   });
+
+  test('uses sum of multiclass levels', () => {
+    CharacterState.classes = [
+      { level: 2 },
+      { level: 3 },
+    ];
+    updateProficiencyBonus();
+    expect(CharacterState.system.attributes.prof).toBe(3);
+  });
 });

--- a/__tests__/spellslots.test.js
+++ b/__tests__/spellslots.test.js
@@ -14,4 +14,20 @@ describe("updateSpellSlots", () => {
     expect(CharacterState.system.spells.pact.level).toBe(3);
     expect(CharacterState.system.spells.pact.max).toBe(2);
   });
+
+  test('pools spell slots for multiclass casters', () => {
+    CharacterState.classes = [
+      { name: 'Wizard', level: 3 },
+      { name: 'Cleric', level: 2 },
+    ];
+    for (let i = 1; i <= 9; i++) {
+      const key = `spell${i}`;
+      CharacterState.system.spells[key].value = 0;
+      CharacterState.system.spells[key].max = 0;
+    }
+    updateSpellSlots();
+    expect(CharacterState.system.spells.spell1.max).toBe(4);
+    expect(CharacterState.system.spells.spell2.max).toBe(3);
+    expect(CharacterState.system.spells.spell3.max).toBe(2);
+  });
 });

--- a/__tests__/totallevel.test.js
+++ b/__tests__/totallevel.test.js
@@ -1,0 +1,15 @@
+import { CharacterState, totalLevel } from '../src/data.js';
+
+describe('totalLevel', () => {
+  beforeEach(() => {
+    CharacterState.classes = [];
+  });
+
+  test('sums levels across multiple classes', () => {
+    CharacterState.classes = [
+      { name: 'Wizard', level: 3 },
+      { name: 'Cleric', level: 2 },
+    ];
+    expect(totalLevel()).toBe(5);
+  });
+});


### PR DESCRIPTION
## Summary
- add unit tests covering total level calculation for multiclass characters
- verify pooled spell slots and proficiency bonus with multiple classes

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ac39e875c0832e963b43891249b0a0