### PR TITLE
Fix background feat choice validation

### DIFF
--- a/src/step4.js
+++ b/src/step4.js
@@ -258,6 +258,13 @@ function selectBackground(bg) {
       featChoicesDiv.innerHTML = '';
       if (sel.value) {
         pendingSelections.featRenderer = await renderFeatChoices(sel.value, featChoicesDiv);
+        const all = [
+          ...(pendingSelections.featRenderer.abilitySelects || []),
+          ...(pendingSelections.featRenderer.skillSelects || []),
+          ...(pendingSelections.featRenderer.toolSelects || []),
+          ...(pendingSelections.featRenderer.languageSelects || [])
+        ];
+        all.forEach((s) => s.addEventListener('change', validateBackgroundChoices));
       }
       validateBackgroundChoices();
     });


### PR DESCRIPTION
## Summary
- ensure background feat choices trigger validation when sub-options change

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68adad5ffc74832ea48eb0f9569a6e25