### PR TITLE
Fix missing race selection options

### DIFF
--- a/data/races/dhampir.json
+++ b/data/races/dhampir.json
@@ -12,11 +12,16 @@
 		"walk": 35,
 		"climb": 35
 	},
-	"darkvision": 60,
-	"traitTags": [
-		"Natural Weapon"
+"darkvision": 60,
+"traitTags": [
+"Natural Weapon"
+],
+	"skillProficiencies": [
+		{
+			"any": 2
+		}
 	],
-	"entries": [
+"entries": [
 		{
 			"type": "entries",
 			"name": "Size",

--- a/data/races/elfastral.json
+++ b/data/races/elfastral.json
@@ -28,50 +28,31 @@
 			"perception": true
 		}
 	],
-	"additionalSpells": [
-		{
-			"known": {
-				"1": [
-					"dancing lights#c"
-				]
-			},
-			"ability": {
-				"choose": [
-					"int",
-					"wis",
-					"cha"
-				]
-			}
-		},
-		{
-			"known": {
-				"1": [
-					"light#c"
-				]
-			},
-			"ability": {
-				"choose": [
-					"int",
-					"wis",
-					"cha"
-				]
-			}
-		},
-		{
-			"known": {
-				"1": [
-					"sacred flame#c"
-				]
-			},
-			"ability": {
-				"choose": [
-					"int",
-					"wis",
-					"cha"
-				]
-			}
-		}
-	],
+"additionalSpells": [
+{
+"ability": {
+"choose": [
+"int",
+"wis",
+"cha"
+]
+},
+"known": {
+"1": [
+{
+"choose": {
+"from": [
+"dancing lights#c",
+"light#c",
+"sacred flame#c"
+],
+"count": 1
+}
+}
+]
+}
+}
+],
 	"entries": [
 		{
 			"type": "entries",

--- a/data/races/kenku.json
+++ b/data/races/kenku.json
@@ -22,13 +22,26 @@
 		"mature": 12,
 		"max": 60
 	},
-	"languageProficiencies": [
-		{
-			"common": true,
-			"auran": true
+"languageProficiencies": [
+{
+"common": true,
+"auran": true
 		}
 	],
-	"entries": [
+	"skillProficiencies": [
+		{
+			"choose": {
+				"from": [
+"acrobatics",
+"deception",
+"stealth",
+"sleight of hand"
+],
+				"count": 2
+}
+}
+],
+"entries": [
 		{
 			"name": "Expert Forgery",
 			"type": "entries",

--- a/data/races/leonin.json
+++ b/data/races/leonin.json
@@ -22,13 +22,27 @@
 		"mature": 18,
 		"max": 100
 	},
-	"languageProficiencies": [
-		{
-			"common": true,
-			"leonin": true
+"languageProficiencies": [
+{
+"common": true,
+"leonin": true
 		}
 	],
-	"entries": [
+	"skillProficiencies": [
+		{
+			"choose": {
+				"from": [
+"athletics",
+"intimidation",
+"perception",
+"stealth",
+"survival"
+],
+				"count": 1
+}
+}
+],
+"entries": [
 		{
 			"name": "Claws",
 			"type": "entries",

--- a/data/races/lizardfolk.json
+++ b/data/races/lizardfolk.json
@@ -25,13 +25,27 @@
 		"mature": 14,
 		"max": 60
 	},
-	"languageProficiencies": [
-		{
-			"common": true,
-			"draconic": true
+"languageProficiencies": [
+{
+"common": true,
+"draconic": true
 		}
 	],
-	"entries": [
+	"skillProficiencies": [
+		{
+			"choose": {
+				"from": [
+"animal handling",
+"nature",
+"perception",
+"stealth",
+"survival"
+],
+				"count": 2
+}
+}
+],
+"entries": [
 		{
 			"name": "Bite",
 			"type": "entries",


### PR DESCRIPTION
## Summary
- add choose-able cantrip for Astral Elf
- add missing skill proficiency choices for Dhampir, Kenku, Leonin, and Lizardfolk

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68adda0fcce8832e93b775846a5b918b