### PR TITLE
Add grouped race selection with subrace support

### DIFF
--- a/__tests__/races.test.js
+++ b/__tests__/races.test.js
@@ -1,0 +1,33 @@
+import { DATA, loadRaces } from '../src/data.js';
+import fs from 'fs';
+import path from 'path';
+import { fileURLToPath } from 'url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+
+describe('loadRaces', () => {
+  beforeAll(() => {
+    const read = (p) => JSON.parse(fs.readFileSync(path.join(__dirname, '..', p), 'utf-8'));
+    const files = {
+      'data/races.json': {
+        items: {
+          'Dwarf (Hill)': 'data/races/dwarfhill.json',
+          'Dwarf (Mountain)': 'data/races/dwarfmountain.json',
+        },
+      },
+      'data/races/dwarfhill.json': read('data/races/dwarfhill.json'),
+      'data/races/dwarfmountain.json': read('data/races/dwarfmountain.json'),
+    };
+    global.fetch = (filePath) =>
+      Promise.resolve({ ok: true, json: () => Promise.resolve(files[filePath]) });
+    global.window = { confirm: () => false, alert: () => {} };
+  });
+
+  it('groups races by base race name', async () => {
+    await loadRaces();
+    expect(DATA.races.Dwarf).toBeDefined();
+    const names = DATA.races.Dwarf.map((r) => r.name);
+    expect(names).toContain('Dwarf (Hill)');
+    expect(names).toContain('Dwarf (Mountain)');
+  });
+});

--- a/src/data.js
+++ b/src/data.js
@@ -51,6 +51,28 @@ export async function loadFeats() {
   DATA.feats = Object.keys(json.feats || {});
 }
 
+/**
+ * Fetches race data and groups variants by their base race name.
+ */
+export async function loadRaces() {
+  if (DATA.races && Object.keys(DATA.races).length) return;
+
+  const index = await fetchJsonWithRetry('data/races.json', 'race index');
+  const entries = index.items || {};
+  const groups = {};
+
+  await Promise.all(
+    Object.values(entries).map(async (path) => {
+      const race = await fetchJsonWithRetry(path, `race at ${path}`);
+      const base = race.raceName || race.name;
+      if (!groups[base]) groups[base] = [];
+      groups[base].push({ name: race.name, path });
+    })
+  );
+
+  DATA.races = groups;
+}
+
 export const CharacterState = {
   name: "",
   type: "character",
@@ -78,6 +100,7 @@ export const CharacterState = {
     details: {
       background: "",
       race: "",
+      subrace: "",
       alignment: "",
     },
     traits: {

--- a/src/step3.js
+++ b/src/step3.js
@@ -1,0 +1,269 @@
+import {
+  DATA,
+  CharacterState,
+  fetchJsonWithRetry,
+  loadRaces,
+  logCharacterState
+} from './data.js';
+import { refreshBaseState, rebuildFromClasses } from './step2.js';
+import { t } from './i18n.js';
+import { showStep } from './main.js';
+
+let selectedBaseRace = '';
+let currentRaceData = null;
+
+const ALL_SKILLS = [
+  'Acrobatics',
+  'Animal Handling',
+  'Arcana',
+  'Athletics',
+  'Deception',
+  'History',
+  'Insight',
+  'Intimidation',
+  'Investigation',
+  'Medicine',
+  'Nature',
+  'Perception',
+  'Performance',
+  'Persuasion',
+  'Religion',
+  'Sleight of Hand',
+  'Stealth',
+  'Survival',
+];
+
+const ALL_TOOLS = [
+  "Alchemist's Supplies",
+  "Brewer's Supplies",
+  "Calligrapher's Supplies",
+  "Carpenter's Tools",
+  "Cartographer's Tools",
+  "Cobbler's Tools",
+  "Cook's Utensils",
+  "Glassblower's Tools",
+  "Jeweler's Tools",
+  "Leatherworker's Tools",
+  "Mason's Tools",
+  "Painter's Supplies",
+  "Potter's Tools",
+  "Smith's Tools",
+  "Tinker's Tools",
+  "Weaver's Tools",
+  "Woodcarver's Tools",
+  'Disguise Kit',
+  'Forgery Kit',
+  'Herbalism Kit',
+  "Navigator's Tools",
+  "Poisoner's Kit",
+  "Thieves' Tools",
+];
+
+function capitalize(str) {
+  return str.charAt(0).toUpperCase() + str.slice(1);
+}
+
+function getProficiencyList(type) {
+  if (type === 'skills') return CharacterState.system.skills;
+  if (type === 'tools') return CharacterState.system.tools;
+  if (type === 'languages') return CharacterState.system.traits.languages.value;
+  if (type === 'cantrips') return CharacterState.system.spells.cantrips;
+  return [];
+}
+
+function getAllOptions(type) {
+  if (type === 'skills') return ALL_SKILLS;
+  if (type === 'tools') return ALL_TOOLS;
+  if (type === 'languages') return DATA.languages || [];
+  return [];
+}
+
+function addUniqueProficiency(type, value, container) {
+  if (!value) return;
+  const list = getProficiencyList(type);
+  if (!list.includes(value)) {
+    list.push(value);
+    logCharacterState();
+    return;
+  }
+  const msg = document.createElement('div');
+  const label = document.createElement('label');
+  label.textContent = t('duplicateProficiency', {
+    value,
+    type: t(type.slice(0, -1))
+  });
+  const sel = document.createElement('select');
+  sel.innerHTML = `<option value=''>${t('select')}</option>`;
+  getAllOptions(type)
+    .filter((opt) => !list.includes(opt))
+    .forEach((opt) => {
+      const o = document.createElement('option');
+      o.value = opt;
+      o.textContent = opt;
+      sel.appendChild(o);
+    });
+  sel.addEventListener('change', () => {
+    if (sel.value && !list.includes(sel.value)) {
+      list.push(sel.value);
+      sel.disabled = true;
+      logCharacterState();
+    }
+  });
+  label.appendChild(sel);
+  msg.appendChild(label);
+  container.appendChild(msg);
+}
+
+function renderBaseRaces() {
+  const container = document.getElementById('raceList');
+  if (!container) return;
+  container.innerHTML = '';
+  Object.keys(DATA.races).forEach((base) => {
+    const card = document.createElement('div');
+    card.className = 'class-card';
+    card.textContent = base;
+    card.addEventListener('click', () => selectBaseRace(base));
+    container.appendChild(card);
+  });
+}
+
+function selectBaseRace(base) {
+  selectedBaseRace = base;
+  const select = document.getElementById('raceSelect');
+  const traits = document.getElementById('raceTraits');
+  if (traits) traits.innerHTML = '';
+  if (select) {
+    select.classList.remove('hidden');
+    select.innerHTML = `<option value="">${t('select')}</option>`;
+    DATA.races[base].forEach(({ name, path }) => {
+      const opt = document.createElement('option');
+      opt.value = path;
+      opt.textContent = name;
+      select.appendChild(opt);
+    });
+  }
+}
+
+async function handleSubraceChange(e) {
+  const path = e.target.value;
+  const container = document.getElementById('raceTraits');
+  if (!path || !container) return;
+  currentRaceData = await fetchJsonWithRetry(path, `race at ${path}`);
+  container.innerHTML = '';
+  if (currentRaceData.entries) {
+    const ul = document.createElement('ul');
+    currentRaceData.entries.forEach((e) => {
+      if (e.name) {
+        const li = document.createElement('li');
+        li.textContent = e.name;
+        ul.appendChild(li);
+      }
+    });
+    container.appendChild(ul);
+  }
+  if (currentRaceData.skillProficiencies) {
+    const raceSkills = [];
+    currentRaceData.skillProficiencies.forEach((obj) => {
+      for (const k in obj) if (obj[k]) raceSkills.push(capitalize(k));
+    });
+    if (raceSkills.length) {
+      const p = document.createElement('p');
+      p.textContent = `${t('skills')}: ${raceSkills.join(', ')}`;
+      container.appendChild(p);
+    }
+  }
+  if (currentRaceData.languageProficiencies) {
+    const raceLang = [];
+    currentRaceData.languageProficiencies.forEach((obj) => {
+      for (const k in obj) if (obj[k]) raceLang.push(capitalize(k));
+    });
+    if (raceLang.length) {
+      const p = document.createElement('p');
+      p.textContent = `${t('languages')}: ${raceLang.join(', ')}`;
+      container.appendChild(p);
+    }
+  }
+}
+
+function confirmRaceSelection() {
+  if (!currentRaceData || !selectedBaseRace) return;
+  const container = document.getElementById('raceTraits');
+  CharacterState.system.details.race = selectedBaseRace;
+  CharacterState.system.details.subrace = currentRaceData.name;
+
+  const sizeMap = { T: 'tiny', S: 'sm', M: 'med', L: 'lg', H: 'huge', G: 'grg' };
+  if (currentRaceData.size) {
+    const sz = Array.isArray(currentRaceData.size)
+      ? currentRaceData.size[0]
+      : currentRaceData.size;
+    CharacterState.system.traits.size =
+      sizeMap[sz] || CharacterState.system.traits.size;
+  }
+
+  const move = CharacterState.system.attributes.movement || {};
+  const speed = currentRaceData.speed;
+  if (typeof speed === 'number') move.walk = speed;
+  else if (speed && typeof speed === 'object') {
+    if (typeof speed.walk === 'number') move.walk = speed.walk;
+    ['burrow', 'climb', 'fly', 'swim'].forEach((t) => {
+      const val = speed[t];
+      if (typeof val === 'number') move[t] = val;
+      else if (val === true && typeof move.walk === 'number') move[t] = move.walk;
+    });
+  }
+  CharacterState.system.attributes.movement = move;
+
+  if (Array.isArray(currentRaceData.ability)) {
+    currentRaceData.ability.forEach((obj) => {
+      for (const [ab, val] of Object.entries(obj)) {
+        if (typeof val === 'number' && CharacterState.system.abilities[ab]) {
+          const abil = CharacterState.system.abilities[ab];
+          abil.value = (abil.value || 0) + val;
+        }
+      }
+    });
+  }
+
+  if (currentRaceData.darkvision)
+    CharacterState.system.traits.senses.darkvision = currentRaceData.darkvision;
+  if (currentRaceData.traitTags)
+    CharacterState.system.traits.traitTags = [...currentRaceData.traitTags];
+
+  if (currentRaceData.skillProficiencies) {
+    currentRaceData.skillProficiencies.forEach((obj) => {
+      for (const k in obj)
+        if (obj[k]) addUniqueProficiency('skills', capitalize(k), container);
+    });
+  }
+  if (currentRaceData.languageProficiencies) {
+    currentRaceData.languageProficiencies.forEach((obj) => {
+      for (const k in obj)
+        if (obj[k]) addUniqueProficiency('languages', capitalize(k), container);
+    });
+  }
+  refreshBaseState();
+  rebuildFromClasses();
+  const btn4 = document.getElementById('btnStep4');
+  if (btn4) btn4.disabled = false;
+  logCharacterState();
+  showStep(4);
+}
+
+export async function loadStep3(force = false) {
+  await loadRaces();
+  const container = document.getElementById('raceList');
+  if (!container) return;
+  if (container.childElementCount && !force) return;
+  renderBaseRaces();
+
+  const sel = document.getElementById('raceSelect');
+  sel?.addEventListener('change', handleSubraceChange);
+  sel?.classList.add('hidden');
+
+  const btn = document.getElementById('confirmRaceSelection');
+  btn?.addEventListener('click', () => {
+    confirmRaceSelection();
+    const btn4 = document.getElementById('btnStep4');
+    if (btn4) btn4.disabled = false;
+  });
+}


### PR DESCRIPTION
## Summary
- group race definitions by base race and expose via `loadRaces`
- implement race selection UI with base race then variant choice
- track base race and subrace in `CharacterState`

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ac51443fe4832ebcddda54b90c71b9