### PR TITLE
Add step completion warnings and highlight incomplete selections

### DIFF
--- a/css/site-theme.css
+++ b/css/site-theme.css
@@ -188,6 +188,13 @@ th {
   opacity: 1;
 }
 
+#nextStepWarning {
+  color: #e74c3c;
+  font-size: 0.9rem;
+  text-align: center;
+  margin-top: 0.5rem;
+}
+
 .class-list {
   display: flex;
   flex-wrap: wrap;
@@ -272,6 +279,19 @@ th {
 .feature-block.needs-selection.incomplete .accordion-header {
   border-color: #e74c3c;
   color: #e74c3c;
+}
+
+.needs-selection.incomplete {
+  border: 2px solid #e74c3c;
+  border-radius: 4px;
+  position: relative;
+  padding: 0.5em;
+}
+
+.needs-selection.incomplete .accordion-header::before {
+  content: "\26A0";
+  color: #e74c3c;
+  margin-right: 0.25em;
 }
 
 /* Modal styles for class details */

--- a/src/ui-helpers.js
+++ b/src/ui-helpers.js
@@ -34,3 +34,50 @@ export function createAccordionItem(title, content, isChoice = false, descriptio
   item.append(header, body);
   return item;
 }
+
+export function initNextStepWarning() {
+  const nextBtn = document.getElementById('nextStep');
+  if (!nextBtn) return;
+
+  const warn = document.createElement('div');
+  warn.id = 'nextStepWarning';
+  warn.className = 'next-step-warning hidden';
+  nextBtn.insertAdjacentElement('afterend', warn);
+
+  const messages = {
+    step2: 'Select a class to proceed.',
+    step3: 'Select a race to proceed.',
+    step4: 'Select a background to proceed.',
+    step5: 'Choose your equipment to proceed.',
+    step6: 'Assign all ability points to proceed.',
+  };
+
+  const updateWarning = () => {
+    const active = document.querySelector('.step:not(.hidden)');
+    const msg = active ? messages[active.id] : null;
+    if (nextBtn.disabled && msg) {
+      warn.textContent = msg;
+      warn.classList.remove('hidden');
+    } else {
+      warn.classList.add('hidden');
+    }
+  };
+
+  new MutationObserver(updateWarning).observe(nextBtn, {
+    attributes: true,
+    attributeFilter: ['disabled'],
+  });
+
+  const stepContainer = document.getElementById('stepContainer');
+  if (stepContainer) {
+    new MutationObserver(updateWarning).observe(stepContainer, {
+      attributes: true,
+      subtree: true,
+      attributeFilter: ['class'],
+    });
+  }
+
+  updateWarning();
+}
+
+document.addEventListener('DOMContentLoaded', initNextStepWarning);


### PR DESCRIPTION
## Summary
- Show context-sensitive warnings near the next-step arrow when progression is blocked
- Emphasize incomplete selection areas with red borders and icons

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b06162e28c832ea53885070750c425