### PR TITLE
feat: support Altered race alterations

### DIFF
--- a/data/races/altered.json
+++ b/data/races/altered.json
@@ -28,6 +28,35 @@
   "languageProficiencies": [
     { "common": true, "anyStandard": 1 }
   ],
+  "minorAlterations": [
+    "Aquatic Adaptation",
+    "Altered Metabolism",
+    "Darkvision",
+    "Fleet of Foot",
+    "Glider",
+    "Natural Weapon",
+    "Nimble Climber",
+    "Mutated Eyes",
+    "Silent Speech",
+    "Skilled",
+    "Strong-Minded",
+    "Supernatural Resistance"
+  ],
+  "majorAlterations": [
+    "Amorphous",
+    "Augmented Toughness",
+    "Blind Sense",
+    "Magical Affinity",
+    "Massive Build",
+    "Painful Regeneration",
+    "Secondary Arms",
+    "Shapechanger",
+    "Unnatural Armor"
+  ],
+  "alterationCombinations": [
+    { "minor": 3 },
+    { "minor": 2, "major": 1 }
+  ],
   "entries": [
     {
       "name": "Size",

--- a/src/data.js
+++ b/src/data.js
@@ -173,7 +173,7 @@ export const CharacterState = {
   feats: [],
   equipment: [],
   knownSpells: {},
-  raceChoices: { spells: [], spellAbility: '', size: '' },
+    raceChoices: { spells: [], spellAbility: '', size: '', alterations: {} },
   bonusAbilities: {
     str: 0,
     dex: 0,


### PR DESCRIPTION
## Summary
- add minor and major alteration options plus combination rules for the Altered race
- allow selecting and validating Altered race alterations in step 3
- record chosen alterations on the character state

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b2a310e0d0832ea8eda011f2a9eeeb