### PR TITLE
Fix cantrip selection clearing for multiple cantrips

### DIFF
--- a/__tests__/step2.test.js
+++ b/__tests__/step2.test.js
@@ -8,6 +8,7 @@ import { CharacterState } from '../src/data.js';
 describe('duplicate selection prevention', () => {
   beforeEach(() => {
     CharacterState.system.skills = [];
+    CharacterState.system.spells.cantrips = [];
   });
 
   function createSelect(options) {
@@ -92,5 +93,27 @@ describe('duplicate selection prevention', () => {
 
     expect(skillSelect1.value).toBe('Acrobatics');
     expect(skillSelect2.value).toBe('Athletics');
+  });
+
+  test('selecting two different cantrips keeps both selections and disables them elsewhere', () => {
+    CharacterState.system.spells.cantrips = ['Fire Bolt'];
+    const cantripSelect1 = createSelect(['Fire Bolt', 'Light']);
+    const cantripSelect2 = createSelect(['Fire Bolt', 'Light']);
+    cantripSelect1.value = 'Fire Bolt';
+    const selects = [cantripSelect1, cantripSelect2];
+
+    updateChoiceSelectOptions(selects, 'cantrips');
+
+    cantripSelect2.value = 'Light';
+    updateChoiceSelectOptions(selects, 'cantrips');
+
+    expect(cantripSelect1.value).toBe('Fire Bolt');
+    expect(cantripSelect2.value).toBe('Light');
+    expect(
+      cantripSelect1.querySelector("option[value='Light']").disabled
+    ).toBe(true);
+    expect(
+      cantripSelect2.querySelector("option[value='Fire Bolt']").disabled
+    ).toBe(true);
   });
 });

--- a/src/step2.js
+++ b/src/step2.js
@@ -165,6 +165,12 @@ function updateChoiceSelectOptions(
     if (!val) return;
     counts.set(val, (counts.get(val) || 0) + 1);
   };
+  const subtract = val => {
+    if (!val) return;
+    const newCount = (counts.get(val) || 0) - 1;
+    if (newCount <= 0) counts.delete(val);
+    else counts.set(val, newCount);
+  };
 
   if (type === 'skills') {
     getProficiencyList('skills').forEach(add);
@@ -176,6 +182,10 @@ function updateChoiceSelectOptions(
     getProficiencyList(type).forEach(add);
   }
 
+  // Remove the current selections before recounting
+  selects.forEach(sel => subtract(sel.value));
+
+  // Add the current selections back once to track duplicates correctly
   selects.forEach(sel => add(sel.value));
 
   selects.forEach(sel => {
@@ -186,8 +196,8 @@ function updateChoiceSelectOptions(
       opt.disabled = !isCurrent && count > 0;
     });
 
-    const currentCount = counts.get(sel.value) || 0;
-    if (sel.value && currentCount > 1) {
+    const currentCount = (counts.get(sel.value) || 0) - 1;
+    if (sel.value && currentCount > 0) {
       sel.value = '';
       sel.dispatchEvent(new Event('change'));
     }


### PR DESCRIPTION
## Summary
- prevent cantrip dropdowns from clearing earlier selections by removing current values from counts before re-adding
- adjust duplicate detection logic to ignore the select's own value
- add tests ensuring multiple cantrip selections persist and disable duplicates

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68aedb225a64832ebf050b73bf085730