### PR TITLE
Reveal background features after selection

### DIFF
--- a/src/step4.js
+++ b/src/step4.js
@@ -86,6 +86,7 @@ function selectBackground(bg) {
     features.className = 'accordion';
     list?.after(features);
   }
+  features.classList.remove('hidden');
   features.innerHTML = '';
 
   pendingSelections.skills = [];


### PR DESCRIPTION
## Summary
- Unhide background feature container upon selection to show details immediately

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68aee11c84d4832e95f25b48d307ad60