### PR TITLE
Validate race selections before confirmation

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -48,4 +48,8 @@ select.missing,
 input.missing {
   border: 2px solid #e74c3c;
 }
+
+select.duplicate {
+  border: 2px solid #e67e22;
+}
   


### PR DESCRIPTION
## Summary
- track pending subrace, language, and spell choices
- disable race confirmation until all selections are made and unique
- highlight missing or duplicate race selections inline

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68ac5f90b4bc832ea8f0cc1c3af5a23a