### PR TITLE
Support race tool proficiency choices

### DIFF
--- a/__tests__/step3.test.js
+++ b/__tests__/step3.test.js
@@ -26,7 +26,7 @@ jest.unstable_mockModule('../src/data.js', () => ({
         cha: { value: 8 },
       },
     },
-    raceChoices: { spells: [], spellAbility: '', size: '' },
+    raceChoices: { spells: [], spellAbility: '', size: '', tools: [] },
     bonusAbilities: {
       str: 0,
       dex: 0,
@@ -176,7 +176,7 @@ describe('race size selection', () => {
 
   afterEach(() => {
     CharacterState.system.details = {};
-    CharacterState.raceChoices = { spells: [], spellAbility: '', size: '' };
+    CharacterState.raceChoices = { spells: [], spellAbility: '', size: '', tools: [] };
   });
 
   test('requires selecting size when multiple options', async () => {
@@ -241,6 +241,51 @@ describe('Aarakocra selections', () => {
     await new Promise((r) => setTimeout(r, 0));
     expect(await confirmStep()).toBe(true);
     expect(isStepComplete()).toBe(true);
+  });
+});
+
+describe('race tool proficiency choices', () => {
+  beforeEach(() => {
+    document.body.innerHTML = `
+      <div id="raceList"></div>
+      <div id="raceFeatures"></div>
+    `;
+    DATA.races = {
+      Gith: [{ name: 'Githyanki', path: 'gith' }],
+    };
+    const race = {
+      name: 'Githyanki',
+      entries: [],
+      toolProficiencies: [
+        { any: 1 },
+        { choose: { from: ["smith's tools", "brewer's supplies"] } },
+      ],
+    };
+    mockFetch.mockImplementation(() => Promise.resolve(race));
+    CharacterState.system.details = {};
+    CharacterState.raceChoices = { spells: [], spellAbility: '', size: '', tools: [] };
+    CharacterState.system.tools = [];
+  });
+
+  test('requires selecting tools and applies choices', async () => {
+    await selectBaseRace('Gith');
+    document.querySelector('#raceList .class-card').click();
+    await new Promise((r) => setTimeout(r, 0));
+    const selects = document.querySelectorAll('#raceFeatures select');
+    expect(selects.length).toBe(2);
+    expect(await confirmStep()).toBe(false);
+    selects[0].value = "Thieves' Tools";
+    selects[0].dispatchEvent(new Event('change'));
+    selects[1].value = "Smith's Tools";
+    selects[1].dispatchEvent(new Event('change'));
+    await new Promise((r) => setTimeout(r, 0));
+    expect(await confirmStep()).toBe(true);
+    expect(CharacterState.system.tools).toEqual(
+      expect.arrayContaining(["Thieves' Tools", "Smith's Tools"])
+    );
+    expect(CharacterState.raceChoices.tools).toEqual(
+      expect.arrayContaining(["Thieves' Tools", "Smith's Tools"])
+    );
   });
 });
 
@@ -371,7 +416,7 @@ describe('duplicate proficiency replacement', () => {
     };
     DATA.languages = ['Common', 'Dwarvish'];
     CharacterState.system.details = {};
-    CharacterState.raceChoices = { spells: [], spellAbility: '', size: '' };
+    CharacterState.raceChoices = { spells: [], spellAbility: '', size: '', tools: [] };
     CharacterState.system.traits.languages.value = ['Elvish'];
     const race = {
       name: 'Elf (High)',
@@ -413,11 +458,12 @@ describe('change race cleanup', () => {
       entries: [],
       skillProficiencies: [{ survival: true }],
       languageProficiencies: [{ draconic: true }],
+      toolProficiencies: [{ "tinker's tools": true }],
       speed: { swim: 30 },
       ability: [{ str: 2 }],
     };
     CharacterState.system.details = {};
-    CharacterState.raceChoices = { spells: [], spellAbility: '', size: '' };
+    CharacterState.raceChoices = { spells: [], spellAbility: '', size: '', tools: [] };
     CharacterState.system.skills = [];
     CharacterState.system.traits.languages.value = [];
     CharacterState.system.attributes = {};
@@ -439,6 +485,7 @@ describe('change race cleanup', () => {
     expect(CharacterState.system.skills).toContain('Survival');
     expect(CharacterState.system.traits.languages.value).toContain('Draconic');
     expect(CharacterState.system.attributes.movement.swim).toBe(30);
+    expect(CharacterState.system.tools).toContain("Tinker's Tools");
 
     // Changing race should remove metadata but leave abilities unchanged
     document.getElementById('changeRace').click();
@@ -449,6 +496,7 @@ describe('change race cleanup', () => {
     expect(CharacterState.system.skills).not.toContain('Survival');
     expect(CharacterState.system.traits.languages.value).not.toContain('Draconic');
     expect(CharacterState.system.attributes.movement.swim).toBeUndefined();
+    expect(CharacterState.system.tools).not.toContain("Tinker's Tools");
     expect(refreshBaseState).toHaveBeenCalled();
     expect(rebuildFromClasses).toHaveBeenCalled();
   });
@@ -473,7 +521,7 @@ describe('race skill proficiency choices', () => {
       skillProficiencies: [{ any: 1 }],
     };
     CharacterState.system.details = {};
-    CharacterState.raceChoices = { spells: [], spellAbility: '', size: '' };
+    CharacterState.raceChoices = { spells: [], spellAbility: '', size: '', tools: [] };
     CharacterState.system.skills = [];
     mockFetch.mockImplementation(() => Promise.resolve(race));
   });

--- a/src/data.js
+++ b/src/data.js
@@ -173,7 +173,7 @@ export const CharacterState = {
   feats: [],
   equipment: [],
   knownSpells: {},
-    raceChoices: { spells: [], spellAbility: '', size: '', alterations: {} },
+    raceChoices: { spells: [], spellAbility: '', size: '', alterations: {}, tools: [] },
   bonusAbilities: {
     str: 0,
     dex: 0,

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -57,5 +57,6 @@
   "selectionRequired": "Selection required",
   "languageAlreadyKnown": "Language already known",
   "skillAlreadyKnown": "Skill already known",
+  "toolAlreadyKnown": "Tool already known",
   "selectionsMustBeUnique": "Selections must be unique"
 }

--- a/src/i18n/it.json
+++ b/src/i18n/it.json
@@ -57,5 +57,6 @@
   "selectionRequired": "Selezione obbligatoria",
   "languageAlreadyKnown": "Lingua già conosciuta",
   "skillAlreadyKnown": "Abilità già conosciuta",
+  "toolAlreadyKnown": "Strumento già conosciuto",
   "selectionsMustBeUnique": "Le selezioni devono essere uniche"
 }

--- a/src/step3.js
+++ b/src/step3.js
@@ -13,6 +13,7 @@ import {
   addUniqueProficiency,
   pendingReplacements,
   ALL_SKILLS,
+  ALL_TOOLS,
 } from './proficiency.js';
 import {
   createAccordionItem,
@@ -30,6 +31,7 @@ const pendingRaceChoices = {
   languages: [],
   spells: [],
   abilities: [],
+  tools: [],
   size: null,
   alterations: { combo: null, minor: [], major: [] },
 };
@@ -42,6 +44,7 @@ function validateRaceChoices() {
     ...pendingRaceChoices.languages,
     ...pendingRaceChoices.spells,
     ...pendingRaceChoices.abilities,
+    ...pendingRaceChoices.tools,
     ...(pendingRaceChoices.alterations?.minor || []),
     ...(pendingRaceChoices.alterations?.major || []),
   ];
@@ -74,6 +77,7 @@ function validateRaceChoices() {
     ...(CharacterState.system.traits.languages.value || []),
   ]);
   const existingSkills = new Set([...(CharacterState.system.skills || [])]);
+  const existingTools = new Set([...(CharacterState.system.tools || [])]);
   if (currentRaceData?.skillProficiencies) {
     currentRaceData.skillProficiencies.forEach((obj) => {
       for (const k in obj) {
@@ -82,10 +86,19 @@ function validateRaceChoices() {
       }
     });
   }
+  if (currentRaceData?.toolProficiencies) {
+    currentRaceData.toolProficiencies.forEach((obj) => {
+      for (const k in obj) {
+        if (k !== 'choose' && k !== 'any' && obj[k])
+          existingTools.add(capitalize(k));
+      }
+    });
+  }
 
   const duplicateSet = new Set();
   const languageDupSet = new Set();
   const skillDupSet = new Set();
+  const toolDupSet = new Set();
 
   choiceSelects.forEach((s) => {
     if (s.value && counts[s.value] > 1) duplicateSet.add(s);
@@ -108,6 +121,12 @@ function validateRaceChoices() {
       skillDupSet.add(s);
     }
   });
+  pendingRaceChoices.tools.forEach((s) => {
+    if (s.value && existingTools.has(s.value)) {
+      duplicateSet.add(s);
+      toolDupSet.add(s);
+    }
+  });
 
   const duplicates = Array.from(duplicateSet);
   duplicates.forEach((s) => {
@@ -116,6 +135,8 @@ function validateRaceChoices() {
       ? t('languageAlreadyKnown')
       : skillDupSet.has(s)
       ? t('skillAlreadyKnown')
+      : toolDupSet.has(s)
+      ? t('toolAlreadyKnown')
       : t('selectionsMustBeUnique');
   });
 
@@ -197,6 +218,7 @@ async function selectBaseRace(base) {
   pendingRaceChoices.languages = [];
   pendingRaceChoices.spells = [];
   pendingRaceChoices.abilities = [];
+  pendingRaceChoices.tools = [];
   pendingRaceChoices.size = null;
   pendingRaceChoices.alterations = { combo: null, minor: [], major: [] };
   const traits = document.getElementById('raceTraits');
@@ -246,6 +268,7 @@ async function renderSelectedRace() {
   pendingRaceChoices.languages = [];
   pendingRaceChoices.spells = [];
   pendingRaceChoices.abilities = [];
+  pendingRaceChoices.tools = [];
   pendingRaceChoices.size = null;
   pendingRaceChoices.alterations = { combo: null, minor: [], major: [] };
 
@@ -365,6 +388,76 @@ async function renderSelectedRace() {
           `${t('skills')}`,
           skillContent,
           pendingRaceChoices.skills.length > 0
+        )
+      );
+    }
+  }
+  if (currentRaceData.toolProficiencies) {
+    const raceTools = [];
+    let pendingAny = 0;
+    const chooseGroups = [];
+    currentRaceData.toolProficiencies.forEach((obj) => {
+      if (typeof obj.any === 'number') pendingAny += obj.any;
+      else if (obj.choose) {
+        const from = obj.choose.from || obj.choose.options || [];
+        const count = obj.choose.count || obj.choose.amount || 1;
+        chooseGroups.push({ from, count });
+      } else {
+        for (const k in obj) if (obj[k]) raceTools.push(capitalize(k));
+      }
+    });
+    if (raceTools.length || pendingAny > 0 || chooseGroups.length) {
+      const toolContent = document.createElement('div');
+      if (raceTools.length) {
+        const p = document.createElement('p');
+        p.textContent = raceTools.join(', ');
+        toolContent.appendChild(p);
+      }
+      const known = new Set([
+        ...(CharacterState.system.tools || []),
+        ...raceTools,
+      ]);
+      for (let i = 0; i < pendingAny; i++) {
+        const sel = document.createElement('select');
+        sel.innerHTML = `<option value=''>${t('select')}</option>`;
+        ALL_TOOLS.filter((tl) => !known.has(tl)).forEach((tl) => {
+          const o = document.createElement('option');
+          o.value = tl;
+          o.textContent = tl;
+          sel.appendChild(o);
+        });
+        sel.dataset.type = 'choice';
+        sel.dataset.choice = 'tool';
+        sel.addEventListener('change', validateRaceChoices);
+        toolContent.appendChild(sel);
+        pendingRaceChoices.tools.push(sel);
+      }
+      chooseGroups.forEach((grp) => {
+        const opts = (grp.from || []).map((s) => capitalize(s));
+        const count = grp.count || 1;
+        for (let i = 0; i < count; i++) {
+          const sel = document.createElement('select');
+          sel.innerHTML = `<option value=''>${t('select')}</option>`;
+          opts
+            .filter((opt) => !known.has(opt))
+            .forEach((opt) => {
+              const o = document.createElement('option');
+              o.value = opt;
+              o.textContent = opt;
+              sel.appendChild(o);
+            });
+          sel.dataset.type = 'choice';
+          sel.dataset.choice = 'tool';
+          sel.addEventListener('change', validateRaceChoices);
+          toolContent.appendChild(sel);
+          pendingRaceChoices.tools.push(sel);
+        }
+      });
+      accordion.appendChild(
+        createAccordionItem(
+          `${t('tools')}`,
+          toolContent,
+          pendingRaceChoices.tools.length > 0
         )
       );
     }
@@ -757,6 +850,36 @@ function confirmRaceSelection() {
     CharacterState.raceChoices.skills.push(sel.value);
     sel.disabled = true;
   });
+  if (currentRaceData.toolProficiencies) {
+    currentRaceData.toolProficiencies.forEach((obj) => {
+      for (const k in obj)
+        if (k !== 'any' && k !== 'choose' && obj[k]) {
+          const val = capitalize(k);
+          const sel = addUniqueProficiency('tools', val, container);
+          if (sel) {
+            sel.dataset.proftype = 'tools';
+            replacements.push(sel);
+          } else {
+            CharacterState.raceChoices.tools =
+              CharacterState.raceChoices.tools || [];
+            CharacterState.raceChoices.tools.push(val);
+          }
+        }
+    });
+  }
+  pendingRaceChoices.tools.forEach((sel) => {
+    const repl = addUniqueProficiency('tools', sel.value, container);
+    if (repl) {
+      repl.dataset.proftype = 'tools';
+      replacements.push(repl);
+    }
+    if (!CharacterState.system.tools.includes(sel.value))
+      CharacterState.system.tools.push(sel.value);
+    CharacterState.raceChoices.tools =
+      CharacterState.raceChoices.tools || [];
+    CharacterState.raceChoices.tools.push(sel.value);
+    sel.disabled = true;
+  });
   if (currentRaceData.languageProficiencies) {
     currentRaceData.languageProficiencies.forEach((obj) => {
       for (const k in obj)
@@ -828,6 +951,7 @@ function confirmRaceSelection() {
   pendingRaceChoices.languages = [];
   pendingRaceChoices.spells = [];
   pendingRaceChoices.abilities = [];
+  pendingRaceChoices.tools = [];
   pendingRaceChoices.size = null;
   pendingRaceChoices.alterations = { combo: null, minor: [], major: [] };
   refreshBaseState();
@@ -920,6 +1044,7 @@ export async function loadStep3(force = false) {
     pendingRaceChoices.languages = [];
     pendingRaceChoices.spells = [];
     pendingRaceChoices.abilities = [];
+    pendingRaceChoices.tools = [];
     pendingRaceChoices.size = null;
     pendingRaceChoices.alterations = { combo: null, minor: [], major: [] };
     if (CharacterState.system?.details) {


### PR DESCRIPTION
## Summary
- Parse race tool proficiencies including `any` and `choose` patterns
- Let users pick tool proficiencies during race selection and store them
- Apply and reset race tool choices in character state

## Testing
- `npm run validate:races` *(fails: altered.json missing selection metadata for: size, changeling.json missing selection metadata for: size, dhampir.json missing selection metadata for: size, elfsea.json missing selection metadata for: languageProficiencies, genasiair.json missing selection metadata for: size, genasiearth.json missing selection metadata for: size, genasifire.json missing selection metadata for: size, genasiwater.json missing selection metadata for: size, harengon.json missing selection metadata for: size, hexblood.json missing selection metadata for: size, Race validation failed.)*
- `node --experimental-vm-modules ./node_modules/jest/bin/jest.js`


------
https://chatgpt.com/codex/tasks/task_e_68b2acd8ff50832e81bc215b5e8dd000