### PR TITLE
Render choice descriptions for features

### DIFF
--- a/src/feat.js
+++ b/src/feat.js
@@ -1,7 +1,7 @@
 import { CharacterState, loadFeatDetails } from './data.js';
 import { t } from './i18n.js';
 import { addUniqueProficiency } from './proficiency.js';
-import { createElement, capitalize } from './ui-helpers.js';
+import { createElement, capitalize, appendEntries } from './ui-helpers.js';
 
 function refreshAbility(ab) {
   const base = CharacterState.baseAbilities?.[ab];
@@ -19,6 +19,8 @@ export async function renderFeatChoices(featName, container) {
   const feat = await loadFeatDetails(featName);
   const wrapper = createElement('div');
   container.appendChild(wrapper);
+  if (feat.description) wrapper.appendChild(createElement('p', feat.description));
+  appendEntries(wrapper, feat.entries);
 
   const abilitySelects = [];
   const skillSelects = [];

--- a/src/step3.js
+++ b/src/step3.js
@@ -14,6 +14,8 @@ import {
   createAccordionItem,
   createSelectableCard,
   capitalize,
+  appendEntries,
+  createElement,
 } from './ui-helpers.js';
 
 let selectedBaseRace = '';
@@ -224,6 +226,17 @@ async function renderSelectedRace() {
   header.textContent = currentRaceData.name;
   accordion.appendChild(header);
 
+  const entryMap = {};
+  (currentRaceData.entries || []).forEach(e => {
+    if (e.name) entryMap[e.name] = e;
+  });
+  const usedEntries = new Set();
+  const spellEntry = Object.values(entryMap).find(e =>
+    Array.isArray(e.entries) &&
+    e.entries.some(sub => typeof sub === 'string' && /@spell|spell/i.test(sub))
+  );
+  let spellEntryUsed = false;
+
   if (
     Array.isArray(currentRaceData.size) &&
     currentRaceData.size.length > 1
@@ -250,23 +263,16 @@ async function renderSelectedRace() {
     sel.addEventListener('change', validateRaceChoices);
     sizeContent.appendChild(sel);
     pendingRaceChoices.size = sel;
+    const sizeEntry = Object.values(entryMap).find(
+      e => e.name && e.name.toLowerCase() === 'size'
+    );
+    if (sizeEntry) {
+      if (sizeEntry.description)
+        sizeContent.appendChild(createElement('p', sizeEntry.description));
+      appendEntries(sizeContent, sizeEntry.entries);
+      usedEntries.add(sizeEntry.name);
+    }
     accordion.appendChild(createAccordionItem(t('size'), sizeContent, true));
-  }
-
-  if (currentRaceData.entries) {
-    currentRaceData.entries.forEach((e) => {
-      if (e.name) {
-        const body = document.createElement('div');
-        (e.entries || []).forEach((sub) => {
-          if (typeof sub === 'string') {
-            const p = document.createElement('p');
-            p.textContent = sub;
-            body.appendChild(p);
-          }
-        });
-        accordion.appendChild(createAccordionItem(e.name, body));
-      }
-    });
   }
 
   if (currentRaceData.skillProficiencies) {
@@ -295,10 +301,19 @@ async function renderSelectedRace() {
         DATA.languages = langs.languages || langs;
       }
       const langContent = document.createElement('div');
+      const langEntry = Object.values(entryMap).find(
+        e => e.name && e.name.toLowerCase() === 'languages'
+      );
+      if (langEntry) {
+        if (langEntry.description)
+          langContent.appendChild(createElement('p', langEntry.description));
+        appendEntries(langContent, langEntry.entries);
+        usedEntries.add(langEntry.name);
+      }
       if (raceLang.length) {
-        const p = document.createElement('p');
-        p.textContent = raceLang.join(', ');
-        langContent.appendChild(p);
+        langContent.appendChild(
+          createElement('p', raceLang.join(', '))
+        );
       }
       if (pendingLang > 0) {
         const known = new Set([
@@ -404,6 +419,13 @@ async function renderSelectedRace() {
 
     if (abilityOpts) {
       const abilityContent = document.createElement('div');
+      if (spellEntry) {
+        if (spellEntry.description)
+          abilityContent.appendChild(createElement('p', spellEntry.description));
+        appendEntries(abilityContent, spellEntry.entries);
+        usedEntries.add(spellEntry.name);
+        spellEntryUsed = true;
+      }
       const sel = document.createElement('select');
       sel.innerHTML = `<option value=''>${t('select')}</option>`;
       abilityOpts.forEach((ab) => {
@@ -447,6 +469,13 @@ async function renderSelectedRace() {
         V: 'Evocation',
       };
       const spellContent = document.createElement('div');
+      if (spellEntry && !spellEntryUsed) {
+        if (spellEntry.description)
+          spellContent.appendChild(createElement('p', spellEntry.description));
+        appendEntries(spellContent, spellEntry.entries);
+        usedEntries.add(spellEntry.name);
+        spellEntryUsed = true;
+      }
 
       function updateSpellSelects() {
         const chosen = new Set([
@@ -525,6 +554,13 @@ async function renderSelectedRace() {
 
   const traitsDiv = document.createElement('div');
   traitsDiv.id = 'raceTraits';
+  Object.values(entryMap).forEach(e => {
+    if (!e.name || usedEntries.has(e.name)) return;
+    const body = document.createElement('div');
+    if (e.description) body.appendChild(createElement('p', e.description));
+    appendEntries(body, e.entries);
+    accordion.appendChild(createAccordionItem(e.name, body));
+  });
   accordion.appendChild(traitsDiv);
   validateRaceChoices();
 }

--- a/src/step4.js
+++ b/src/step4.js
@@ -128,10 +128,19 @@ function selectBackground(bg) {
   features.appendChild(createAccordionItem(t('details') || 'Details', details));
 
   // Choices --------------------------------------------------
+  const appendFeatureDesc = (wrapper, key) => {
+    const entry = (currentBackgroundData.entries || []).find(
+      e => e.name && e.name.toLowerCase().includes(key)
+    );
+    if (entry) {
+      if (entry.description) wrapper.appendChild(createElement('p', entry.description));
+      appendEntries(wrapper, entry.entries);
+    }
+  };
 
   if (currentBackgroundData.skillChoices?.choose) {
     const wrapper = document.createElement('div');
-    appendEntries(wrapper, currentBackgroundData.entries);
+    appendFeatureDesc(wrapper, 'skill');
     for (let i = 0; i < currentBackgroundData.skillChoices.choose; i++) {
       const sel = document.createElement('select');
       sel.innerHTML = `<option value=''>${t('selectSkill') || 'Select skill'}</option>`;
@@ -162,7 +171,7 @@ function selectBackground(bg) {
       : null);
   if (toolData?.choose) {
     const wrapper = document.createElement('div');
-    appendEntries(wrapper, currentBackgroundData.entries);
+    appendFeatureDesc(wrapper, 'tool');
     for (let i = 0; i < toolData.choose; i++) {
       const sel = document.createElement('select');
       sel.innerHTML = `<option value=''>${t('selectTool') || 'Select tool'}</option>`;
@@ -192,7 +201,7 @@ function selectBackground(bg) {
     currentBackgroundData.languages.choose
   ) {
     const wrapper = document.createElement('div');
-    appendEntries(wrapper, currentBackgroundData.entries);
+    appendFeatureDesc(wrapper, 'language');
     const langOpts = currentBackgroundData.languages.options?.length
       ? currentBackgroundData.languages.options
       : DATA.languages || [];
@@ -221,7 +230,7 @@ function selectBackground(bg) {
 
   if (currentBackgroundData.featOptions && currentBackgroundData.featOptions.length) {
     const wrapper = document.createElement('div');
-    appendEntries(wrapper, currentBackgroundData.entries);
+    appendFeatureDesc(wrapper, 'feat');
     const sel = document.createElement('select');
     sel.innerHTML = `<option value=''>${t('selectFeat') || 'Select feat'}</option>`;
     currentBackgroundData.featOptions.forEach((f) => {

--- a/src/ui-helpers.js
+++ b/src/ui-helpers.js
@@ -11,11 +11,15 @@ export function createElement(tag, text) {
 export function appendEntries(container, entries) {
   (entries || []).forEach(e => {
     if (!e) return;
-    const text =
-      typeof e === 'string'
-        ? e
-        : e.entry || e.description || e.name || '';
-    if (text) container.appendChild(createElement('p', text));
+    if (typeof e === 'string') {
+      container.appendChild(createElement('p', e));
+    } else if (typeof e === 'object') {
+      if (e.description) container.appendChild(createElement('p', e.description));
+      if (typeof e.entry === 'string') container.appendChild(createElement('p', e.entry));
+      if (Array.isArray(e.entries)) appendEntries(container, e.entries);
+      else if (e.name && !e.entry && !e.entries && !e.description)
+        container.appendChild(createElement('p', e.name));
+    }
   });
 }
 


### PR DESCRIPTION
## Summary
- Show full descriptions and entries for class feature choices
- Display race trait descriptions alongside selectors
- Include background and feat descriptions before choice selectors

## Testing
- `npm test` *(fails: altered.json missing selection metadata for: size ... Race validation failed.)*


------
https://chatgpt.com/codex/tasks/task_e_68b2ab35e460832e81c9a3b1cee9360d