### PR TITLE
Prevent duplicate search listeners

### DIFF
--- a/src/step2.js
+++ b/src/step2.js
@@ -707,7 +707,7 @@ function updateStep2Completion() {
 export async function loadStep2(refresh = true) {
   const classListContainer = document.getElementById('classList');
   const selectedClassesContainer = document.getElementById('selectedClasses');
-  const searchInput = document.getElementById('classSearch');
+  let searchInput = document.getElementById('classSearch');
   if (!classListContainer || !selectedClassesContainer) return;
   classListContainer.innerHTML = '';
   selectedClassesContainer.innerHTML = '';
@@ -774,9 +774,14 @@ export async function loadStep2(refresh = true) {
         classListContainer.appendChild(classCard);
       });
   }
-  searchInput?.addEventListener('input', () =>
-    renderClassCards(searchInput.value)
-  );
+  if (searchInput) {
+    const newInput = searchInput.cloneNode(true);
+    searchInput.parentNode.replaceChild(newInput, searchInput);
+    searchInput = newInput;
+    searchInput.addEventListener('input', () =>
+      renderClassCards(searchInput.value)
+    );
+  }
   renderClassCards();
 }
 

--- a/src/step3.js
+++ b/src/step3.js
@@ -633,16 +633,21 @@ function confirmRaceSelection() {
 export async function loadStep3(force = false) {
   await loadRaces();
   const container = document.getElementById('raceList');
-  const searchInput = document.getElementById('raceSearch');
+  let searchInput = document.getElementById('raceSearch');
   if (!container) return;
   if (container.childElementCount && !force) return;
   await renderBaseRaces(searchInput?.value);
 
-  searchInput?.addEventListener('input', async (e) => {
-    const term = e.target.value;
-    if (selectedBaseRace) await renderSubraceCards(selectedBaseRace, term);
-    else await renderBaseRaces(term);
-  });
+  if (searchInput) {
+    const newInput = searchInput.cloneNode(true);
+    searchInput.parentNode.replaceChild(newInput, searchInput);
+    searchInput = newInput;
+    searchInput.addEventListener('input', async (e) => {
+      const term = e.target.value;
+      if (selectedBaseRace) await renderSubraceCards(selectedBaseRace, term);
+      else await renderBaseRaces(term);
+    });
+  }
 
   const btn = document.getElementById('confirmRaceSelection');
   btn?.addEventListener('click', confirmRaceSelection);

--- a/src/step4.js
+++ b/src/step4.js
@@ -369,7 +369,7 @@ async function confirmBackgroundSelection() {
 
 export function loadStep4(force = false) {
   const container = document.getElementById('backgroundList');
-  const searchInput = document.getElementById('backgroundSearch');
+  let searchInput = document.getElementById('backgroundSearch');
   if (!container) return;
   if (force) {
     container.classList.remove('hidden');
@@ -378,9 +378,14 @@ export function loadStep4(force = false) {
   }
   if (container.childElementCount && !force) return;
   renderBackgroundList(searchInput?.value);
-  searchInput?.addEventListener('input', (e) => {
-    renderBackgroundList(e.target.value);
-  });
+  if (searchInput) {
+    const newInput = searchInput.cloneNode(true);
+    searchInput.parentNode.replaceChild(newInput, searchInput);
+    searchInput = newInput;
+    searchInput.addEventListener('input', (e) => {
+      renderBackgroundList(e.target.value);
+    });
+  }
   const btn = document.getElementById('confirmBackgroundSelection');
   btn?.addEventListener('click', confirmBackgroundSelection);
   btn?.setAttribute('disabled', 'true');


### PR DESCRIPTION
## Summary
- Ensure class search field only wires a single input handler by replacing existing element
- Reset race search input before attaching handler to avoid duplicates
- Do the same for background search input, guaranteeing only one listener

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b02d0a6db4832ea526f2bf0bd43716