### PR TITLE
Hide class list after selection

### DIFF
--- a/src/step2.js
+++ b/src/step2.js
@@ -875,6 +875,9 @@ function selectClass(cls) {
   modal?.classList.add('hidden');
   rebuildFromClasses();
   renderSelectedClasses();
+  document.getElementById('classList')?.classList.add('hidden');
+  document.getElementById('selectedClasses')?.classList.remove('hidden');
+  loadStep2(false);
   updateStep2Completion();
 }
 


### PR DESCRIPTION
## Summary
- Hide class selection list and show the selected class editor when a class is chosen
- Re-render class list to remove already chosen options and prevent duplicate selection

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68adbef126ac832e9d39f64801b63334