### PR TITLE
Use addUniqueProficiency in background selection

### DIFF
--- a/__tests__/step4.test.js
+++ b/__tests__/step4.test.js
@@ -14,6 +14,7 @@ jest.unstable_mockModule('../src/data.js', () => ({
     },
   },
   logCharacterState: jest.fn(),
+  fetchJsonWithRetry: jest.fn(),
 }));
 
 jest.unstable_mockModule('../src/step2.js', () => ({


### PR DESCRIPTION
## Summary
- leverage `addUniqueProficiency` when confirming background skills, tools, and languages, loading language data on demand
- prevent step progression until all duplicate proficiency replacements are resolved
- adjust tests for new data import

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68aef6593b74832eb082e18a012b5ebb