### PR TITLE
Show subrace counts on base race cards

### DIFF
--- a/__tests__/step3.test.js
+++ b/__tests__/step3.test.js
@@ -63,7 +63,7 @@ describe('race search behavior', () => {
     await renderBaseRaces('Eladrin');
     const cards = document.querySelectorAll('#raceList .class-card');
     expect(cards).toHaveLength(1);
-    expect(cards[0].querySelector('h3').textContent).toBe('Elf');
+    expect(cards[0].querySelector('h3').textContent).toBe('Elf (2)');
   });
 
   test('selecting base race clears search and shows all subraces', async () => {
@@ -98,7 +98,7 @@ describe('race search behavior', () => {
     await p1;
     const cards = document.querySelectorAll('#raceList .class-card');
     expect(cards).toHaveLength(1);
-    expect(cards[0].querySelector('h3').textContent).toBe('Dwarf');
+    expect(cards[0].querySelector('h3').textContent).toBe('Dwarf (1)');
   });
 });
 

--- a/src/step3.js
+++ b/src/step3.js
@@ -185,7 +185,11 @@ async function renderBaseRaces(search = '') {
       race = { ...data, name: base };
     }
     if (seq !== raceRenderSeq) return;
-    const card = createRaceCard(race, () => selectBaseRace(base));
+    const card = createRaceCard(
+      race,
+      () => selectBaseRace(base),
+      `${base} (${subs.length})`
+    );
     if (seq !== raceRenderSeq) return;
     container.appendChild(card);
   }


### PR DESCRIPTION
## Summary
- Display subrace counts on base race cards
- Adjust tests for new base race card headings

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68addd3cc98c832e985e53cfaa0e2bbb