### PR TITLE
refactor: reuse centralized spell loader

### DIFF
--- a/__tests__/spell-select.test.js
+++ b/__tests__/spell-select.test.js
@@ -3,7 +3,8 @@
  */
 
 import { jest } from '@jest/globals';
-import { updateSpellSelectOptions, loadSpells } from '../src/spell-select.js';
+import { updateSpellSelectOptions } from '../src/spell-select.js';
+import { loadSpells, DATA } from '../src/data.js';
 
 describe('spell select duplicate prevention', () => {
   function createSelect(options) {
@@ -66,5 +67,6 @@ describe('loadSpells', () => {
     expect(fetchMock).toHaveBeenCalledTimes(10);
 
     global.fetch = originalFetch;
+    DATA.spells = undefined;
   });
 });

--- a/src/spell-select.js
+++ b/src/spell-select.js
@@ -1,24 +1,5 @@
-import {
-  CharacterState,
-  updateSpellSlots,
-  fetchJsonWithRetry,
-} from './data.js';
+import { CharacterState, updateSpellSlots, loadSpells } from './data.js';
 import { t } from './i18n.js';
-
-let spellCache;
-
-export async function loadSpells() {
-  if (!spellCache) {
-    const promises = [];
-    for (let i = 0; i <= 9; i++) {
-      promises.push(
-        fetchJsonWithRetry(`data/spells/level${i}.json`, `spells level ${i}`)
-      );
-    }
-    spellCache = (await Promise.all(promises)).flat();
-  }
-  return spellCache;
-}
 
 export function updateSpellSelectOptions(selects) {
   const counts = new Map();


### PR DESCRIPTION
## Summary
- remove redundant spell data loader
- reuse centralized `loadSpells` from data module

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b29d98e248832e917701b8d74317e9