### PR TITLE
feat: allow changing selected background

### DIFF
--- a/__tests__/step4.test.js
+++ b/__tests__/step4.test.js
@@ -1,0 +1,60 @@
+/**
+ * @jest-environment jsdom
+ */
+import { jest } from '@jest/globals';
+
+jest.unstable_mockModule('../src/data.js', () => ({
+  DATA: { backgrounds: {} },
+  CharacterState: {
+    system: {
+      details: {},
+      skills: [],
+      tools: [],
+      traits: { languages: { value: [] } },
+    },
+  },
+  logCharacterState: jest.fn(),
+}));
+
+jest.unstable_mockModule('../src/step2.js', () => ({
+  refreshBaseState: jest.fn(),
+  rebuildFromClasses: jest.fn(),
+  updateChoiceSelectOptions: jest.fn(),
+}));
+
+jest.unstable_mockModule('../src/i18n.js', () => ({ t: (k) => k }));
+jest.unstable_mockModule('../src/main.js', () => ({ showStep: jest.fn() }));
+
+const { loadStep4 } = await import('../src/step4.js');
+const { DATA } = await import('../src/data.js');
+
+describe('change background button', () => {
+  beforeEach(() => {
+    document.body.innerHTML = `
+      <input id="backgroundSearch" />
+      <div id="backgroundList"></div>
+      <button id="confirmBackgroundSelection"></button>
+      <button id="changeBackground" class="hidden"></button>
+    `;
+    DATA.backgrounds = {
+      Acolyte: { name: 'Acolyte', skills: [], languages: [], featOptions: [] },
+    };
+  });
+
+  test('repopulates list and shows search when changing background', () => {
+    loadStep4();
+    const card = document.querySelector('#backgroundList .class-card');
+    card.click();
+    DATA.backgrounds = {
+      Acolyte: { name: 'Acolyte', skills: [], languages: [], featOptions: [] },
+      Hermit: { name: 'Hermit', skills: [], languages: [], featOptions: [] },
+    };
+    const changeBtn = document.getElementById('changeBackground');
+    changeBtn.click();
+    const cards = document.querySelectorAll('#backgroundList .class-card');
+    expect(cards).toHaveLength(2);
+    const search = document.getElementById('backgroundSearch');
+    expect(search.classList.contains('hidden')).toBe(false);
+  });
+});
+

--- a/index.html
+++ b/index.html
@@ -150,6 +150,7 @@
         <div id="backgroundLanguages"></div>
         <div id="backgroundFeat"></div>
         <div class="form-group">
+          <button id="changeBackground" class="btn hidden">Change Background</button>
           <button id="confirmBackgroundSelection" class="btn btn-primary">Seleziona Background</button>
         </div>
       </div>

--- a/src/step4.js
+++ b/src/step4.js
@@ -48,6 +48,8 @@ export function renderBackgroundList(query = '') {
   const container = document.getElementById('backgroundList');
   if (!container) return;
   container.innerHTML = '';
+  const changeBtn = document.getElementById('changeBackground');
+  changeBtn?.classList.add('hidden');
   const entries = DATA.backgrounds || {};
   const term = query.toLowerCase();
   for (const [name, bg] of Object.entries(entries)) {
@@ -66,6 +68,7 @@ function selectBackground(bg) {
   const list = document.getElementById('backgroundList');
   list?.classList.add('hidden');
   document.getElementById('backgroundSearch')?.classList.add('hidden');
+  document.getElementById('changeBackground')?.classList.remove('hidden');
 
   let features = document.getElementById('backgroundFeatures');
   if (!features) {
@@ -291,5 +294,24 @@ export function loadStep4(force = false) {
   const btn = document.getElementById('confirmBackgroundSelection');
   btn?.addEventListener('click', confirmBackgroundSelection);
   btn?.setAttribute('disabled', 'true');
+
+  const changeBtn = document.getElementById('changeBackground');
+  changeBtn?.addEventListener('click', () => {
+    currentBackgroundData = null;
+    pendingSelections.skills = [];
+    pendingSelections.tools = [];
+    pendingSelections.languages = [];
+    pendingSelections.feat = null;
+    const list = document.getElementById('backgroundList');
+    list?.classList.remove('hidden');
+    const search = document.getElementById('backgroundSearch');
+    search?.classList.remove('hidden');
+    const features = document.getElementById('backgroundFeatures');
+    if (features) {
+      features.classList.add('hidden');
+      features.innerHTML = '';
+    }
+    renderBackgroundList(search?.value);
+  });
 }
 


### PR DESCRIPTION
## Summary
- add Change Background button to step 4 UI
- wire button to reset background selection and repopulate choices
- cover background change workflow with a unit test

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ade1f1becc832eb898007fe7bdfec8