### PR TITLE
Persist race-derived attributes

### DIFF
--- a/__tests__/export.test.js
+++ b/__tests__/export.test.js
@@ -29,6 +29,7 @@ describe("exportFoundryActor", () => {
           hp: { value: 10, max: 10 },
           init: { value: 0 },
           prof: 2,
+          movement: { walk: 30 },
         },
         details: { background: "", race: "", alignment: "" },
         traits: {

--- a/__tests__/fixtures/sample-actor.json
+++ b/__tests__/fixtures/sample-actor.json
@@ -16,7 +16,8 @@
       "ac": 10,
       "hp": { "value": 10, "max": 10 },
       "init": { "value": 0 },
-      "prof": 2
+      "prof": 2,
+      "movement": { "walk": 30 }
     },
     "details": { "background": "", "race": "", "alignment": "" },
     "traits": {

--- a/src/data.js
+++ b/src/data.js
@@ -73,6 +73,7 @@ export const CharacterState = {
       hp: { value: 1, max: 1 },
       init: { value: 0 },
       prof: 2,
+      movement: { walk: 30 },
     },
     details: {
       background: "",

--- a/src/main.js
+++ b/src/main.js
@@ -372,6 +372,49 @@ function confirmRaceSelection() {
   if (!currentRaceData) return;
   const container = document.getElementById("raceTraits");
   CharacterState.system.details.race = currentRaceData.name;
+
+  // Persist size
+  const sizeMap = { T: "tiny", S: "sm", M: "med", L: "lg", H: "huge", G: "grg" };
+  if (currentRaceData.size) {
+    const sz = Array.isArray(currentRaceData.size)
+      ? currentRaceData.size[0]
+      : currentRaceData.size;
+    CharacterState.system.traits.size =
+      sizeMap[sz] || CharacterState.system.traits.size;
+  }
+
+  // Persist movement speeds
+  const move = CharacterState.system.attributes.movement || {};
+  const speed = currentRaceData.speed;
+  if (typeof speed === "number") move.walk = speed;
+  else if (speed && typeof speed === "object") {
+    if (typeof speed.walk === "number") move.walk = speed.walk;
+    ["burrow", "climb", "fly", "swim"].forEach((t) => {
+      const val = speed[t];
+      if (typeof val === "number") move[t] = val;
+      else if (val === true && typeof move.walk === "number") move[t] = move.walk;
+    });
+  }
+  CharacterState.system.attributes.movement = move;
+
+  // Apply ability score bonuses
+  if (Array.isArray(currentRaceData.ability)) {
+    currentRaceData.ability.forEach((obj) => {
+      for (const [ab, val] of Object.entries(obj)) {
+        if (typeof val === "number" && CharacterState.system.abilities[ab]) {
+          const abil = CharacterState.system.abilities[ab];
+          abil.value = (abil.value || 0) + val;
+        }
+      }
+    });
+  }
+
+  // Persist darkvision and trait tags
+  if (currentRaceData.darkvision)
+    CharacterState.system.traits.senses.darkvision = currentRaceData.darkvision;
+  if (currentRaceData.traitTags)
+    CharacterState.system.traits.traitTags = [...currentRaceData.traitTags];
+
   if (currentRaceData.skillProficiencies) {
     currentRaceData.skillProficiencies.forEach((obj) => {
       for (const k in obj)


### PR DESCRIPTION
## Summary
- preserve race-based properties like size, speeds, darkvision and trait tags on selection
- merge racial ability bonuses into existing ability scores
- add movement fields so speed data is retained and adjust tests

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ac50414344832eab8ac63151e6b468