### PR TITLE
Hide class search input after class selection

### DIFF
--- a/__tests__/classSearch.test.js
+++ b/__tests__/classSearch.test.js
@@ -1,0 +1,68 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import { jest } from '@jest/globals';
+
+jest.unstable_mockModule('../src/data.js', () => {
+  const CharacterState = {
+    classes: [],
+    feats: [],
+    system: {
+      abilities: {
+        str: { value: 8 },
+        dex: { value: 8 },
+        con: { value: 8 },
+        int: { value: 8 },
+        wis: { value: 8 },
+        cha: { value: 8 },
+      },
+      skills: [],
+      tools: [],
+      traits: { languages: { value: [] } },
+      spells: { cantrips: [] },
+      attributes: { prof: 2 },
+    },
+  };
+  return {
+    DATA: { classes: [{ name: 'Fighter', description: '' }], feats: [] },
+    CharacterState,
+    loadClasses: jest.fn().mockResolvedValue(),
+    loadFeats: jest.fn().mockResolvedValue(),
+    logCharacterState: jest.fn(),
+    totalLevel: () => CharacterState.classes.reduce((s, c) => s + c.level, 0),
+    updateSpellSlots: jest.fn(),
+    updateProficiencyBonus: jest.fn(),
+    MAX_CHARACTER_LEVEL: 20,
+  };
+});
+
+const { loadStep2 } = await import('../src/step2.js');
+const { CharacterState } = await import('../src/data.js');
+
+describe('class search visibility', () => {
+  beforeEach(() => {
+    document.body.innerHTML = `
+      <input id="classSearch" class="form-control" />
+      <div id="classList" class="class-list"></div>
+      <div id="selectedClasses"></div>
+    `;
+    CharacterState.classes = [];
+  });
+
+  test('search bar visible with no classes selected', async () => {
+    await loadStep2(true);
+    expect(
+      document.getElementById('classSearch').classList.contains('hidden')
+    ).toBe(false);
+  });
+
+  test('search bar hidden after class selected', async () => {
+    await loadStep2(true);
+    CharacterState.classes = [{ name: 'Fighter', level: 1 }];
+    await loadStep2(false);
+    expect(
+      document.getElementById('classSearch').classList.contains('hidden')
+    ).toBe(true);
+  });
+});

--- a/src/step2.js
+++ b/src/step2.js
@@ -723,6 +723,7 @@ function updateStep2Completion() {
 export async function loadStep2(refresh = true) {
   const classListContainer = document.getElementById('classList');
   const selectedClassesContainer = document.getElementById('selectedClasses');
+  const searchInput = document.getElementById('classSearch');
   if (!classListContainer || !selectedClassesContainer) return;
   classListContainer.innerHTML = '';
   selectedClassesContainer.innerHTML = '';
@@ -744,6 +745,7 @@ export async function loadStep2(refresh = true) {
   // Show either the class selection list or the already selected classes
   classListContainer.classList.toggle('hidden', CharacterState.classes.length !== 0);
   selectedClassesContainer?.classList.toggle('hidden', CharacterState.classes.length === 0);
+  searchInput?.classList.toggle('hidden', CharacterState.classes.length !== 0);
 
   if (CharacterState.classes.length !== 0) {
     return;
@@ -754,7 +756,6 @@ export async function loadStep2(refresh = true) {
     console.error('Dati classi non disponibili.');
     return;
   }
-  const searchInput = document.getElementById('classSearch');
   function renderClassCards(query = '') {
     classListContainer.innerHTML = '';
     const taken = new Set(CharacterState.classes.map(c => c.name));
@@ -873,6 +874,7 @@ function selectClass(cls) {
   modal?.classList.add('hidden');
   rebuildFromClasses();
   document.getElementById('classList')?.classList.add('hidden');
+  document.getElementById('classSearch')?.classList.add('hidden');
   document.getElementById('selectedClasses')?.classList.remove('hidden');
   loadStep2(false);
   updateStep2Completion();


### PR DESCRIPTION
## Summary
- Hide class search bar once a class is chosen
- Toggle search bar visibility in loadStep2 when classes are selected
- Add tests confirming class search bar visibility toggles correctly

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68adcaf88828832e81046c0416427e8b