### PR TITLE
feat(background): add search filtering

### DIFF
--- a/index.html
+++ b/index.html
@@ -132,6 +132,12 @@
       <!-- Step 4: Background -->
       <div id="step4" class="step hidden">
         <h2>Step 4: Background</h2>
+        <input
+          id="backgroundSearch"
+          type="text"
+          class="form-control"
+          placeholder="Search backgrounds"
+        />
         <div id="backgroundList" class="class-list"></div>
         <div class="form-group">
           <label for="backgroundSelect" class="hidden">Background:</label>

--- a/src/step4.js
+++ b/src/step4.js
@@ -44,12 +44,14 @@ function createAccordionItem(title, content, isChoice = false) {
   return item;
 }
 
-export function renderBackgroundList() {
+export function renderBackgroundList(query = '') {
   const container = document.getElementById('backgroundList');
   if (!container) return;
   container.innerHTML = '';
   const entries = DATA.backgrounds || {};
+  const term = query.toLowerCase();
   for (const [name, bg] of Object.entries(entries)) {
+    if (!name.toLowerCase().includes(term)) continue;
     const card = document.createElement('div');
     card.className = 'class-card';
     card.addEventListener('click', () => selectBackground(bg));
@@ -273,9 +275,13 @@ function confirmBackgroundSelection() {
 
 export function loadStep4(force = false) {
   const container = document.getElementById('backgroundList');
+  const searchInput = document.getElementById('backgroundSearch');
   if (!container) return;
   if (container.childElementCount && !force) return;
-  renderBackgroundList();
+  renderBackgroundList(searchInput?.value);
+  searchInput?.addEventListener('input', (e) => {
+    renderBackgroundList(e.target.value);
+  });
   const btn = document.getElementById('confirmBackgroundSelection');
   btn?.addEventListener('click', confirmBackgroundSelection);
   btn?.setAttribute('disabled', 'true');


### PR DESCRIPTION
## Summary
- add search input for background selection
- filter backgrounds by search term
- rerender background list when search input changes

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68adbd87b2b4832e9126160cde82ac33