### PR TITLE
Centralize step confirmation and streamline navigation

### DIFF
--- a/index.html
+++ b/index.html
@@ -109,7 +109,6 @@
         <div id="classActions" class="form-group hidden">
           <button id="changeClassButton" class="btn">Cambia Classe</button>
           <p id="addClassPrompt" class="hidden"><a href="#" id="addClassLink" data-i18n="addAnotherClass">Add another class?</a></p>
-          <button id="confirmClassButton" class="btn btn-primary">Conferma Classe</button>
         </div>
       </div>
       <!-- Step 3: Scelta della Razza -->
@@ -128,7 +127,6 @@
         </div>
         <div class="form-group">
           <button id="changeRace" class="btn hidden" data-i18n="changeRace">Change Race</button>
-          <button id="confirmRaceSelection" class="btn btn-primary" disabled>Seleziona Razza</button>
         </div>
       </div>
       <!-- Step 4: Background -->
@@ -154,7 +152,6 @@
         <div id="backgroundFeat"></div>
         <div class="form-group">
           <button id="changeBackground" class="btn hidden" data-i18n="changeBackground">Change Background</button>
-          <button id="confirmBackgroundSelection" class="btn btn-primary">Seleziona Background</button>
         </div>
       </div>
       <!-- Step 5: Equipment -->

--- a/src/main.js
+++ b/src/main.js
@@ -13,9 +13,18 @@ import {
   rebuildFromClasses,
   refreshBaseState,
   isStepComplete as isStep2Complete,
+  confirmStep as confirmStep2,
 } from "./step2.js";
-import { loadStep3, isStepComplete as isStep3Complete } from "./step3.js";
-import { loadStep4, isStepComplete as isStep4Complete } from "./step4.js";
+import {
+  loadStep3,
+  isStepComplete as isStep3Complete,
+  confirmStep as confirmStep3,
+} from "./step3.js";
+import {
+  loadStep4,
+  isStepComplete as isStep4Complete,
+  confirmStep as confirmStep4,
+} from "./step4.js";
 import { loadStep5, isStepComplete as isStep5Complete } from "./step5.js";
 import { loadStep6 } from "./step6.js";
 import { exportFoundryActor } from "./export.js";
@@ -278,11 +287,20 @@ document.addEventListener("DOMContentLoaded", async () => {
     if (resetBtn) {
       resetBtn.addEventListener("click", () => location.reload());
     }
+    const confirmMap = { 2: confirmStep2, 3: confirmStep3, 4: confirmStep4 };
     const nextArrow = document.getElementById("nextStep");
     if (nextArrow) {
-      nextArrow.addEventListener("click", () => {
-        if (!nextArrow.disabled) {
+      nextArrow.addEventListener("click", async () => {
+        if (nextArrow.disabled) return;
+        try {
+          const fn = confirmMap[currentStep];
+          if (fn) {
+            const ok = await fn();
+            if (!ok) return;
+          }
           showStep(currentStep + 1);
+        } catch (err) {
+          console.error(err);
         }
       });
     }

--- a/src/step2.js
+++ b/src/step2.js
@@ -13,6 +13,7 @@ import { t } from './i18n.js';
 import { createElement, createAccordionItem } from './ui-helpers.js';
 import { renderFeatChoices } from './feat.js';
 import { renderSpellChoices } from './spell-select.js';
+import { pendingReplacements } from './proficiency.js';
 
 const abilityMap = {
   Strength: 'str',
@@ -799,7 +800,12 @@ globalThis.updateStep2Completion = updateStep2Completion;
 export function isStepComplete() {
   const incomplete = (CharacterState.classes || []).some(classHasPendingChoices);
   const hasClass = (CharacterState.classes || []).length > 0;
-  return hasClass && !incomplete;
+  return hasClass && !incomplete && pendingReplacements() === 0;
+}
+
+export function confirmStep() {
+  updateStep2Completion();
+  return isStepComplete();
 }
 
 /**


### PR DESCRIPTION
## Summary
- route step navigation through new `confirmStep` functions for steps 2–4
- remove redundant confirm buttons in the UI and modules
- block advancement until duplicate proficiency replacements are resolved

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b17a0a169c832eb46125e04ddc20d1