### PR TITLE
chore: validate race selection fields

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
   "scripts": {
     "build": "rollup -c",
     "dev": "rollup -c -w",
-    "test": "node --experimental-vm-modules ./node_modules/jest/bin/jest.js"
+    "validate:races": "node scripts/validate-races.js",
+    "test": "npm run validate:races && node --experimental-vm-modules ./node_modules/jest/bin/jest.js"
   },
   "devDependencies": {
     "@rollup/plugin-commonjs": "^28.0.6",

--- a/scripts/validate-races.js
+++ b/scripts/validate-races.js
@@ -1,0 +1,55 @@
+#!/usr/bin/env node
+import { readdirSync, readFileSync } from 'fs';
+import path from 'path';
+
+const racesDir = path.resolve('data', 'races');
+let hasError = false;
+
+function hasSelectionMeta(value) {
+  if (!value) return false;
+  if (Array.isArray(value)) {
+    return value.some(v => hasSelectionMeta(v));
+  }
+  if (typeof value === 'object') {
+    if ('choose' in value) return true;
+    return Object.keys(value).some(k => /^any/i.test(k) || hasSelectionMeta(value[k]));
+  }
+  return false;
+}
+
+function checkField(value) {
+  if (!Array.isArray(value)) return false;
+  if (value.length <= 1) return false;
+  if (hasSelectionMeta(value)) return false;
+  return true;
+}
+
+for (const file of readdirSync(racesDir)) {
+  if (!file.endsWith('.json')) continue;
+  const filePath = path.join(racesDir, file);
+  let race;
+  try {
+    race = JSON.parse(readFileSync(filePath, 'utf8'));
+  } catch (e) {
+    console.error(`Failed to parse ${file}: ${e.message}`);
+    hasError = true;
+    continue;
+  }
+  const issues = [];
+  if (checkField(race.size)) issues.push('size');
+  if (checkField(race.languageProficiencies)) issues.push('languageProficiencies');
+  if (checkField(race.ability)) issues.push('ability');
+  if (checkField(race.custom)) issues.push('custom');
+
+  if (issues.length) {
+    console.error(`${file} missing selection metadata for: ${issues.join(', ')}`);
+    hasError = true;
+  }
+}
+
+if (hasError) {
+  console.error('Race validation failed.');
+  process.exit(1);
+} else {
+  console.log('All race files passed validation.');
+}


### PR DESCRIPTION
## Summary
- add script to validate race files for missing selection info
- wire race validator into test workflow

## Testing
- `npm test` *(fails: Race validation failed for size and languages in several files)*

------
https://chatgpt.com/codex/tasks/task_e_68b2a324281c832eb0cc59020a597204