### PR TITLE
feat: inject callbacks for json fetch retry

### DIFF
--- a/__tests__/fetchJsonWithRetry.test.js
+++ b/__tests__/fetchJsonWithRetry.test.js
@@ -1,0 +1,38 @@
+/**
+ * @jest-environment node
+ */
+import { jest } from '@jest/globals';
+import { fetchJsonWithRetry } from '../src/data.js';
+
+describe('fetchJsonWithRetry callbacks', () => {
+  afterEach(() => {
+    delete global.fetch;
+  });
+
+  test('uses injected callbacks to retry', async () => {
+    const mockFetch = jest
+      .fn()
+      .mockResolvedValueOnce({ ok: false })
+      .mockResolvedValueOnce({ ok: true, json: async () => ({ value: 42 }) });
+    global.fetch = mockFetch;
+
+    const onRetry = jest.fn(() => true); // retry once
+    const onError = jest.fn();
+
+    const result = await fetchJsonWithRetry('url', 'resource', { onRetry, onError });
+
+    expect(mockFetch).toHaveBeenCalledTimes(2);
+    expect(onRetry).toHaveBeenCalledTimes(1);
+    expect(onError).not.toHaveBeenCalled();
+    expect(result).toEqual({ value: 42 });
+  });
+
+  test('default callbacks do not throw without window', async () => {
+    const mockFetch = jest.fn().mockResolvedValue({ ok: false });
+    global.fetch = mockFetch;
+
+    await expect(fetchJsonWithRetry('url', 'thing')).rejects.toThrow(
+      'Failed loading thing'
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- refactor fetchJsonWithRetry to support injectable callbacks
- add tests covering callback behaviour and non-browser fallback

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b051c8b87c832e8d0fb602b3ff2759