### PR TITLE
feat: preload background details for selection

### DIFF
--- a/src/data.js
+++ b/src/data.js
@@ -52,6 +52,29 @@ export async function loadFeats() {
 }
 
 /**
+ * Fetches background data from the JSON index and stores full objects
+ * keyed by their background name on `DATA.backgrounds`.
+ */
+export async function loadBackgrounds() {
+  if (DATA.backgrounds && Object.keys(DATA.backgrounds).length) return;
+
+  const index = await fetchJsonWithRetry(
+    'data/backgrounds.json',
+    'background index'
+  );
+  const entries = index.items || {};
+  DATA.backgrounds = {};
+
+  await Promise.all(
+    Object.entries(entries).map(async ([name, path]) => {
+      const bg = await fetchJsonWithRetry(path, `background at ${path}`);
+      if (!bg.name) bg.name = name;
+      DATA.backgrounds[name] = bg;
+    })
+  );
+}
+
+/**
  * Fetches race data and groups variants by their base race name.
  */
 export async function loadRaces() {

--- a/src/main.js
+++ b/src/main.js
@@ -6,6 +6,7 @@ import {
   logCharacterState,
   adjustResource,
   updateSpellSlots,
+  loadBackgrounds,
 } from "./data.js";
 import { loadStep2, rebuildFromClasses, refreshBaseState } from "./step2.js";
 import { loadStep3 } from "./step3.js";
@@ -36,19 +37,15 @@ function showStep(step) {
 }
 
 async function loadData() {
-  // Load each class file referenced in data/classes.json
-  await loadClasses();
+  // Load class and background data
+  await Promise.all([loadClasses(), loadBackgrounds()]);
 
-  // Retain existing logic for other data types
-  const sources = {
-    backgrounds: "data/backgrounds.json",
-    languages: "data/languages.json",
-  };
-
-  for (const [key, path] of Object.entries(sources)) {
-    const json = await fetchJsonWithRetry(path, key);
-    DATA[key] = json.items || json.languages;
-  }
+  // Load languages separately
+  const langJson = await fetchJsonWithRetry(
+    "data/languages.json",
+    "languages"
+  );
+  DATA.languages = langJson.languages;
 }
 
 function capitalize(str) {

--- a/src/step4.js
+++ b/src/step4.js
@@ -1,7 +1,6 @@
 import {
   DATA,
   CharacterState,
-  fetchJsonWithRetry,
   logCharacterState
 } from './data.js';
 import { refreshBaseState, rebuildFromClasses, updateChoiceSelectOptions } from './step2.js';
@@ -51,18 +50,18 @@ export function renderBackgroundList() {
   if (!container) return;
   container.innerHTML = '';
   const entries = DATA.backgrounds || {};
-  for (const [name, path] of Object.entries(entries)) {
+  for (const [name, bg] of Object.entries(entries)) {
     const card = document.createElement('div');
     card.className = 'class-card';
-    card.addEventListener('click', () => selectBackground(path));
+    card.addEventListener('click', () => selectBackground(bg));
     const title = createElement('h3', name);
     card.appendChild(title);
     container.appendChild(card);
   }
 }
 
-async function selectBackground(path) {
-  currentBackgroundData = await fetchJsonWithRetry(path, `background at ${path}`);
+function selectBackground(bg) {
+  currentBackgroundData = bg;
   const list = document.getElementById('backgroundList');
   list?.classList.add('hidden');
 


### PR DESCRIPTION
## Summary
- add `loadBackgrounds` to fetch background index and details
- use `loadBackgrounds` in main data loader and preload background objects
- update background list rendering to use preloaded background objects

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68ac75953c08832ea4a98797476c0974