### PR TITLE
Improve race search and selection behavior

### DIFF
--- a/__tests__/step3.test.js
+++ b/__tests__/step3.test.js
@@ -1,0 +1,81 @@
+/**
+ * @jest-environment jsdom
+ */
+import { jest } from '@jest/globals';
+
+const mockFetch = jest.fn();
+const mockLoadRaces = jest.fn().mockResolvedValue();
+
+jest.unstable_mockModule('../src/data.js', () => ({
+  DATA: { races: {}, languages: [] },
+  CharacterState: {
+    system: {
+      spells: { cantrips: [] },
+      details: {},
+      traits: { languages: { value: [] } },
+      attributes: {},
+    },
+    raceChoices: { spells: [] },
+  },
+  fetchJsonWithRetry: mockFetch,
+  loadRaces: mockLoadRaces,
+  logCharacterState: jest.fn(),
+  loadClasses: jest.fn(),
+  adjustResource: jest.fn(),
+  updateSpellSlots: jest.fn(),
+  loadBackgrounds: jest.fn(),
+}));
+
+jest.unstable_mockModule('../src/step2.js', () => ({
+  refreshBaseState: jest.fn(),
+  rebuildFromClasses: jest.fn(),
+  updateChoiceSelectOptions: jest.fn(),
+  loadStep2: jest.fn(),
+}));
+
+const { renderBaseRaces, selectBaseRace } = await import('../src/step3.js');
+const { DATA } = await import('../src/data.js');
+
+describe('race search behavior', () => {
+  beforeEach(() => {
+    document.body.innerHTML = `
+      <input id="raceSearch" />
+      <div id="raceList"></div>
+      <div id="raceFeatures"></div>
+      <button id="changeRace"></button>
+    `;
+    DATA.races = {
+      Elf: [
+        { name: 'Elf (Eladrin)', path: 'eladrin' },
+        { name: 'Elf (Wood)', path: 'wood' },
+      ],
+      Dwarf: [{ name: 'Dwarf (Hill)', path: 'dwarfHill' }],
+    };
+    const raceData = {
+      eladrin: { name: 'Elf (Eladrin)', entries: [] },
+      wood: { name: 'Elf (Wood)', entries: [] },
+      dwarfHill: { name: 'Dwarf (Hill)', entries: [] },
+    };
+    mockFetch.mockImplementation((p) => Promise.resolve(raceData[p]));
+  });
+
+  test('search term matches subrace and shows base race card', async () => {
+    await renderBaseRaces('Eladrin');
+    const cards = document.querySelectorAll('#raceList .class-card');
+    expect(cards).toHaveLength(1);
+    expect(cards[0].querySelector('h3').textContent).toBe('Elf');
+  });
+
+  test('selecting base race clears search and shows all subraces', async () => {
+    const search = document.getElementById('raceSearch');
+    search.value = 'Eladrin';
+    await selectBaseRace('Elf');
+    expect(search.value).toBe('');
+    const cards = document.querySelectorAll('#raceList .class-card');
+    const names = [...cards].map((c) => c.querySelector('h3').textContent);
+    expect(names).toEqual(
+      expect.arrayContaining(['Elf (Eladrin)', 'Elf (Wood)'])
+    );
+  });
+});
+

--- a/src/step3.js
+++ b/src/step3.js
@@ -166,13 +166,15 @@ async function renderBaseRaces(search = '') {
   const term = (search || '').toLowerCase();
   await Promise.all(
     Object.entries(DATA.races).map(async ([base, subs]) => {
+      const baseMatch = base.toLowerCase().includes(term);
+      const subMatch = subs.some((s) => s.name.toLowerCase().includes(term));
+      if (term && !baseMatch && !subMatch) return;
       let race = { name: base };
       const path = subs[0]?.path;
       if (path) {
         const data = await fetchJsonWithRetry(path, `race at ${path}`);
         race = { ...data, name: base };
       }
-      if (!race.name.toLowerCase().includes(term)) return;
       const card = createRaceCard(race, () => selectBaseRace(base));
       container.appendChild(card);
     })
@@ -191,8 +193,9 @@ async function selectBaseRace(base) {
   features?.classList.add('hidden');
   const list = document.getElementById('raceList');
   list?.classList.remove('hidden');
-  const search = document.getElementById('raceSearch')?.value;
-  await renderSubraceCards(base, search);
+  const searchInput = document.getElementById('raceSearch');
+  if (searchInput) searchInput.value = '';
+  await renderSubraceCards(base);
   validateRaceChoices();
 }
 
@@ -547,3 +550,5 @@ export async function loadStep3(force = false) {
     validateRaceChoices();
   });
 }
+
+export { renderBaseRaces, selectBaseRace };


### PR DESCRIPTION
## Summary
- Show base race cards when search matches either base or subrace names
- Reset race search field when a base race is chosen to display all subraces
- Add tests verifying search and selection behaviors

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68adc0c0e22c832ebd2306cbbddd3b94