### PR TITLE
Add shared race name to elven subraces

### DIFF
--- a/data/races/elfastral.json
+++ b/data/races/elfastral.json
@@ -1,5 +1,6 @@
 {
 	"name": "Astral Elf",
+	"raceName": "Elf",
 	"source": "AAG",
 	"page": 10,
 	"lineage": "VRGR",

--- a/data/races/elfeladrin.json
+++ b/data/races/elfeladrin.json
@@ -1,5 +1,6 @@
 {
 	"name": "Eladrin",
+	"raceName": "Elf",
 	"source": "MPMM",
 	"page": 13,
 	"lineage": "VRGR",


### PR DESCRIPTION
## Summary
- add `raceName: "Elf"` to Astral Elf and Eladrin data

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68adb34fc004832e84aae7ca9df4d98c