### PR TITLE
Prevent duplicate equipment listeners

### DIFF
--- a/__tests__/step5.test.js
+++ b/__tests__/step5.test.js
@@ -1,0 +1,47 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import { jest } from '@jest/globals';
+
+jest.unstable_mockModule('../src/data.js', () => ({
+  DATA: {},
+  CharacterState: { classes: [{ name: 'Test', level: 1 }], equipment: [] }
+}));
+
+jest.unstable_mockModule('../src/i18n.js', () => ({ t: (k) => k }));
+
+const showStep = jest.fn();
+jest.unstable_mockModule('../src/main.js', () => ({ showStep }));
+
+const { loadStep5 } = await import('../src/step5.js');
+const { CharacterState } = await import('../src/data.js');
+
+describe('step5 re-entry', () => {
+  beforeEach(() => {
+    document.body.innerHTML =
+      '<div id="equipmentSelections"></div><button id="confirmEquipment"></button>';
+    global.fetch = () =>
+      Promise.resolve({
+        json: () =>
+          Promise.resolve({
+            standard: [],
+            classes: { Test: { fixed: [], choices: [] } }
+          })
+      });
+    CharacterState.classes = [{ name: 'Test', level: 1 }];
+    showStep.mockClear();
+  });
+
+  test('reloading step5 does not duplicate UI or listeners', async () => {
+    await loadStep5(true);
+    await loadStep5(true);
+    const accs = document.querySelectorAll('#equipmentSelections .accordion');
+    expect(accs).toHaveLength(1);
+
+    const btn = document.getElementById('confirmEquipment');
+    btn.click();
+    expect(showStep).toHaveBeenCalledTimes(1);
+    expect(showStep).toHaveBeenCalledWith(6);
+  });
+});

--- a/src/step4.js
+++ b/src/step4.js
@@ -7,7 +7,6 @@ import {
 import { refreshBaseState, rebuildFromClasses, updateChoiceSelectOptions } from './step2.js';
 import { t } from './i18n.js';
 import { showStep } from './main.js';
-import { loadStep5 } from './step5.js';
 import { createElement, createAccordionItem } from './ui-helpers.js';
 import { addUniqueProficiency } from './proficiency.js';
 
@@ -350,7 +349,6 @@ async function confirmBackgroundSelection() {
   const finalize = () => {
     logCharacterState();
     showStep(5);
-    loadStep5(true);
   };
 
   if (replacements.length) {

--- a/src/step5.js
+++ b/src/step5.js
@@ -255,9 +255,11 @@ function confirmEquipment() {
 
 export async function loadStep5(force = false) {
   const container = document.getElementById('equipmentSelections');
-  const confirmBtn = document.getElementById('confirmEquipment');
+  let confirmBtn = document.getElementById('confirmEquipment');
   if (!container || !confirmBtn) return;
   confirmBtn.textContent = t('confirmEquipment');
+  confirmBtn.replaceWith(confirmBtn.cloneNode(true));
+  confirmBtn = document.getElementById('confirmEquipment');
 
   await loadEquipmentData();
 


### PR DESCRIPTION
## Summary
- Load step 5 only via `showStep` when confirming background
- Reset equipment confirmation button to remove old listeners when entering step 5
- Test that re-entering step 5 doesn't duplicate UI or event handlers

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b024187204832ea862f1f00ce23bac