### PR TITLE
Handle race skill proficiency choices

### DIFF
--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -56,5 +56,6 @@
   "selectSpellsWarning": "Please select all required spells",
   "selectionRequired": "Selection required",
   "languageAlreadyKnown": "Language already known",
+  "skillAlreadyKnown": "Skill already known",
   "selectionsMustBeUnique": "Selections must be unique"
 }

--- a/src/i18n/it.json
+++ b/src/i18n/it.json
@@ -56,5 +56,6 @@
   "selectSpellsWarning": "Seleziona tutti gli incantesimi richiesti",
   "selectionRequired": "Selezione obbligatoria",
   "languageAlreadyKnown": "Lingua già conosciuta",
+  "skillAlreadyKnown": "Abilità già conosciuta",
   "selectionsMustBeUnique": "Le selezioni devono essere uniche"
 }


### PR DESCRIPTION
## Summary
- detect race skill proficiency options and render selectable menus
- validate and apply chosen skills to character state
- cover race skill choice flow with tests and translations

## Testing
- `npm test` *(fails: Race validation failed)*
- `node --experimental-vm-modules ./node_modules/jest/bin/jest.js`

------
https://chatgpt.com/codex/tasks/task_e_68b2aac6a2c0832e9a0a33f449aa669e