### PR TITLE
Apply static feat ability bonuses

### DIFF
--- a/src/feat.js
+++ b/src/feat.js
@@ -7,6 +7,18 @@ function capitalize(str) {
   return str.replace(/(^|\s)\w/g, (c) => c.toUpperCase());
 }
 
+function refreshAbility(ab) {
+  const base = CharacterState.baseAbilities?.[ab];
+  const bonus = CharacterState.bonusAbilities?.[ab] || 0;
+  const finalVal = (base || 0) + bonus;
+  const baseSpan = document.getElementById(`${ab}Points`);
+  const bonusSpan = document.getElementById(`${ab}RaceModifier`);
+  const finalCell = document.getElementById(`${ab}FinalScore`);
+  if (baseSpan) baseSpan.textContent = base;
+  if (bonusSpan) bonusSpan.textContent = bonus;
+  if (finalCell) finalCell.textContent = finalVal;
+}
+
 async function getFeat(name) {
   const mod = await import('./data.js');
   return mod.loadFeatDetails(name);
@@ -21,6 +33,7 @@ export async function renderFeatChoices(featName, container) {
   const skillSelects = [];
   const toolSelects = [];
   const languageSelects = [];
+  const fixedAbilityBonuses = {};
 
   if (Array.isArray(feat.ability)) {
     feat.ability.forEach((ab) => {
@@ -39,6 +52,24 @@ export async function renderFeatChoices(featName, container) {
           wrapper.appendChild(sel);
           abilitySelects.push(sel);
         }
+      } else {
+        Object.entries(ab).forEach(([code, val]) => {
+          if (
+            CharacterState.system.abilities[code] &&
+            CharacterState.bonusAbilities[code] !== undefined
+          ) {
+            const base =
+              CharacterState.baseAbilities?.[code] ??
+              CharacterState.system.abilities[code].value -
+                (CharacterState.bonusAbilities[code] || 0);
+            CharacterState.bonusAbilities[code] += val;
+            CharacterState.system.abilities[code].value =
+              base + CharacterState.bonusAbilities[code];
+            fixedAbilityBonuses[code] =
+              (fixedAbilityBonuses[code] || 0) + val;
+            refreshAbility(code);
+          }
+        });
       }
     });
   }
@@ -82,6 +113,9 @@ export async function renderFeatChoices(featName, container) {
 
   const apply = () => {
     const featObj = { name: featName, system: {} };
+    if (Object.keys(fixedAbilityBonuses).length) {
+      featObj.ability = { ...fixedAbilityBonuses };
+    }
     if (abilitySelects.length) {
       abilitySelects.forEach((sel) => {
         const code = sel.value;
@@ -98,6 +132,7 @@ export async function renderFeatChoices(featName, container) {
           CharacterState.bonusAbilities[code] += 1;
           CharacterState.system.abilities[code].value =
             base + CharacterState.bonusAbilities[code];
+          refreshAbility(code);
         }
       });
     }

--- a/src/step6.js
+++ b/src/step6.js
@@ -15,7 +15,7 @@ function calcRemaining() {
   return remaining;
 }
 
-function updateFinal(ab) {
+export function updateFinal(ab) {
   const base = CharacterState.baseAbilities[ab];
   const bonus = CharacterState.bonusAbilities?.[ab] || 0;
   const finalVal = base + bonus;


### PR DESCRIPTION
## Summary
- export step 6 ability refresh helper
- auto-apply fixed ability bonuses from feats and update ability UI

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b18954a014832e81f255aa31e590bc