### PR TITLE
feat: track proficiency replacements

### DIFF
--- a/__tests__/proficiencyUtils.test.js
+++ b/__tests__/proficiencyUtils.test.js
@@ -1,0 +1,63 @@
+/**
+ * @jest-environment jsdom
+ */
+import { jest } from '@jest/globals';
+
+const mockState = {
+  system: {
+    skills: [],
+    tools: [],
+    traits: { languages: { value: [] } },
+    spells: { cantrips: [] },
+  },
+  feats: [],
+};
+
+jest.unstable_mockModule('../src/data.js', () => ({
+  DATA: { languages: [], feats: [] },
+  CharacterState: mockState,
+  logCharacterState: jest.fn(),
+}));
+
+const {
+  addUniqueProficiency,
+  pendingReplacements,
+  getAllOptions,
+} = await import('../src/proficiency.js');
+const { CharacterState, DATA } = await import('../src/data.js');
+
+describe('addUniqueProficiency and pendingReplacements', () => {
+  beforeEach(() => {
+    CharacterState.system.skills = [];
+    CharacterState.feats = [];
+  });
+
+  test('returns null when proficiency added normally', () => {
+    const container = document.createElement('div');
+    const res = addUniqueProficiency('skills', 'Stealth', container);
+    expect(res).toBeNull();
+    expect(CharacterState.system.skills).toContain('Stealth');
+    expect(pendingReplacements('skills')).toBe(0);
+  });
+
+  test('tracks pending replacements when duplicate', () => {
+    CharacterState.system.skills = ['Stealth'];
+    const container = document.createElement('div');
+    const sel = addUniqueProficiency('skills', 'Stealth', container);
+    expect(sel).not.toBeNull();
+    expect(pendingReplacements('skills')).toBe(1);
+    sel.value = 'Arcana';
+    sel.dispatchEvent(new Event('change'));
+    expect(CharacterState.system.skills).toEqual(
+      expect.arrayContaining(['Stealth', 'Arcana'])
+    );
+    expect(pendingReplacements('skills')).toBe(0);
+  });
+});
+
+test('getAllOptions supplies feats and instruments', () => {
+  DATA.feats = ['Lucky'];
+  expect(getAllOptions('feats')).toEqual(['Lucky']);
+  expect(getAllOptions('instruments')).toContain('Lute');
+});
+

--- a/src/proficiency.js
+++ b/src/proficiency.js
@@ -50,19 +50,49 @@ export const ALL_TOOLS = [
   "Thieves' Tools",
 ];
 
+// musical instrument options used when replacing duplicates
+export const ALL_INSTRUMENTS = [
+  'Bagpipes',
+  'Drum',
+  'Dulcimer',
+  'Flute',
+  'Horn',
+  'Lute',
+  'Lyre',
+  'Pan Flute',
+  'Shawm',
+  'Viol',
+];
+
+// Track pending replacement selects by proficiency type so steps can
+// verify that all duplicates have been resolved before advancing.
+const pendingSelects = {};
+
 export function getProficiencyList(type) {
   if (type === 'skills') return CharacterState.system.skills;
   if (type === 'tools') return CharacterState.system.tools;
+  if (type === 'instruments') return CharacterState.system.tools;
   if (type === 'languages') return CharacterState.system.traits.languages.value;
   if (type === 'cantrips') return CharacterState.system.spells.cantrips;
+  if (type === 'feats') return CharacterState.feats;
   return [];
 }
 
 export function getAllOptions(type) {
   if (type === 'skills') return ALL_SKILLS;
   if (type === 'tools') return ALL_TOOLS;
+  if (type === 'instruments') return ALL_INSTRUMENTS;
   if (type === 'languages') return DATA.languages || [];
+  if (type === 'feats') return DATA.feats || [];
   return [];
+}
+
+export function pendingReplacements(type) {
+  if (type) return pendingSelects[type]?.size || 0;
+  return Object.values(pendingSelects).reduce(
+    (acc, set) => acc + (set?.size || 0),
+    0,
+  );
 }
 
 export function addUniqueProficiency(type, value, container) {
@@ -89,10 +119,14 @@ export function addUniqueProficiency(type, value, container) {
       o.textContent = opt;
       sel.appendChild(o);
     });
+  // Track this select as a pending replacement until a new value is chosen
+  const pending = (pendingSelects[type] = pendingSelects[type] || new Set());
+  pending.add(sel);
   sel.addEventListener('change', () => {
     if (sel.value && !list.includes(sel.value)) {
       list.push(sel.value);
       sel.disabled = true;
+      pending.delete(sel);
       logCharacterState();
     }
   });


### PR DESCRIPTION
## Summary
- expand proficiency option handling to include feats and instruments
- track pending replacement selections and expose `pendingReplacements`
- test proficiency replacement tracking and option sources

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68aef7cf81f0832ea6781907d0b28558