### PR TITLE
Restrict known spells to usable levels

### DIFF
--- a/src/spell-select.js
+++ b/src/spell-select.js
@@ -1,4 +1,4 @@
-import { CharacterState } from './data.js';
+import { CharacterState, updateSpellSlots } from './data.js';
 import { t } from './i18n.js';
 
 let spellCache;
@@ -20,6 +20,14 @@ export function renderSpellChoices(cls) {
   let spells = [];
 
   function build() {
+    updateSpellSlots();
+    const spellState = CharacterState.system.spells || {};
+    let maxLevel = 0;
+    for (let i = 1; i <= 9; i++) {
+      if (spellState[`spell${i}`]?.max > 0) maxLevel = i;
+    }
+    if (spellState.pact?.level > maxLevel) maxLevel = spellState.pact.level;
+
     const count = cls.spellcasting?.spellsPerLevel?.[cls.level] || 0;
     container.innerHTML = '';
     selects.length = 0;
@@ -28,7 +36,12 @@ export function renderSpellChoices(cls) {
       const sel = document.createElement('select');
       sel.innerHTML = `<option value=''>${t('selectSpell')}</option>`;
       spells
-        .filter((s) => (s.spell_list || []).includes(cls.name))
+        .filter(
+          (s) =>
+            (s.spell_list || []).includes(cls.name) &&
+            s.level >= 1 &&
+            s.level <= maxLevel
+        )
         .forEach((spell) => {
           const opt = document.createElement('option');
           opt.value = spell.name;

--- a/src/step2.js
+++ b/src/step2.js
@@ -460,14 +460,15 @@ function renderClassEditor(cls, index) {
     }
     compileClassFeatures(cls);
     rebuildFromClasses();
-    if (cls.spellcasting?.type === 'known') {
-      const newRenderer = renderSpellChoices(cls);
-      const newItem = createAccordionItem(t('spellsKnown'), newRenderer.element, true);
-      if (spellItem) accordion.replaceChild(newItem, spellItem);
-      else accordion.appendChild(newItem);
-      cls.spellRenderer = newRenderer;
-      spellItem = newItem;
-    }
+    (CharacterState.classes || []).forEach(c => {
+      if (c.spellcasting?.type === 'known' && c.spellItem) {
+        const newRenderer = renderSpellChoices(c);
+        const newItem = createAccordionItem(t('spellsKnown'), newRenderer.element, true);
+        c.spellItem.parentNode.replaceChild(newItem, c.spellItem);
+        c.spellRenderer = newRenderer;
+        c.spellItem = newItem;
+      }
+    });
     updateStep2Completion();
   });
   card.appendChild(levelSel);
@@ -478,7 +479,6 @@ function renderClassEditor(cls, index) {
   const skillSelects = [];
   const skillChoiceSelects = [];
   const skillChoiceSelectMap = new Map();
-  let spellItem;
 
   const clsDef = DATA.classes.find(c => c.name === cls.name);
   if (clsDef) {
@@ -631,8 +631,8 @@ function renderClassEditor(cls, index) {
 
   if (cls.spellcasting?.type === 'known') {
     cls.spellRenderer = renderSpellChoices(cls);
-    spellItem = createAccordionItem(t('spellsKnown'), cls.spellRenderer.element, true);
-    accordion.appendChild(spellItem);
+    cls.spellItem = createAccordionItem(t('spellsKnown'), cls.spellRenderer.element, true);
+    accordion.appendChild(cls.spellItem);
   }
 
   card.appendChild(accordion);


### PR DESCRIPTION
## Summary
- Compute highest available spell level and filter spells beyond it
- Rebuild spell choices when class levels change to refresh limits

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b1820f4590832eb2030e8b83535313