### PR TITLE
Fix skill selection counting

### DIFF
--- a/__tests__/step2.test.js
+++ b/__tests__/step2.test.js
@@ -78,4 +78,19 @@ describe('duplicate selection prevention', () => {
       choiceSelect1.querySelector("option[value='Acrobatics']").disabled
     ).toBe(false);
   });
+
+  test('selecting two different skills keeps both selections', () => {
+    const skillSelect1 = createSelect(['Acrobatics', 'Athletics']);
+    const skillSelect2 = createSelect(['Acrobatics', 'Athletics']);
+    skillSelect1.value = 'Acrobatics';
+    const skillSelects = [skillSelect1, skillSelect2];
+
+    updateSkillSelectOptions(skillSelects);
+
+    skillSelect2.value = 'Athletics';
+    updateSkillSelectOptions(skillSelects);
+
+    expect(skillSelect1.value).toBe('Acrobatics');
+    expect(skillSelect2.value).toBe('Athletics');
+  });
 });

--- a/src/step2.js
+++ b/src/step2.js
@@ -157,10 +157,23 @@ function updateSkillSelectOptions(skillSelectsList, choiceSkillSelectsList = [])
     if (!val) return;
     counts.set(val, (counts.get(val) || 0) + 1);
   };
+  const subtract = val => {
+    if (!val) return;
+    const newCount = (counts.get(val) || 0) - 1;
+    if (newCount <= 0) counts.delete(val);
+    else counts.set(val, newCount);
+  };
 
+  // Start from the character's known skills
   CharacterState.system.skills.forEach(add);
-  choiceSkillSelectsList.forEach(sel => add(sel.value));
+
+  // Remove the current class's selections before recounting
+  skillSelectsList.forEach(sel => subtract(sel.value));
+  choiceSkillSelectsList.forEach(sel => subtract(sel.value));
+
+  // Add the current selections back once to track duplicates correctly
   skillSelectsList.forEach(sel => add(sel.value));
+  choiceSkillSelectsList.forEach(sel => add(sel.value));
 
   skillSelectsList.forEach(sel => {
     Array.from(sel.options).forEach(opt => {


### PR DESCRIPTION
## Summary
- correct skill option counting by subtracting current class selections before re-adding
- add regression test ensuring selecting two different skills retains both selections

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68adcf21f54c832e9f277e122f12a6ed