### PR TITLE
Use translations for race choice validation

### DIFF
--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -53,5 +53,8 @@
   "maxScoreLevel1": "Ability scores cannot exceed 17 at level 1",
   "spellsKnown": "Spells Known",
   "selectSpell": "Select spell",
-  "selectSpellsWarning": "Please select all required spells"
+  "selectSpellsWarning": "Please select all required spells",
+  "selectionRequired": "Selection required",
+  "languageAlreadyKnown": "Language already known",
+  "selectionsMustBeUnique": "Selections must be unique"
 }

--- a/src/i18n/it.json
+++ b/src/i18n/it.json
@@ -53,5 +53,8 @@
   "maxScoreLevel1": "I punteggi delle caratteristiche non possono superare 17 al livello 1",
   "spellsKnown": "Incantesimi Conosciuti",
   "selectSpell": "Seleziona incantesimo",
-  "selectSpellsWarning": "Seleziona tutti gli incantesimi richiesti"
+  "selectSpellsWarning": "Seleziona tutti gli incantesimi richiesti",
+  "selectionRequired": "Selezione obbligatoria",
+  "languageAlreadyKnown": "Lingua già conosciuta",
+  "selectionsMustBeUnique": "Le selezioni devono essere uniche"
 }

--- a/src/step3.js
+++ b/src/step3.js
@@ -38,7 +38,7 @@ function validateRaceChoices() {
   const missing = allSelects.filter((s) => !s.value);
   missing.forEach((s) => {
     s.classList.add('missing');
-    s.title = 'Selection required';
+    s.title = t('selectionRequired');
   });
 
   const counts = {};
@@ -76,19 +76,14 @@ function validateRaceChoices() {
   duplicates.forEach((s) => {
     s.classList.add('duplicate');
     s.title = languageDupSet.has(s)
-      ? 'Language already known'
-      : 'Selections must be unique';
+      ? t('languageAlreadyKnown')
+      : t('selectionsMustBeUnique');
   });
 
   const valid =
     missing.length === 0 &&
     duplicates.length === 0 &&
     !!pendingRaceChoices.subrace;
-
-  const errors = [];
-  if (!pendingRaceChoices.subrace) errors.push('Select a subrace');
-  if (missing.length) errors.push('Complete all selections');
-  if (duplicates.length) errors.push('Choose unique options');
 
   main.setCurrentStepComplete?.(valid);
   return valid;


### PR DESCRIPTION
## Summary
- localize race choice validation messages
- remove unused error aggregation
- add English and Italian translations for validation keys

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b298380e64832e8b73d156a9c43d1a