### PR TITLE
Load cantrips from spell list

### DIFF
--- a/data/classes/artificer.json
+++ b/data/classes/artificer.json
@@ -246,21 +246,7 @@
       "name": "Cantrip",
       "description": "Choose 2 artificer cantrips to learn",
       "count": 2,
-      "type": "cantrips",
-      "selection": [
-        "Fire Bolt",
-        "Guidance",
-        "Light",
-        "Mage Hand",
-        "Prestidigitation",
-        "Ray of Frost",
-        "Resistance",
-        "Shocking Grasp",
-        "Spare the Dying",
-        "Sword Burst",
-        "Thorn Whip",
-        "Thunderclap"
-      ]
+      "type": "cantrips"
     },
     {
       "level": 2,

--- a/data/classes/bard.json
+++ b/data/classes/bard.json
@@ -318,15 +318,7 @@
       "name": "Cantrip",
       "description": "Choose 2 bard cantrips to learn",
       "count": 2,
-      "type": "cantrips",
-      "selection": [
-        "Light",
-        "Mage Hand",
-        "Prestidigitation",
-        "Thunderclap",
-        "True Strike",
-        "Vicious Mockery"
-      ]
+      "type": "cantrips"
     },
     {
       "level": 3,

--- a/data/classes/cleric.json
+++ b/data/classes/cleric.json
@@ -344,17 +344,7 @@
       "name": "Cantrip",
       "description": "Choose 3 cleric cantrips to learn",
       "count": 3,
-      "type": "cantrips",
-      "selection": [
-        "Guidance",
-        "Light",
-        "Resistance",
-        "Sacred Flame",
-        "Spare the Dying",
-        "Thaumaturgy",
-        "Toll the Dead",
-        "Word of Radiance"
-      ]
+      "type": "cantrips"
     },
     {
       "level": 4,

--- a/data/classes/druid.json
+++ b/data/classes/druid.json
@@ -263,16 +263,7 @@
       "name": "Cantrip",
       "description": "Choose 2 druid cantrips to learn",
       "count": 2,
-      "type": "cantrips",
-      "selection": [
-        "Guidance",
-        "Produce Flame",
-        "Resistance",
-        "Shape Water",
-        "Shillelagh",
-        "Thorn Whip",
-        "Thunderclap"
-      ]
+      "type": "cantrips"
     },
     {
       "level": 4,

--- a/data/classes/sorcerer.json
+++ b/data/classes/sorcerer.json
@@ -263,19 +263,7 @@
       "name": "Cantrip",
       "description": "Choose 4 sorcerer cantrips to learn",
       "count": 4,
-      "type": "cantrips",
-      "selection": [
-        "Fire Bolt",
-        "Light",
-        "Mage Hand",
-        "Prestidigitation",
-        "Ray of Frost",
-        "Shape Water",
-        "Shocking Grasp",
-        "Sword Burst",
-        "Thunderclap",
-        "True Strike"
-      ]
+      "type": "cantrips"
     },
     {
       "level": 3,

--- a/data/classes/warlock.json
+++ b/data/classes/warlock.json
@@ -263,15 +263,7 @@
       "name": "Cantrip",
       "description": "Choose 2 warlock cantrips to learn",
       "count": 2,
-      "type": "cantrips",
-      "selection": [
-        "Eldritch Blast",
-        "Mage Hand",
-        "Prestidigitation",
-        "Sword Burst",
-        "Thunderclap",
-        "Toll the Dead"
-      ]
+      "type": "cantrips"
     },
     {
       "level": 2,

--- a/data/classes/wizard.json
+++ b/data/classes/wizard.json
@@ -133,20 +133,7 @@
       "name": "Cantrip",
       "description": "Choose 3 wizard cantrips to learn",
       "count": 3,
-      "type": "cantrips",
-      "selection": [
-        "Fire Bolt",
-        "Light",
-        "Mage Hand",
-        "Prestidigitation",
-        "Ray of Frost",
-        "Shape Water",
-        "Shocking Grasp",
-        "Sword Burst",
-        "Thunderclap",
-        "Toll the Dead",
-        "True Strike"
-      ]
+      "type": "cantrips"
     },
     {
       "level": 4,


### PR DESCRIPTION
## Summary
- fetch class cantrips from spell data instead of hard-coded lists
- drop hardcoded cantrip selections in class data

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b1b75764d8832e845989b14ab89ba9