### PR TITLE
Toggle race details inline

### DIFF
--- a/__tests__/step3.test.js
+++ b/__tests__/step3.test.js
@@ -102,3 +102,29 @@ describe('race search behavior', () => {
   });
 });
 
+describe('race card details toggle', () => {
+  beforeEach(() => {
+    document.body.innerHTML = `
+      <div id="raceList"></div>
+    `;
+    DATA.races = {
+      Elf: [{ name: 'Elf', path: 'elfPath' }],
+    };
+    mockFetch.mockImplementation(() =>
+      Promise.resolve({
+        name: 'Elf',
+        entries: ['A nimble folk.', { name: 'Keen Senses' }],
+      })
+    );
+  });
+
+  test('details are hidden and toggle on click', async () => {
+    await renderBaseRaces();
+    const card = document.querySelector('#raceList .class-card');
+    const details = card.querySelector('.race-details');
+    expect(details.classList.contains('hidden')).toBe(true);
+    card.querySelector('button').click();
+    expect(details.classList.contains('hidden')).toBe(false);
+  });
+});
+

--- a/css/site-theme.css
+++ b/css/site-theme.css
@@ -339,3 +339,7 @@ th {
 .class-card button {
   margin-top: 10px;
 }
+
+.race-details.hidden {
+  display: none;
+}

--- a/src/step3.js
+++ b/src/step3.js
@@ -120,11 +120,14 @@ function createRaceCard(race, onSelect, displayName = race.name) {
   title.textContent = displayName;
   card.appendChild(title);
 
+  const details = document.createElement('div');
+  details.className = 'race-details hidden';
+
   const shortDesc = (race.entries || []).find((e) => typeof e === 'string');
   if (shortDesc) {
     const p = document.createElement('p');
     p.textContent = shortDesc;
-    card.appendChild(p);
+    details.appendChild(p);
   }
 
   const traits = (race.entries || [])
@@ -138,15 +141,17 @@ function createRaceCard(race, onSelect, displayName = race.name) {
       li.textContent = t;
       ul.appendChild(li);
     });
-    card.appendChild(ul);
+    details.appendChild(ul);
   }
+
+  card.appendChild(details);
 
   const detailsBtn = document.createElement('button');
   detailsBtn.className = 'btn btn-primary';
   detailsBtn.textContent = 'Details';
   detailsBtn.addEventListener('click', (e) => {
     e.stopPropagation();
-    showRaceModal(race);
+    details.classList.toggle('hidden');
   });
   card.appendChild(detailsBtn);
 


### PR DESCRIPTION
## Summary
- Show race descriptions and traits inline by toggling a hidden details section on each race card
- Add CSS to hide race details by default
- Test that race card details are hidden initially and toggle on button click

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68add0b39130832eb7cc4ee63e8cd0f6