### PR TITLE
Refresh equipment step after changing classes

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -34,6 +34,7 @@ let currentStep = 1;
       bar.style.width = `${((step - 1) / 6) * 100}%`;
     }
     currentStep = step;
+    if (step === 5) loadStep5(true);
     if (step === 7) renderFinalRecap();
 
     const prevBtn = document.getElementById("prevStep");

--- a/src/step4.js
+++ b/src/step4.js
@@ -6,6 +6,7 @@ import {
 import { refreshBaseState, rebuildFromClasses, updateChoiceSelectOptions } from './step2.js';
 import { t } from './i18n.js';
 import { showStep } from './main.js';
+import { loadStep5 } from './step5.js';
 import { createElement, createAccordionItem } from './ui-helpers.js';
 
 let currentBackgroundData = null;
@@ -285,6 +286,7 @@ function confirmBackgroundSelection() {
   rebuildFromClasses();
   logCharacterState();
   showStep(5);
+  loadStep5(true);
 }
 
 export function loadStep4(force = false) {


### PR DESCRIPTION
## Summary
- Rebuild equipment selection after confirming a background
- Refresh equipment UI whenever step 5 becomes active

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68aee25bd658832ea8d9fbe30116116e