### PR TITLE
refactor: centralize capitalize helper

### DIFF
--- a/src/feat.js
+++ b/src/feat.js
@@ -1,11 +1,7 @@
 import { CharacterState } from './data.js';
 import { t } from './i18n.js';
 import { addUniqueProficiency } from './proficiency.js';
-import { createElement } from './ui-helpers.js';
-
-function capitalize(str) {
-  return str.replace(/(^|\s)\w/g, (c) => c.toUpperCase());
-}
+import { createElement, capitalize } from './ui-helpers.js';
 
 function refreshAbility(ab) {
   const base = CharacterState.baseAbilities?.[ab];

--- a/src/main.js
+++ b/src/main.js
@@ -118,10 +118,6 @@ async function loadData() {
   DATA.languages = langJson.languages;
 }
 
-function capitalize(str) {
-  return str.charAt(0).toUpperCase() + str.slice(1);
-}
-
 // Render a summary of resources and spell slots on the final step. Users can
 // tweak resource values directly from here using the helper functions in
 // data.js.

--- a/src/step3.js
+++ b/src/step3.js
@@ -10,7 +10,11 @@ import { refreshBaseState, rebuildFromClasses } from './step2.js';
 import { t } from './i18n.js';
 import * as main from './main.js';
 import { addUniqueProficiency, pendingReplacements } from './proficiency.js';
-import { createAccordionItem, createSelectableCard } from './ui-helpers.js';
+import {
+  createAccordionItem,
+  createSelectableCard,
+  capitalize,
+} from './ui-helpers.js';
 
 let selectedBaseRace = '';
 let currentRaceData = null;
@@ -87,10 +91,6 @@ function validateRaceChoices() {
 
   main.setCurrentStepComplete?.(valid);
   return valid;
-}
-
-function capitalize(str) {
-  return str.charAt(0).toUpperCase() + str.slice(1);
 }
 
 function createRaceCard(race, onSelect, displayName = race.name) {

--- a/src/ui-helpers.js
+++ b/src/ui-helpers.js
@@ -1,3 +1,7 @@
+export function capitalize(str) {
+  return str.replace(/(^|\s)\w/g, (c) => c.toUpperCase());
+}
+
 export function createElement(tag, text) {
   const el = document.createElement(tag);
   if (text) el.textContent = text;


### PR DESCRIPTION
## Summary
- centralize `capitalize` helper in `ui-helpers`
- remove duplicate `capitalize` functions from modules
- use shared helper throughout

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b29a1a1fb8832eb4b2c1640108e448