### PR TITLE
Track ability bonuses separately

### DIFF
--- a/__tests__/step3.test.js
+++ b/__tests__/step3.test.js
@@ -27,6 +27,14 @@ jest.unstable_mockModule('../src/data.js', () => ({
       },
     },
     raceChoices: { spells: [], spellAbility: '' },
+    bonusAbilities: {
+      str: 0,
+      dex: 0,
+      con: 0,
+      int: 0,
+      wis: 0,
+      cha: 0,
+    },
   },
   fetchJsonWithRetry: mockFetch,
   loadRaces: mockLoadRaces,
@@ -388,6 +396,7 @@ describe('change race cleanup', () => {
 
   test('removes race bonuses when changing race', async () => {
     expect(CharacterState.system.abilities.str.value).toBe(10);
+    expect(CharacterState.bonusAbilities.str).toBe(2);
     expect(CharacterState.system.skills).toContain('Survival');
     expect(CharacterState.system.traits.languages.value).toContain('Draconic');
     expect(CharacterState.system.attributes.movement.swim).toBe(30);
@@ -396,6 +405,7 @@ describe('change race cleanup', () => {
     await new Promise((r) => setTimeout(r, 0));
 
     expect(CharacterState.system.abilities.str.value).toBe(8);
+    expect(CharacterState.bonusAbilities.str).toBe(0);
     expect(CharacterState.system.skills).not.toContain('Survival');
     expect(CharacterState.system.traits.languages.value).not.toContain('Draconic');
     expect(CharacterState.system.attributes.movement.swim).toBeUndefined();

--- a/src/data.js
+++ b/src/data.js
@@ -149,6 +149,14 @@ export const CharacterState = {
   feats: [],
   equipment: [],
   raceChoices: { spells: [], spellAbility: '' },
+  bonusAbilities: {
+    str: 0,
+    dex: 0,
+    con: 0,
+    int: 0,
+    wis: 0,
+    cha: 0,
+  },
   system: {
     abilities: {
       str: { value: 8 },

--- a/src/feat.js
+++ b/src/feat.js
@@ -87,8 +87,17 @@ export async function renderFeatChoices(featName, container) {
         const code = sel.value;
         featObj.ability = featObj.ability || {};
         featObj.ability[code] = (featObj.ability[code] || 0) + 1;
-        if (CharacterState.system.abilities[code]) {
-          CharacterState.system.abilities[code].value += 1;
+        if (
+          CharacterState.system.abilities[code] &&
+          CharacterState.bonusAbilities[code] !== undefined
+        ) {
+          const base =
+            CharacterState.baseAbilities?.[code] ??
+            CharacterState.system.abilities[code].value -
+              (CharacterState.bonusAbilities[code] || 0);
+          CharacterState.bonusAbilities[code] += 1;
+          CharacterState.system.abilities[code].value =
+            base + CharacterState.bonusAbilities[code];
         }
       });
     }

--- a/src/step3.js
+++ b/src/step3.js
@@ -524,9 +524,18 @@ function confirmRaceSelection() {
   if (Array.isArray(currentRaceData.ability)) {
     currentRaceData.ability.forEach((obj) => {
       for (const [ab, val] of Object.entries(obj)) {
-        if (typeof val === 'number' && CharacterState.system.abilities[ab]) {
-          const abil = CharacterState.system.abilities[ab];
-          abil.value = (abil.value || 0) + val;
+        if (
+          typeof val === 'number' &&
+          CharacterState.system.abilities[ab] &&
+          CharacterState.bonusAbilities[ab] !== undefined
+        ) {
+          const base =
+            CharacterState.baseAbilities?.[ab] ??
+            CharacterState.system.abilities[ab].value -
+              (CharacterState.bonusAbilities[ab] || 0);
+          CharacterState.bonusAbilities[ab] += val;
+          CharacterState.system.abilities[ab].value =
+            base + CharacterState.bonusAbilities[ab];
         }
       }
     });
@@ -678,9 +687,19 @@ export async function loadStep3(force = false) {
       if (Array.isArray(currentRaceData.ability)) {
         currentRaceData.ability.forEach((obj) => {
           for (const [ab, val] of Object.entries(obj)) {
-            const abil = CharacterState.system.abilities[ab];
-            if (abil && typeof val === 'number')
-              abil.value = (abil.value || 0) - val;
+            if (
+              typeof val === 'number' &&
+              CharacterState.system.abilities[ab] &&
+              CharacterState.bonusAbilities[ab] !== undefined
+            ) {
+              const base =
+                CharacterState.baseAbilities?.[ab] ??
+                CharacterState.system.abilities[ab].value -
+                  CharacterState.bonusAbilities[ab];
+              CharacterState.bonusAbilities[ab] -= val;
+              CharacterState.system.abilities[ab].value =
+                base + CharacterState.bonusAbilities[ab];
+            }
           }
         });
       }

--- a/src/step6.js
+++ b/src/step6.js
@@ -4,7 +4,6 @@ import * as main from './main.js';
 
 const ABILITIES = ['str', 'dex', 'con', 'int', 'wis', 'cha'];
 const COST = { 8:0, 9:1, 10:2, 11:3, 12:4, 13:5, 14:7, 15:9 };
-let bonuses = {};
 
 function calcRemaining() {
   const remaining = 27 - ABILITIES.reduce((sum, ab) => sum + (COST[CharacterState.baseAbilities[ab]] || 0), 0);
@@ -16,7 +15,7 @@ function calcRemaining() {
 
 function updateFinal(ab) {
   const base = CharacterState.baseAbilities[ab];
-  const bonus = bonuses[ab] || 0;
+  const bonus = CharacterState.bonusAbilities?.[ab] || 0;
   const finalVal = base + bonus;
   const baseSpan = document.getElementById(`${ab}Points`);
   const bonusSpan = document.getElementById(`${ab}RaceModifier`);
@@ -41,7 +40,7 @@ function adjustAbility(ab, delta) {
 function confirmAbilities() {
   ABILITIES.forEach((ab) => {
     const base = CharacterState.baseAbilities[ab];
-    const bonus = bonuses[ab] || 0;
+    const bonus = CharacterState.bonusAbilities?.[ab] || 0;
     CharacterState.system.abilities[ab].value = base + bonus;
   });
   main.showStep?.(7);
@@ -65,20 +64,15 @@ export function loadStep6(force = false) {
   confirmBtn.addEventListener('click', confirmAbilities);
 
   if (!CharacterState.baseAbilities || force) {
-    CharacterState.baseAbilities = {};
-    bonuses = {};
-    ABILITIES.forEach((ab) => {
-      const val = CharacterState.system.abilities[ab]?.value ?? 8;
-      bonuses[ab] = val - 8;
-      CharacterState.baseAbilities[ab] = 8;
-    });
-  } else {
-    bonuses = {};
-    ABILITIES.forEach((ab) => {
-      const val = CharacterState.system.abilities[ab]?.value ?? 8;
-      bonuses[ab] = val - CharacterState.baseAbilities[ab];
-    });
+    CharacterState.baseAbilities = CharacterState.baseAbilities || {};
   }
+  ABILITIES.forEach((ab) => {
+    const bonus = CharacterState.bonusAbilities?.[ab] || 0;
+    const val = CharacterState.system.abilities[ab]?.value ?? 8;
+    if (!CharacterState.baseAbilities[ab] || force) {
+      CharacterState.baseAbilities[ab] = val - bonus;
+    }
+  });
 
   ABILITIES.forEach((ab) => {
     updateFinal(ab);


### PR DESCRIPTION
## Summary
- add `bonusAbilities` to `CharacterState`
- update race and feat handling to accumulate bonuses rather than modifying ability scores directly
- use `bonusAbilities` in ability score step

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b06965b810832eaeef4c5a73d41027