### PR TITLE
refactor: use loadFeatDetails directly

### DIFF
--- a/__tests__/classSearch.test.js
+++ b/__tests__/classSearch.test.js
@@ -36,6 +36,7 @@ jest.unstable_mockModule('../src/data.js', () => {
     MAX_CHARACTER_LEVEL: 20,
     loadSpells: jest.fn(),
     fetchJsonWithRetry: jest.fn(),
+    loadFeatDetails: jest.fn(),
   };
 });
 

--- a/__tests__/step4.test.js
+++ b/__tests__/step4.test.js
@@ -16,6 +16,7 @@ jest.unstable_mockModule('../src/data.js', () => ({
   logCharacterState: jest.fn(),
   fetchJsonWithRetry: jest.fn(),
   loadSpells: jest.fn(),
+  loadFeatDetails: jest.fn(),
 }));
 
 jest.unstable_mockModule('../src/step2.js', () => ({

--- a/src/feat.js
+++ b/src/feat.js
@@ -1,4 +1,4 @@
-import { CharacterState } from './data.js';
+import { CharacterState, loadFeatDetails } from './data.js';
 import { t } from './i18n.js';
 import { addUniqueProficiency } from './proficiency.js';
 import { createElement, capitalize } from './ui-helpers.js';
@@ -15,13 +15,8 @@ function refreshAbility(ab) {
   if (finalCell) finalCell.textContent = finalVal;
 }
 
-async function getFeat(name) {
-  const mod = await import('./data.js');
-  return mod.loadFeatDetails(name);
-}
-
 export async function renderFeatChoices(featName, container) {
-  const feat = await getFeat(featName);
+  const feat = await loadFeatDetails(featName);
   const wrapper = createElement('div');
   container.appendChild(wrapper);
 


### PR DESCRIPTION
## Summary
- import `loadFeatDetails` directly instead of lazy `getFeat`
- mock `loadFeatDetails` in tests

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b29cb4aeb8832eb419e7c7ea2a4d3b