### PR TITLE
Handle equipment data load failures

### DIFF
--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -31,5 +31,6 @@
   "standardGear": "Standard Gear",
   "fixedItems": "Fixed Items",
   "upgradeOptions": "Upgrade Options",
-  "selectSimpleWeapon": "Select simple weapon"
+  "selectSimpleWeapon": "Select simple weapon",
+  "equipmentLoadError": "Failed to load equipment data"
 }

--- a/src/i18n/it.json
+++ b/src/i18n/it.json
@@ -31,5 +31,6 @@
   "standardGear": "Equipaggiamento standard",
   "fixedItems": "Oggetti fissi",
   "upgradeOptions": "Opzioni di potenziamento",
-  "selectSimpleWeapon": "Scegli arma semplice"
+  "selectSimpleWeapon": "Scegli arma semplice",
+  "equipmentLoadError": "Impossibile caricare i dati dell'equipaggiamento"
 }

--- a/src/step5.js
+++ b/src/step5.js
@@ -25,8 +25,16 @@ const SIMPLE_WEAPONS = DATA.simpleWeapons || [
 
 async function loadEquipmentData() {
   if (!equipmentData) {
-    const resp = await fetch('data/equipment.json');
-    equipmentData = await resp.json();
+    try {
+      const resp = await fetch('data/equipment.json');
+      if (resp.ok === false) throw new Error(resp.statusText || 'Failed to fetch');
+      equipmentData = await resp.json();
+    } catch (err) {
+      console.error(err);
+      const container = document.getElementById('equipmentSelections');
+      if (container) container.textContent = t('equipmentLoadError');
+      return null;
+    }
   }
   return equipmentData;
 }
@@ -271,7 +279,8 @@ export async function loadStep5(force = false) {
   confirmBtn.replaceWith(confirmBtn.cloneNode(true));
   confirmBtn = document.getElementById('confirmEquipment');
 
-  await loadEquipmentData();
+  const data = await loadEquipmentData();
+  if (!data) return;
 
   if (force) container.innerHTML = '';
   if (!force && container.querySelector('.accordion')) return;


### PR DESCRIPTION
## Summary
- handle fetch errors when loading equipment data with user-facing message
- skip rendering when equipment data can't be loaded
- localize equipment load error message in English and Italian

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b024efd02c832ebbce34d2ecfdb40e