### PR TITLE
Center modal vertically and add padding

### DIFF
--- a/css/site-theme.css
+++ b/css/site-theme.css
@@ -283,10 +283,11 @@ th {
   height: 100%;
   background: rgba(0, 0, 0, 0.5);
   justify-content: center;
-  align-items: flex-start;
+  align-items: center;
   z-index: 1000;
   display: flex;
   overflow-y: auto;
+  padding: 1rem;
 }
 
 .modal-content {


### PR DESCRIPTION
## Summary
- Center modals vertically by using `align-items: center`
- Add `padding: 1rem` to modals to avoid touching the viewport edges

## Testing
- `npm test`
- Verified modal flex centering via jsdom script

------
https://chatgpt.com/codex/tasks/task_e_68b05c7f0990832e843495c7392e554c