### PR TITLE
Refresh equipment accordions on class change

### DIFF
--- a/__tests__/equipment.test.js
+++ b/__tests__/equipment.test.js
@@ -1,0 +1,37 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import { loadStep5 } from '../src/step5.js';
+import { CharacterState } from '../src/data.js';
+import fs from 'fs';
+import path from 'path';
+import { fileURLToPath } from 'url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+
+describe('equipment rendering', () => {
+  beforeEach(() => {
+    const equipment = JSON.parse(
+      fs.readFileSync(path.join(__dirname, '..', 'data', 'equipment.json'), 'utf-8')
+    );
+    global.fetch = (filePath) => {
+      if (filePath === 'data/equipment.json') {
+        return Promise.resolve({ json: () => Promise.resolve(equipment) });
+      }
+      return Promise.resolve({ json: () => Promise.resolve({}) });
+    };
+    document.body.innerHTML = '<div id="equipmentSelections"></div><button id="confirmEquipment"></button>';
+    CharacterState.classes = [{ name: 'Artificer', level: 1 }];
+  });
+
+  it('renders fixed and choice accordions', async () => {
+    await loadStep5(true);
+    const headers = Array.from(
+      document.querySelectorAll('.accordion-item > .accordion-header')
+    ).map((h) => h.textContent.trim());
+    expect(headers).toEqual(
+      expect.arrayContaining(['standardGear', 'fixedItems', 'Weapon', 'Armor'])
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- Recompute current class each time equipment UI renders and refresh on dropdown changes
- Warn and show fallback if a class has no equipment mapping
- Add unit test ensuring fixed and choice equipment sections render for a class

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68aeddada018832e803ba0be2163c620