### PR TITLE
Refactor race selection to avoid ability score changes

### DIFF
--- a/__tests__/step3.test.js
+++ b/__tests__/step3.test.js
@@ -394,13 +394,16 @@ describe('change race cleanup', () => {
     await confirmStep();
   });
 
-  test('removes race bonuses when changing race', async () => {
-    expect(CharacterState.system.abilities.str.value).toBe(10);
-    expect(CharacterState.bonusAbilities.str).toBe(2);
+  test('cleans up race metadata when changing race', async () => {
+    // Ability scores should remain untouched during race confirmation
+    expect(CharacterState.system.abilities.str.value).toBe(8);
+    expect(CharacterState.bonusAbilities.str).toBe(0);
+    // Other race features should still be applied
     expect(CharacterState.system.skills).toContain('Survival');
     expect(CharacterState.system.traits.languages.value).toContain('Draconic');
     expect(CharacterState.system.attributes.movement.swim).toBe(30);
 
+    // Changing race should remove metadata but leave abilities unchanged
     document.getElementById('changeRace').click();
     await new Promise((r) => setTimeout(r, 0));
 

--- a/src/step3.js
+++ b/src/step3.js
@@ -514,25 +514,8 @@ function confirmRaceSelection() {
   };
   CharacterState.raceChoices.movement = move;
 
-  if (Array.isArray(currentRaceData.ability)) {
-    currentRaceData.ability.forEach((obj) => {
-      for (const [ab, val] of Object.entries(obj)) {
-        if (
-          typeof val === 'number' &&
-          CharacterState.system.abilities[ab] &&
-          CharacterState.bonusAbilities[ab] !== undefined
-        ) {
-          const base =
-            CharacterState.baseAbilities?.[ab] ??
-            CharacterState.system.abilities[ab].value -
-              (CharacterState.bonusAbilities[ab] || 0);
-          CharacterState.bonusAbilities[ab] += val;
-          CharacterState.system.abilities[ab].value =
-            base + CharacterState.bonusAbilities[ab];
-        }
-      }
-    });
-  }
+  // Ability score increases are now handled in Step 6. Race selection
+  // should not apply any modifiers to ability scores directly.
 
   if (currentRaceData.darkvision)
     CharacterState.system.traits.senses.darkvision = currentRaceData.darkvision;
@@ -672,25 +655,8 @@ export async function loadStep3(force = false) {
         else delete movement[m];
       });
       CharacterState.system.attributes.movement = movement;
-      if (Array.isArray(currentRaceData.ability)) {
-        currentRaceData.ability.forEach((obj) => {
-          for (const [ab, val] of Object.entries(obj)) {
-            if (
-              typeof val === 'number' &&
-              CharacterState.system.abilities[ab] &&
-              CharacterState.bonusAbilities[ab] !== undefined
-            ) {
-              const base =
-                CharacterState.baseAbilities?.[ab] ??
-                CharacterState.system.abilities[ab].value -
-                  CharacterState.bonusAbilities[ab];
-              CharacterState.bonusAbilities[ab] -= val;
-              CharacterState.system.abilities[ab].value =
-                base + CharacterState.bonusAbilities[ab];
-            }
-          }
-        });
-      }
+      // No ability score adjustments are made during race selection,
+      // so there is nothing to revert here.
       CharacterState.raceChoices.skills = [];
       CharacterState.raceChoices.tools = [];
       CharacterState.raceChoices.languages = [];


### PR DESCRIPTION
## Summary
- Stop Step 3 from applying racial ability score bonuses
- Leave race selection to set only size, movement, languages, skills, and similar metadata
- Update tests to reflect ability score handling in Step 6

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b18a7b81ec832eb060ce4ff0cad061