### PR TITLE
Hide background search on selection and restore on reset

### DIFF
--- a/src/step4.js
+++ b/src/step4.js
@@ -65,6 +65,7 @@ function selectBackground(bg) {
   currentBackgroundData = bg;
   const list = document.getElementById('backgroundList');
   list?.classList.add('hidden');
+  document.getElementById('backgroundSearch')?.classList.add('hidden');
 
   let features = document.getElementById('backgroundFeatures');
   if (!features) {
@@ -277,6 +278,11 @@ export function loadStep4(force = false) {
   const container = document.getElementById('backgroundList');
   const searchInput = document.getElementById('backgroundSearch');
   if (!container) return;
+  if (force) {
+    container.classList.remove('hidden');
+    searchInput?.classList.remove('hidden');
+    document.getElementById('backgroundFeatures')?.classList.add('hidden');
+  }
   if (container.childElementCount && !force) return;
   renderBackgroundList(searchInput?.value);
   searchInput?.addEventListener('input', (e) => {


### PR DESCRIPTION
## Summary
- Hide background search input when a background is selected.
- Restore the search field when background selection is reset.

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ade0e1935c832e966bd0ac234e5784