### PR TITLE
refactor: centralize UI helpers

### DIFF
--- a/src/step2.js
+++ b/src/step2.js
@@ -10,6 +10,7 @@ import {
   MAX_CHARACTER_LEVEL,
 } from './data.js';
 import { t } from './i18n.js';
+import { createElement, createAccordionItem } from './ui-helpers.js';
 
 const abilityMap = {
   Strength: 'str',
@@ -100,46 +101,6 @@ function validateTotalLevel(pendingClass) {
     return false;
   }
   return true;
-}
-
-function createElement(tag, text) {
-  const el = document.createElement(tag);
-  if (text) el.textContent = text;
-  return el;
-}
-
-function createAccordionItem(title, content, isChoice = false, description = '') {
-  const item = document.createElement('div');
-  item.className = 'accordion-item' + (isChoice ? ' user-choice' : '');
-
-  const header = document.createElement('button');
-  header.className = 'accordion-header';
-  if (description) {
-    const titleSpan = document.createElement('span');
-    titleSpan.textContent = title;
-    const descSpan = document.createElement('small');
-    descSpan.textContent = ` - ${description}`;
-    header.appendChild(titleSpan);
-    header.appendChild(descSpan);
-  } else {
-    header.textContent = title;
-  }
-
-  const body = document.createElement('div');
-  body.className = 'accordion-content';
-  if (typeof content === 'string') {
-    body.textContent = content;
-  } else {
-    body.appendChild(content);
-  }
-  header.addEventListener('click', () => {
-    header.classList.toggle('active');
-    body.classList.toggle('show');
-  });
-
-  item.appendChild(header);
-  item.appendChild(body);
-  return item;
 }
 
 function getProficiencyList(type) {

--- a/src/step3.js
+++ b/src/step3.js
@@ -9,6 +9,7 @@ import { refreshBaseState, rebuildFromClasses } from './step2.js';
 import { t } from './i18n.js';
 import { showStep } from './main.js';
 import { addUniqueProficiency } from './proficiency.js';
+import { createAccordionItem } from './ui-helpers.js';
 
 let selectedBaseRace = '';
 let currentRaceData = null;
@@ -77,41 +78,6 @@ function validateRaceChoices() {
 
 function capitalize(str) {
   return str.charAt(0).toUpperCase() + str.slice(1);
-}
-
-function createAccordionItem(title, content, isChoice = false, description = '') {
-  const item = document.createElement('div');
-  item.className = 'accordion-item' + (isChoice ? ' user-choice' : '');
-
-  const header = document.createElement('button');
-  header.className = 'accordion-header';
-  if (description) {
-    const titleSpan = document.createElement('span');
-    titleSpan.textContent = title;
-    const descSpan = document.createElement('small');
-    descSpan.textContent = ` - ${description}`;
-    header.appendChild(titleSpan);
-    header.appendChild(descSpan);
-  } else {
-    header.textContent = title;
-  }
-
-  const body = document.createElement('div');
-  body.className = 'accordion-content';
-  if (typeof content === 'string') {
-    body.textContent = content;
-  } else {
-    body.appendChild(content);
-  }
-
-  header.addEventListener('click', () => {
-    header.classList.toggle('active');
-    body.classList.toggle('show');
-  });
-
-  item.appendChild(header);
-  item.appendChild(body);
-  return item;
 }
 
 function createRaceCard(race, onSelect, displayName = race.name) {

--- a/src/step4.js
+++ b/src/step4.js
@@ -6,6 +6,7 @@ import {
 import { refreshBaseState, rebuildFromClasses, updateChoiceSelectOptions } from './step2.js';
 import { t } from './i18n.js';
 import { showStep } from './main.js';
+import { createElement, createAccordionItem } from './ui-helpers.js';
 
 let currentBackgroundData = null;
 const pendingSelections = {
@@ -14,35 +15,6 @@ const pendingSelections = {
   languages: [],
   feat: null
 };
-
-function createElement(tag, text) {
-  const el = document.createElement(tag);
-  if (text) el.textContent = text;
-  return el;
-}
-
-function createAccordionItem(title, content, isChoice = false) {
-  const item = document.createElement('div');
-  item.className = 'accordion-item' + (isChoice ? ' user-choice' : '');
-
-  const header = document.createElement('button');
-  header.className = 'accordion-header';
-  header.textContent = title;
-
-  const body = document.createElement('div');
-  body.className = 'accordion-content';
-  if (typeof content === 'string') body.textContent = content;
-  else body.appendChild(content);
-
-  header.addEventListener('click', () => {
-    header.classList.toggle('active');
-    body.classList.toggle('show');
-  });
-
-  item.appendChild(header);
-  item.appendChild(body);
-  return item;
-}
 
 export function renderBackgroundList(query = '') {
   const container = document.getElementById('backgroundList');

--- a/src/ui-helpers.js
+++ b/src/ui-helpers.js
@@ -1,0 +1,40 @@
+export function createElement(tag, text) {
+  const el = document.createElement(tag);
+  if (text) el.textContent = text;
+  return el;
+}
+
+export function createAccordionItem(title, content, isChoice = false, description = '') {
+  const item = document.createElement('div');
+  item.className = 'accordion-item' + (isChoice ? ' user-choice' : '');
+
+  const header = document.createElement('button');
+  header.className = 'accordion-header';
+  if (description) {
+    const titleSpan = document.createElement('span');
+    titleSpan.textContent = title;
+    const descSpan = document.createElement('small');
+    descSpan.textContent = ` - ${description}`;
+    header.appendChild(titleSpan);
+    header.appendChild(descSpan);
+  } else {
+    header.textContent = title;
+  }
+
+  const body = document.createElement('div');
+  body.className = 'accordion-content';
+  if (typeof content === 'string') {
+    body.textContent = content;
+  } else {
+    body.appendChild(content);
+  }
+  header.addEventListener('click', () => {
+    header.classList.toggle('active');
+    body.classList.toggle('show');
+  });
+
+  item.appendChild(header);
+  item.appendChild(body);
+  return item;
+}
+


### PR DESCRIPTION
## Summary
- add `ui-helpers` module with `createElement` and `createAccordionItem`
- reuse UI helpers in step2, step3 and step4 modules

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68aed4429bfc832eabec56ba9420e292