### PR TITLE
Add class filter for racial spell choices

### DIFF
--- a/__tests__/step3.test.js
+++ b/__tests__/step3.test.js
@@ -180,3 +180,63 @@ describe('Aarakocra selections', () => {
   });
 });
 
+describe('High Elf cantrip choices', () => {
+  beforeEach(() => {
+    document.body.innerHTML = `
+      <div id="raceList"></div>
+      <div id="raceFeatures"></div>
+      <button id="confirmRaceSelection"></button>
+    `;
+    DATA.races = {
+      Elf: [{ name: 'Elf (High)', path: 'elfHigh' }],
+    };
+    DATA.spells = [
+      {
+        name: 'Fire Bolt',
+        level: 0,
+        school: 'Evocation',
+        spell_list: ['Wizard', 'Sorcerer'],
+      },
+      {
+        name: 'Sacred Flame',
+        level: 0,
+        school: 'Evocation',
+        spell_list: ['Cleric'],
+      },
+      {
+        name: 'Mage Hand',
+        level: 0,
+        school: 'Conjuration',
+        spell_list: ['Wizard'],
+      },
+      {
+        name: 'Magic Missile',
+        level: 1,
+        school: 'Evocation',
+        spell_list: ['Wizard'],
+      },
+    ];
+    const race = {
+      name: 'Elf (High)',
+      entries: [],
+      additionalSpells: [
+        { ability: 'int', known: { 1: { _: [{ choose: 'level=0|class=Wizard' }] } } },
+      ],
+    };
+    mockFetch.mockImplementation((p) => {
+      if (p === 'elfHigh') return Promise.resolve(race);
+      return Promise.resolve({});
+    });
+  });
+
+  test('only wizard cantrips are offered', async () => {
+    await selectBaseRace('Elf');
+    const card = document.querySelector('#raceList .class-card');
+    card.click();
+    await new Promise((r) => setTimeout(r, 0));
+    const sel = document.querySelector('#raceFeatures select');
+    const values = [...sel.options].map((o) => o.value).filter((v) => v);
+    expect(values).toEqual(['Fire Bolt', 'Mage Hand']);
+  });
+});
+

--- a/src/step3.js
+++ b/src/step3.js
@@ -417,6 +417,15 @@ async function renderSelectedRace() {
                     .map((s) => SCHOOL_MAP[s] || s);
                   return schools.includes(sp.school);
                 }
+                if (key === 'class') {
+                  const classes = val
+                    .split(';')
+                    .map((c) => capitalize(c.trim()))
+                    .filter((c) => c);
+                  return classes.some((c) =>
+                    (sp.spell_list || []).includes(c)
+                  );
+                }
                 return true;
               });
             })


### PR DESCRIPTION
## Summary
- filter additional spell options by class
- add regression test for High Elf cantrip list

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68add89c5fc4832e9a70e6387a6bf09e