### PR TITLE
Add raceName for Deep Gnome

### DIFF
--- a/data/races/gnomedeep.json
+++ b/data/races/gnomedeep.json
@@ -1,8 +1,9 @@
 {
-	"name": "Deep Gnome",
-	"source": "MPMM",
-	"page": 11,
-	"lineage": "VRGR",
+        "name": "Deep Gnome",
+        "raceName": "Gnome",
+        "source": "MPMM",
+        "page": 11,
+        "lineage": "VRGR",
 	"creatureTypes": [
 		"humanoid"
 	],


### PR DESCRIPTION
## Summary
- add missing raceName property to Deep Gnome data

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68adb77bde78832e8a086a1afa094afa