### PR TITLE
Add raceName to Half-Elf base race

### DIFF
--- a/data/races/halfelfstandard.json
+++ b/data/races/halfelfstandard.json
@@ -96,6 +96,7 @@
 			"type": "entries"
 		}
 	],
+	"raceName": "Half-Elf",
 	"hasFluff": true,
 	"hasFluffImages": true
 }


### PR DESCRIPTION
## Summary
- assign `raceName` to Half-Elf base race so variant detection covers all options

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68adb781dd84832ea2098d23647a7dcd