### PR TITLE
Refactor equipment selections to store objects

### DIFF
--- a/src/step5.js
+++ b/src/step5.js
@@ -245,10 +245,20 @@ function validateEquipmentSelections() {
 function confirmEquipment() {
   if (!validateEquipmentSelections()) return;
   const selections = [];
-  selections.push(...(equipmentData.standard || []));
+  (equipmentData.standard || []).forEach((item) => {
+    selections.push({ name: item });
+  });
   const clsData = equipmentData.classes?.[getCurrentClass()] || {};
-  if (clsData.fixed) selections.push(...clsData.fixed);
-  choiceBlocks.forEach((b) => selections.push(...b.getValue()));
+  if (clsData.fixed) {
+    clsData.fixed.forEach((item) => {
+      selections.push({ name: item });
+    });
+  }
+  choiceBlocks.forEach((b) => {
+    b.getValue().forEach((item) => {
+      selections.push({ name: item });
+    });
+  });
   CharacterState.equipment = selections;
   showStep(6);
 }


### PR DESCRIPTION
## Summary
- Wrap equipment selections as `{ name }` objects when confirming equipment
- Ensure fixed and chosen items are collected as objects for export

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b022546d5c832e96a3f58f58e6059f