### PR TITLE
refactor: centralize proficiency utilities

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -11,57 +11,9 @@ import { loadStep2, rebuildFromClasses, refreshBaseState } from "./step2.js";
 import { loadStep3 } from "./step3.js";
 import { exportFoundryActor } from "./export.js";
 import { t, initI18n } from "./i18n.js";
+import { addUniqueProficiency } from "./proficiency.js";
 
 let currentStep = 1;
-
-// full list of skills for replacement handling
-const ALL_SKILLS = [
-  "Acrobatics",
-  "Animal Handling",
-  "Arcana",
-  "Athletics",
-  "Deception",
-  "History",
-  "Insight",
-  "Intimidation",
-  "Investigation",
-  "Medicine",
-  "Nature",
-  "Perception",
-  "Performance",
-  "Persuasion",
-  "Religion",
-  "Sleight of Hand",
-  "Stealth",
-  "Survival",
-];
-
-// basic tool list used when replacing duplicates
-const ALL_TOOLS = [
-  "Alchemist's Supplies",
-  "Brewer's Supplies",
-  "Calligrapher's Supplies",
-  "Carpenter's Tools",
-  "Cartographer's Tools",
-  "Cobbler's Tools",
-  "Cook's Utensils",
-  "Glassblower's Tools",
-  "Jeweler's Tools",
-  "Leatherworker's Tools",
-  "Mason's Tools",
-  "Painter's Supplies",
-  "Potter's Tools",
-  "Smith's Tools",
-  "Tinker's Tools",
-  "Weaver's Tools",
-  "Woodcarver's Tools",
-  "Disguise Kit",
-  "Forgery Kit",
-  "Herbalism Kit",
-  "Navigator's Tools",
-  "Poisoner's Kit",
-  "Thieves' Tools",
-];
 
 function showStep(step) {
   for (let i = 1; i <= 7; i++) {
@@ -115,58 +67,7 @@ function populateBackgroundList() {
   populateSelect("backgroundSelect", "backgrounds");
 }
 
-function getAllOptions(type) {
-  if (type === "skills") return ALL_SKILLS;
-  if (type === "tools") return ALL_TOOLS;
-  if (type === "languages") return DATA.languages || [];
-  return [];
-}
 
-function getProficiencyList(type) {
-  if (type === "skills") return CharacterState.system.skills;
-  if (type === "tools") return CharacterState.system.tools;
-  if (type === "languages")
-    return CharacterState.system.traits.languages.value;
-  if (type === "cantrips") return CharacterState.system.spells.cantrips;
-  return [];
-}
-
-function addUniqueProficiency(type, value, container) {
-  if (!value) return;
-  const list = getProficiencyList(type);
-  if (!list.includes(value)) {
-    list.push(value);
-    logCharacterState();
-    return;
-  }
-  // handle duplicate with replacement
-  const msg = document.createElement("div");
-  const label = document.createElement("label");
-  label.textContent = t("duplicateProficiency", {
-    value,
-    type: t(type.slice(0, -1)),
-  });
-  const sel = document.createElement("select");
-  sel.innerHTML = `<option value=''>${t("select")}</option>`;
-  getAllOptions(type)
-    .filter((opt) => !list.includes(opt))
-    .forEach((opt) => {
-      const o = document.createElement("option");
-      o.value = opt;
-      o.textContent = opt;
-      sel.appendChild(o);
-    });
-  sel.addEventListener("change", () => {
-    if (sel.value && !list.includes(sel.value)) {
-      list.push(sel.value);
-      sel.disabled = true;
-      logCharacterState();
-    }
-  });
-  label.appendChild(sel);
-  msg.appendChild(label);
-  container.appendChild(msg);
-}
 
 function capitalize(str) {
   return str.charAt(0).toUpperCase() + str.slice(1);

--- a/src/proficiency.js
+++ b/src/proficiency.js
@@ -1,0 +1,103 @@
+import { DATA, CharacterState, logCharacterState } from './data.js';
+import { t } from './i18n.js';
+
+// full list of skills for replacement handling
+export const ALL_SKILLS = [
+  'Acrobatics',
+  'Animal Handling',
+  'Arcana',
+  'Athletics',
+  'Deception',
+  'History',
+  'Insight',
+  'Intimidation',
+  'Investigation',
+  'Medicine',
+  'Nature',
+  'Perception',
+  'Performance',
+  'Persuasion',
+  'Religion',
+  'Sleight of Hand',
+  'Stealth',
+  'Survival',
+];
+
+// basic tool list used when replacing duplicates
+export const ALL_TOOLS = [
+  "Alchemist's Supplies",
+  "Brewer's Supplies",
+  "Calligrapher's Supplies",
+  "Carpenter's Tools",
+  "Cartographer's Tools",
+  "Cobbler's Tools",
+  "Cook's Utensils",
+  "Glassblower's Tools",
+  "Jeweler's Tools",
+  "Leatherworker's Tools",
+  "Mason's Tools",
+  "Painter's Supplies",
+  "Potter's Tools",
+  "Smith's Tools",
+  "Tinker's Tools",
+  "Weaver's Tools",
+  "Woodcarver's Tools",
+  'Disguise Kit',
+  'Forgery Kit',
+  'Herbalism Kit',
+  "Navigator's Tools",
+  "Poisoner's Kit",
+  "Thieves' Tools",
+];
+
+export function getProficiencyList(type) {
+  if (type === 'skills') return CharacterState.system.skills;
+  if (type === 'tools') return CharacterState.system.tools;
+  if (type === 'languages') return CharacterState.system.traits.languages.value;
+  if (type === 'cantrips') return CharacterState.system.spells.cantrips;
+  return [];
+}
+
+export function getAllOptions(type) {
+  if (type === 'skills') return ALL_SKILLS;
+  if (type === 'tools') return ALL_TOOLS;
+  if (type === 'languages') return DATA.languages || [];
+  return [];
+}
+
+export function addUniqueProficiency(type, value, container) {
+  if (!value) return;
+  const list = getProficiencyList(type);
+  if (!list.includes(value)) {
+    list.push(value);
+    logCharacterState();
+    return;
+  }
+  const msg = document.createElement('div');
+  const label = document.createElement('label');
+  label.textContent = t('duplicateProficiency', {
+    value,
+    type: t(type.slice(0, -1)),
+  });
+  const sel = document.createElement('select');
+  sel.innerHTML = `<option value=''>${t('select')}</option>`;
+  getAllOptions(type)
+    .filter(opt => !list.includes(opt))
+    .forEach(opt => {
+      const o = document.createElement('option');
+      o.value = opt;
+      o.textContent = opt;
+      sel.appendChild(o);
+    });
+  sel.addEventListener('change', () => {
+    if (sel.value && !list.includes(sel.value)) {
+      list.push(sel.value);
+      sel.disabled = true;
+      logCharacterState();
+    }
+  });
+  label.appendChild(sel);
+  msg.appendChild(label);
+  container.appendChild(msg);
+}
+

--- a/src/step3.js
+++ b/src/step3.js
@@ -8,6 +8,7 @@ import {
 import { refreshBaseState, rebuildFromClasses } from './step2.js';
 import { t } from './i18n.js';
 import { showStep } from './main.js';
+import { addUniqueProficiency } from './proficiency.js';
 
 let selectedBaseRace = '';
 let currentRaceData = null;
@@ -64,107 +65,11 @@ function validateRaceChoices() {
   return valid;
 }
 
-const ALL_SKILLS = [
-  'Acrobatics',
-  'Animal Handling',
-  'Arcana',
-  'Athletics',
-  'Deception',
-  'History',
-  'Insight',
-  'Intimidation',
-  'Investigation',
-  'Medicine',
-  'Nature',
-  'Perception',
-  'Performance',
-  'Persuasion',
-  'Religion',
-  'Sleight of Hand',
-  'Stealth',
-  'Survival',
-];
-
-const ALL_TOOLS = [
-  "Alchemist's Supplies",
-  "Brewer's Supplies",
-  "Calligrapher's Supplies",
-  "Carpenter's Tools",
-  "Cartographer's Tools",
-  "Cobbler's Tools",
-  "Cook's Utensils",
-  "Glassblower's Tools",
-  "Jeweler's Tools",
-  "Leatherworker's Tools",
-  "Mason's Tools",
-  "Painter's Supplies",
-  "Potter's Tools",
-  "Smith's Tools",
-  "Tinker's Tools",
-  "Weaver's Tools",
-  "Woodcarver's Tools",
-  'Disguise Kit',
-  'Forgery Kit',
-  'Herbalism Kit',
-  "Navigator's Tools",
-  "Poisoner's Kit",
-  "Thieves' Tools",
-];
-
 function capitalize(str) {
   return str.charAt(0).toUpperCase() + str.slice(1);
 }
 
-function getProficiencyList(type) {
-  if (type === 'skills') return CharacterState.system.skills;
-  if (type === 'tools') return CharacterState.system.tools;
-  if (type === 'languages') return CharacterState.system.traits.languages.value;
-  if (type === 'cantrips') return CharacterState.system.spells.cantrips;
-  return [];
-}
 
-function getAllOptions(type) {
-  if (type === 'skills') return ALL_SKILLS;
-  if (type === 'tools') return ALL_TOOLS;
-  if (type === 'languages') return DATA.languages || [];
-  return [];
-}
-
-function addUniqueProficiency(type, value, container) {
-  if (!value) return;
-  const list = getProficiencyList(type);
-  if (!list.includes(value)) {
-    list.push(value);
-    logCharacterState();
-    return;
-  }
-  const msg = document.createElement('div');
-  const label = document.createElement('label');
-  label.textContent = t('duplicateProficiency', {
-    value,
-    type: t(type.slice(0, -1))
-  });
-  const sel = document.createElement('select');
-  sel.innerHTML = `<option value=''>${t('select')}</option>`;
-  getAllOptions(type)
-    .filter((opt) => !list.includes(opt))
-    .forEach((opt) => {
-      const o = document.createElement('option');
-      o.value = opt;
-      o.textContent = opt;
-      sel.appendChild(o);
-    });
-  sel.addEventListener('change', () => {
-    if (sel.value && !list.includes(sel.value)) {
-      list.push(sel.value);
-      sel.disabled = true;
-      logCharacterState();
-    }
-  });
-  label.appendChild(sel);
-  msg.appendChild(label);
-  container.appendChild(msg);
-}
 
 function createRaceCard(race, onSelect, displayName = race.name) {
   const card = document.createElement('div');


### PR DESCRIPTION
## Summary
- move skill and tool lists plus proficiency helpers into shared `proficiency.js`
- update `main.js` and `step3.js` to use the shared module

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ac66e9f558832e8d23042dc9afc374