### PR TITLE
feat: add background descriptions

### DIFF
--- a/__tests__/step4.test.js
+++ b/__tests__/step4.test.js
@@ -58,3 +58,35 @@ describe('change background button', () => {
   });
 });
 
+describe('renderBackgroundList description and details', () => {
+  beforeEach(() => {
+    document.body.innerHTML = `
+      <input id="backgroundSearch" />
+      <div id="backgroundList"></div>
+      <button id="confirmBackgroundSelection"></button>
+      <button id="changeBackground" class="hidden"></button>
+    `;
+    DATA.backgrounds = {
+      Acolyte: {
+        name: 'Acolyte',
+        description: 'Devout servant',
+        skills: ['Insight'],
+        languages: [],
+        featOptions: [],
+      },
+    };
+  });
+
+  test('shows description and toggles details', () => {
+    loadStep4();
+    const card = document.querySelector('#backgroundList .class-card');
+    const desc = card.querySelector('p');
+    expect(desc.textContent).toBe('Devout servant');
+    const detailsBtn = card.querySelector('button');
+    expect(detailsBtn).not.toBeNull();
+    detailsBtn.click();
+    const detailsDiv = card.querySelector('.race-details');
+    expect(detailsDiv.classList.contains('hidden')).toBe(false);
+  });
+});
+

--- a/src/step4.js
+++ b/src/step4.js
@@ -59,6 +59,43 @@ export function renderBackgroundList(query = '') {
     card.addEventListener('click', () => selectBackground(bg));
     const title = createElement('h3', name);
     card.appendChild(title);
+
+    const descText =
+      bg.short || bg.description || bg.summary || bg.desc || '';
+    if (descText) card.appendChild(createElement('p', descText));
+
+    const details = document.createElement('div');
+    details.className = 'race-details hidden';
+    if (bg.skills && bg.skills.length)
+      details.appendChild(
+        createElement('p', `${t('skills')}: ${bg.skills.join(', ')}`)
+      );
+    if (Array.isArray(bg.tools) && bg.tools.length)
+      details.appendChild(
+        createElement('p', `${t('tools')}: ${bg.tools.join(', ')}`)
+      );
+    if (Array.isArray(bg.languages) && bg.languages.length)
+      details.appendChild(
+        createElement('p', `${t('languages')}: ${bg.languages.join(', ')}`)
+      );
+    if (bg.featOptions && bg.featOptions.length)
+      details.appendChild(
+        createElement(
+          'p',
+          `${t('featOptions') || 'Feat Options'}: ${bg.featOptions.join(', ')}`
+        )
+      );
+    if (details.childElementCount) {
+      card.appendChild(details);
+      const detailsBtn = document.createElement('button');
+      detailsBtn.className = 'btn btn-primary';
+      detailsBtn.textContent = t('details') || 'Details';
+      detailsBtn.addEventListener('click', (e) => {
+        e.stopPropagation();
+        details.classList.toggle('hidden');
+      });
+      card.appendChild(detailsBtn);
+    }
     container.appendChild(card);
   }
 }


### PR DESCRIPTION
## Summary
- show background descriptions in selection list
- add optional details toggle for background traits
- test background list rendering

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ade418d028832ebe08d90adebc3088