### PR TITLE
Use global replacement for i18n placeholders

### DIFF
--- a/__tests__/i18n.test.js
+++ b/__tests__/i18n.test.js
@@ -1,0 +1,10 @@
+import { t } from '../src/i18n.js';
+
+describe('i18n replacements', () => {
+  test('replaces all occurrences of a key', () => {
+    expect(t('Hello {name}, {name}!', { name: 'Alice' })).toBe(
+      'Hello Alice, Alice!'
+    );
+  });
+});
+

--- a/src/i18n.js
+++ b/src/i18n.js
@@ -17,7 +17,7 @@ export async function initI18n() {
 export function t(key, params = {}) {
   let str = translations[key] || key;
   for (const [k, v] of Object.entries(params)) {
-    str = str.replace(`{${k}}`, v);
+    str = str.replaceAll(`{${k}}`, v);
   }
   return str;
 }


### PR DESCRIPTION
## Summary
- use `replaceAll` to substitute all placeholder occurrences in translations
- test that `t` replaces repeated placeholders

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b29c1c6044832e913b5399e4731f1d