### PR TITLE
Avoid duplicate class list rendering in Step 2

### DIFF
--- a/src/step2.js
+++ b/src/step2.js
@@ -87,7 +87,6 @@ function rebuildFromClasses() {
   }
   updateSpellSlots();
   updateProficiencyBonus();
-  renderSelectedClasses();
 }
 
 function validateTotalLevel(pendingClass) {
@@ -407,7 +406,6 @@ function renderClassEditor(cls, index) {
     }
     compileClassFeatures(cls);
     rebuildFromClasses();
-    renderSelectedClasses();
     updateStep2Completion();
   });
   card.appendChild(levelSel);
@@ -874,7 +872,6 @@ function selectClass(cls) {
   const modal = document.getElementById('classModal');
   modal?.classList.add('hidden');
   rebuildFromClasses();
-  renderSelectedClasses();
   document.getElementById('classList')?.classList.add('hidden');
   document.getElementById('selectedClasses')?.classList.remove('hidden');
   loadStep2(false);


### PR DESCRIPTION
## Summary
- Remove automatic selected-class rendering from `rebuildFromClasses`
- Drop redundant `renderSelectedClasses` calls in level change and class selection handlers

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68adc7973908832ea57162536d995ab8