### PR TITLE
Add selectable card helper

### DIFF
--- a/src/step2.js
+++ b/src/step2.js
@@ -10,7 +10,7 @@ import {
   loadSpells,
 } from './data.js';
 import { t } from './i18n.js';
-import { createElement, createAccordionItem } from './ui-helpers.js';
+import { createElement, createAccordionItem, createSelectableCard } from './ui-helpers.js';
 import { renderFeatChoices } from './feat.js';
 import { renderSpellChoices } from './spell-select.js';
 import { pendingReplacements } from './proficiency.js';
@@ -884,28 +884,15 @@ export async function loadStep2(refresh = true) {
           cls.name.toLowerCase().includes(query.toLowerCase())
       )
       .forEach(cls => {
-        const classCard = document.createElement('div');
-        classCard.className = 'class-card';
-        classCard.addEventListener('click', () => showClassModal(cls));
-
-        const title = createElement('h3', cls.name);
-        const desc = createElement(
-          'p',
-          cls.description || 'Nessuna descrizione disponibile.'
+        const card = createSelectableCard(
+          cls.name,
+          cls.description || 'Nessuna descrizione disponibile.',
+          null,
+          () => showClassModal(cls),
+          'Dettagli',
+          () => showClassModal(cls)
         );
-
-        const detailsBtn = createElement('button', 'Dettagli');
-        detailsBtn.className = 'btn btn-primary';
-        detailsBtn.addEventListener('click', e => {
-          e.stopPropagation();
-          showClassModal(cls);
-        });
-
-        classCard.appendChild(title);
-        classCard.appendChild(desc);
-        classCard.appendChild(detailsBtn);
-
-        classListContainer.appendChild(classCard);
+        classListContainer.appendChild(card);
       });
   }
   if (searchInput) {

--- a/src/step3.js
+++ b/src/step3.js
@@ -10,7 +10,7 @@ import { refreshBaseState, rebuildFromClasses } from './step2.js';
 import { t } from './i18n.js';
 import * as main from './main.js';
 import { addUniqueProficiency, pendingReplacements } from './proficiency.js';
-import { createAccordionItem } from './ui-helpers.js';
+import { createAccordionItem, createSelectableCard } from './ui-helpers.js';
 
 let selectedBaseRace = '';
 let currentRaceData = null;
@@ -94,51 +94,31 @@ function capitalize(str) {
 }
 
 function createRaceCard(race, onSelect, displayName = race.name) {
-  const card = document.createElement('div');
-  card.className = 'class-card';
-
-  const title = document.createElement('h3');
-  title.textContent = displayName;
-  card.appendChild(title);
-
-  const details = document.createElement('div');
-  details.className = 'race-details hidden';
-
-  const shortDesc = (race.entries || []).find((e) => typeof e === 'string');
-  if (shortDesc) {
-    const p = document.createElement('p');
-    p.textContent = shortDesc;
-    details.appendChild(p);
-  }
+  const detailItems = [];
+  const shortDesc = (race.entries || []).find(e => typeof e === 'string');
+  if (shortDesc) detailItems.push(shortDesc);
 
   const traits = (race.entries || [])
-    .filter((e) => e.name)
-    .map((e) => e.name)
+    .filter(e => e.name)
+    .map(e => e.name)
     .slice(0, 3);
   if (traits.length) {
     const ul = document.createElement('ul');
-    traits.forEach((t) => {
+    traits.forEach(t => {
       const li = document.createElement('li');
       li.textContent = t;
       ul.appendChild(li);
     });
-    details.appendChild(ul);
+    detailItems.push(ul);
   }
 
-  card.appendChild(details);
-
-  const detailsBtn = document.createElement('button');
-  detailsBtn.className = 'btn btn-primary';
-  detailsBtn.textContent = t('details');
-  detailsBtn.addEventListener('click', (e) => {
-    e.stopPropagation();
-    details.classList.toggle('hidden');
-  });
-  card.appendChild(detailsBtn);
-
-  card.addEventListener('click', onSelect);
-
-  return card;
+  return createSelectableCard(
+    displayName,
+    null,
+    detailItems,
+    onSelect,
+    t('details') || 'Details'
+  );
 }
 
 async function renderBaseRaces(search = '') {

--- a/src/step4.js
+++ b/src/step4.js
@@ -7,7 +7,7 @@ import {
 import { refreshBaseState, rebuildFromClasses, updateChoiceSelectOptions } from './step2.js';
 import { t } from './i18n.js';
 import * as main from './main.js';
-import { createElement, createAccordionItem } from './ui-helpers.js';
+import { createElement, createAccordionItem, createSelectableCard } from './ui-helpers.js';
 import { addUniqueProficiency, pendingReplacements } from './proficiency.js';
 import { renderFeatChoices } from './feat.js';
 
@@ -36,48 +36,29 @@ export function renderBackgroundList(query = '') {
   const term = query.toLowerCase();
   for (const [name, bg] of Object.entries(entries)) {
     if (!name.toLowerCase().includes(term)) continue;
-    const card = document.createElement('div');
-    card.className = 'class-card';
-    card.addEventListener('click', () => selectBackground(bg));
-    const title = createElement('h3', name);
-    card.appendChild(title);
-
-    const descText =
-      bg.short || bg.description || bg.summary || bg.desc || '';
-    if (descText) card.appendChild(createElement('p', descText));
-
-    const details = document.createElement('div');
-    details.className = 'race-details hidden';
+    const details = [];
     if (bg.skills && bg.skills.length)
-      details.appendChild(
-        createElement('p', `${t('skills')}: ${bg.skills.join(', ')}`)
-      );
+      details.push(createElement('p', `${t('skills')}: ${bg.skills.join(', ')}`));
     if (Array.isArray(bg.tools) && bg.tools.length)
-      details.appendChild(
-        createElement('p', `${t('tools')}: ${bg.tools.join(', ')}`)
-      );
+      details.push(createElement('p', `${t('tools')}: ${bg.tools.join(', ')}`));
     if (Array.isArray(bg.languages) && bg.languages.length)
-      details.appendChild(
+      details.push(
         createElement('p', `${t('languages')}: ${bg.languages.join(', ')}`)
       );
     if (bg.featOptions && bg.featOptions.length)
-      details.appendChild(
+      details.push(
         createElement(
           'p',
           `${t('featOptions') || 'Feat Options'}: ${bg.featOptions.join(', ')}`
         )
       );
-    if (details.childElementCount) {
-      card.appendChild(details);
-      const detailsBtn = document.createElement('button');
-      detailsBtn.className = 'btn btn-primary';
-      detailsBtn.textContent = t('details') || 'Details';
-      detailsBtn.addEventListener('click', (e) => {
-        e.stopPropagation();
-        details.classList.toggle('hidden');
-      });
-      card.appendChild(detailsBtn);
-    }
+    const card = createSelectableCard(
+      name,
+      bg.short || bg.description || bg.summary || bg.desc || '',
+      details,
+      () => selectBackground(bg),
+      t('details') || 'Details'
+    );
     container.appendChild(card);
   }
 }

--- a/src/ui-helpers.js
+++ b/src/ui-helpers.js
@@ -35,6 +35,51 @@ export function createAccordionItem(title, content, isChoice = false, descriptio
   return item;
 }
 
+export function createSelectableCard(
+  title,
+  description,
+  details = null,
+  onClick = null,
+  detailsButtonText = 'Details',
+  onDetailsClick = null
+) {
+  const card = document.createElement('div');
+  card.className = 'class-card';
+  if (onClick) card.addEventListener('click', onClick);
+
+  if (title) card.appendChild(createElement('h3', title));
+  if (description) card.appendChild(createElement('p', description));
+
+  const detailItems = Array.isArray(details)
+    ? details.filter(Boolean)
+    : details
+    ? [details]
+    : [];
+  let detailContainer = null;
+  if (detailItems.length) {
+    detailContainer = document.createElement('div');
+    detailContainer.className = 'race-details hidden';
+    detailItems.forEach(d => {
+      if (typeof d === 'string') detailContainer.appendChild(createElement('p', d));
+      else detailContainer.appendChild(d);
+    });
+    card.appendChild(detailContainer);
+  }
+
+  if (detailItems.length || onDetailsClick) {
+    const btn = createElement('button', detailsButtonText);
+    btn.className = 'btn btn-primary';
+    btn.addEventListener('click', e => {
+      e.stopPropagation();
+      if (onDetailsClick) onDetailsClick(e);
+      else if (detailContainer) detailContainer.classList.toggle('hidden');
+    });
+    card.appendChild(btn);
+  }
+
+  return card;
+}
+
 export function initNextStepWarning() {
   const nextBtn = document.getElementById('nextStep');
   if (!nextBtn) return;


### PR DESCRIPTION
## Summary
- add `createSelectableCard` helper to build clickable cards with optional details
- refactor class, race, and background listings to use the new helper for consistent styling

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b29903e964832e96a4c4e9f243bc11