### PR TITLE
Localize UI text and alerts

### DIFF
--- a/index.html
+++ b/index.html
@@ -75,6 +75,7 @@
           type="text"
           class="form-control"
           placeholder="Search classes"
+          data-i18n-placeholder="searchClasses"
         />
         <div id="classList" class="class-list"></div>
         <div id="selectedClasses"></div>
@@ -107,7 +108,7 @@
         <div id="classFeatures" class="accordion hidden"></div>
         <div id="classActions" class="form-group hidden">
           <button id="changeClassButton" class="btn">Cambia Classe</button>
-          <p id="addClassPrompt" class="hidden"><a href="#" id="addClassLink">Add another class?</a></p>
+          <p id="addClassPrompt" class="hidden"><a href="#" id="addClassLink" data-i18n="addAnotherClass">Add another class?</a></p>
           <button id="confirmClassButton" class="btn btn-primary">Conferma Classe</button>
         </div>
       </div>
@@ -119,13 +120,14 @@
           type="text"
           class="form-control"
           placeholder="Search races"
+          data-i18n-placeholder="searchRaces"
         />
         <div id="raceList" class="class-list"></div>
         <div id="raceFeatures" class="accordion hidden">
           <div id="raceTraits"></div>
         </div>
         <div class="form-group">
-          <button id="changeRace" class="btn hidden">Change Race</button>
+          <button id="changeRace" class="btn hidden" data-i18n="changeRace">Change Race</button>
           <button id="confirmRaceSelection" class="btn btn-primary" disabled>Seleziona Razza</button>
         </div>
       </div>
@@ -137,6 +139,7 @@
           type="text"
           class="form-control"
           placeholder="Search backgrounds"
+          data-i18n-placeholder="searchBackgrounds"
         />
         <div id="backgroundList" class="class-list"></div>
         <div class="form-group">
@@ -150,7 +153,7 @@
         <div id="backgroundLanguages"></div>
         <div id="backgroundFeat"></div>
         <div class="form-group">
-          <button id="changeBackground" class="btn hidden">Change Background</button>
+          <button id="changeBackground" class="btn hidden" data-i18n="changeBackground">Change Background</button>
           <button id="confirmBackgroundSelection" class="btn btn-primary">Seleziona Background</button>
         </div>
       </div>
@@ -159,7 +162,7 @@
         <h2>Step 5: Equipment</h2>
         <div id="equipmentSelections" class="form-group"></div>
         <div class="form-group">
-          <button id="confirmEquipment" class="btn btn-primary">Confirm Equipment</button>
+          <button id="confirmEquipment" class="btn btn-primary" data-i18n="confirmEquipment">Confirm Equipment</button>
         </div>
       </div>
       <!-- Step 6: Sistema Point Buy -->

--- a/src/data.js
+++ b/src/data.js
@@ -1,3 +1,4 @@
+import { t } from './i18n.js';
 export const DATA = {};
 
 // Maximum total level a character can reach
@@ -17,10 +18,10 @@ export async function fetchJsonWithRetry(url, resourceName) {
   } catch (err) {
     console.error(err);
     const retry = window.confirm(
-      `Unable to load ${resourceName}. Would you like to retry?`
+      t('fetchRetry', { resource: resourceName })
     );
     if (retry) return fetchJsonWithRetry(url, resourceName);
-    window.alert(`Data for ${resourceName} could not be loaded.`);
+    window.alert(t('fetchFailed', { resource: resourceName }));
     throw err;
   }
 }

--- a/src/i18n.js
+++ b/src/i18n.js
@@ -21,3 +21,14 @@ export function t(key, params = {}) {
   }
   return str;
 }
+
+export function applyTranslations(root = document) {
+  root.querySelectorAll('[data-i18n]').forEach((el) => {
+    const key = el.getAttribute('data-i18n');
+    if (key) el.textContent = t(key);
+  });
+  root.querySelectorAll('[data-i18n-placeholder]').forEach((el) => {
+    const key = el.getAttribute('data-i18n-placeholder');
+    if (key) el.setAttribute('placeholder', t(key));
+  });
+}

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -35,5 +35,14 @@
   "fixedItems": "Fixed Items",
   "upgradeOptions": "Upgrade Options",
   "selectSimpleWeapon": "Select simple weapon",
-  "equipmentLoadError": "Failed to load equipment data"
+  "equipmentLoadError": "Failed to load equipment data",
+  "searchClasses": "Search classes",
+  "searchRaces": "Search races",
+  "searchBackgrounds": "Search backgrounds",
+  "changeRace": "Change Race",
+  "changeBackground": "Change Background",
+  "addAnotherClass": "Add another class?",
+  "fetchRetry": "Unable to load {resource}. Would you like to retry?",
+  "fetchFailed": "Data for {resource} could not be loaded.",
+  "levelCap": "Total level cannot exceed {max}"
 }

--- a/src/i18n/it.json
+++ b/src/i18n/it.json
@@ -35,5 +35,14 @@
   "fixedItems": "Oggetti fissi",
   "upgradeOptions": "Opzioni di potenziamento",
   "selectSimpleWeapon": "Scegli arma semplice",
-  "equipmentLoadError": "Impossibile caricare i dati dell'equipaggiamento"
+  "equipmentLoadError": "Impossibile caricare i dati dell'equipaggiamento",
+  "searchClasses": "Cerca classi",
+  "searchRaces": "Cerca razze",
+  "searchBackgrounds": "Cerca background",
+  "changeRace": "Cambia Razza",
+  "changeBackground": "Cambia Background",
+  "addAnotherClass": "Aggiungi un'altra classe?",
+  "fetchRetry": "Impossibile caricare {resource}. Vuoi riprovare?",
+  "fetchFailed": "Impossibile caricare i dati per {resource}.",
+  "levelCap": "Il livello totale non può superare {max}"
 }

--- a/src/main.js
+++ b/src/main.js
@@ -13,7 +13,7 @@ import { loadStep3 } from "./step3.js";
 import { loadStep4 } from "./step4.js";
 import { loadStep5 } from "./step5.js";
 import { exportFoundryActor } from "./export.js";
-import { t, initI18n } from "./i18n.js";
+import { t, initI18n, applyTranslations } from "./i18n.js";
 
 let currentStep = 1;
 
@@ -209,6 +209,7 @@ function renderFinalRecap() {
 
 document.addEventListener("DOMContentLoaded", async () => {
   await initI18n();
+  applyTranslations();
   for (let i = 1; i <= 7; i++) {
     const btn = document.getElementById(`btnStep${i}`);
     if (btn) {

--- a/src/step2.js
+++ b/src/step2.js
@@ -97,7 +97,7 @@ function validateTotalLevel(pendingClass) {
     const allowed = Math.max(0, MAX_CHARACTER_LEVEL - existing);
     if (pendingClass) pendingClass.level = allowed;
     if (typeof alert !== 'undefined')
-      alert(`Total level cannot exceed ${MAX_CHARACTER_LEVEL}`);
+      alert(t('levelCap', { max: MAX_CHARACTER_LEVEL }));
     return false;
   }
   return true;
@@ -605,7 +605,7 @@ function renderSelectedClasses() {
 
   const addLink = document.createElement('a');
   addLink.href = '#';
-  addLink.textContent = 'Add another class?';
+  addLink.textContent = t('addAnotherClass');
   addLink.addEventListener('click', e => {
     e.preventDefault();
     showClassSelectionModal();


### PR DESCRIPTION
## Summary
- Translate search fields and buttons via `data-i18n` attributes
- Add runtime `applyTranslations` helper and use for placeholders
- Localize alert/confirm messages and add new i18n keys

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b02e4f07c4832e80741eadb31653f4