### PR TITLE
Add selectable race damage resistance

### DIFF
--- a/__tests__/step3.test.js
+++ b/__tests__/step3.test.js
@@ -13,7 +13,7 @@ jest.unstable_mockModule('../src/data.js', () => ({
     system: {
       spells: { cantrips: [] },
       details: {},
-      traits: { languages: { value: [] } },
+      traits: { languages: { value: [] }, damageResist: [] },
       attributes: {},
       skills: [],
       tools: [],
@@ -26,7 +26,7 @@ jest.unstable_mockModule('../src/data.js', () => ({
         cha: { value: 8 },
       },
     },
-    raceChoices: { spells: [], spellAbility: '', size: '' },
+    raceChoices: { spells: [], spellAbility: '', size: '', resist: '' },
     bonusAbilities: {
       str: 0,
       dex: 0,
@@ -176,7 +176,8 @@ describe('race size selection', () => {
 
   afterEach(() => {
     CharacterState.system.details = {};
-    CharacterState.raceChoices = { spells: [], spellAbility: '', size: '' };
+    CharacterState.system.traits.damageResist = [];
+    CharacterState.raceChoices = { spells: [], spellAbility: '', size: '', resist: '' };
   });
 
   test('requires selecting size when multiple options', async () => {
@@ -195,6 +196,46 @@ describe('race size selection', () => {
   });
 });
 
+describe('race damage resistance selection', () => {
+  beforeEach(() => {
+    document.body.innerHTML = `
+      <div id="raceList"></div>
+      <div id="raceFeatures"></div>
+      <button id="confirmRaceSelection"></button>
+    `;
+    DATA.races = {
+      Dragonborn: [{ name: 'Dragonborn', path: 'dragonborn' }],
+    };
+    const race = {
+      name: 'Dragonborn',
+      entries: [],
+      resist: [{ choose: { from: ['fire', 'cold'] } }],
+    };
+    mockFetch.mockImplementation(() => Promise.resolve(race));
+  });
+
+  afterEach(() => {
+    CharacterState.system.details = {};
+    CharacterState.system.traits.damageResist = [];
+    CharacterState.raceChoices = { spells: [], spellAbility: '', size: '', resist: '' };
+  });
+
+  test('requires selecting damage type and applies result', async () => {
+    await selectBaseRace('Dragonborn');
+    const card = document.querySelector('#raceList .class-card');
+    card.click();
+    await new Promise((r) => setTimeout(r, 0));
+    expect(await confirmStep()).toBe(false);
+    const sel = document.querySelector('#raceFeatures select');
+    sel.value = 'fire';
+    sel.dispatchEvent(new Event('change'));
+    await new Promise((r) => setTimeout(r, 0));
+    expect(await confirmStep()).toBe(true);
+    expect(CharacterState.raceChoices.resist).toBe('fire');
+    expect(CharacterState.system.traits.damageResist).toContain('fire');
+  });
+});
+
 describe('Aarakocra selections', () => {
   beforeEach(() => {
     document.body.innerHTML = `
@@ -205,6 +246,9 @@ describe('Aarakocra selections', () => {
       Aarakocra: [{ name: 'Aarakocra', path: 'aarakocra' }],
     };
     DATA.languages = [];
+    CharacterState.system.details = {};
+    CharacterState.raceChoices = { spells: [], spellAbility: '', size: '', resist: '' };
+    CharacterState.system.traits.damageResist = [];
     const race = {
       name: 'Aarakocra',
       entries: [],
@@ -371,7 +415,8 @@ describe('duplicate proficiency replacement', () => {
     };
     DATA.languages = ['Common', 'Dwarvish'];
     CharacterState.system.details = {};
-    CharacterState.raceChoices = { spells: [], spellAbility: '', size: '' };
+    CharacterState.system.traits.damageResist = [];
+    CharacterState.raceChoices = { spells: [], spellAbility: '', size: '', resist: '' };
     CharacterState.system.traits.languages.value = ['Elvish'];
     const race = {
       name: 'Elf (High)',
@@ -417,7 +462,8 @@ describe('change race cleanup', () => {
       ability: [{ str: 2 }],
     };
     CharacterState.system.details = {};
-    CharacterState.raceChoices = { spells: [], spellAbility: '', size: '' };
+    CharacterState.system.traits.damageResist = [];
+    CharacterState.raceChoices = { spells: [], spellAbility: '', size: '', resist: '' };
     CharacterState.system.skills = [];
     CharacterState.system.traits.languages.value = [];
     CharacterState.system.attributes = {};
@@ -473,7 +519,8 @@ describe('race skill proficiency choices', () => {
       skillProficiencies: [{ any: 1 }],
     };
     CharacterState.system.details = {};
-    CharacterState.raceChoices = { spells: [], spellAbility: '', size: '' };
+    CharacterState.system.traits.damageResist = [];
+    CharacterState.raceChoices = { spells: [], spellAbility: '', size: '', resist: '' };
     CharacterState.system.skills = [];
     mockFetch.mockImplementation(() => Promise.resolve(race));
   });

--- a/src/data.js
+++ b/src/data.js
@@ -173,7 +173,7 @@ export const CharacterState = {
   feats: [],
   equipment: [],
   knownSpells: {},
-    raceChoices: { spells: [], spellAbility: '', size: '', alterations: {} },
+  raceChoices: { spells: [], spellAbility: '', size: '', alterations: {}, resist: '' },
   bonusAbilities: {
     str: 0,
     dex: 0,
@@ -212,6 +212,7 @@ export const CharacterState = {
       size: "med",
       senses: { darkvision: 0 },
       languages: { value: [] },
+      damageResist: [],
     },
     // Resource pools closely matching the structure used by Foundry's
     // dnd5e system.  Each resource tracks a label, current and maximum

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -57,5 +57,6 @@
   "selectionRequired": "Selection required",
   "languageAlreadyKnown": "Language already known",
   "skillAlreadyKnown": "Skill already known",
-  "selectionsMustBeUnique": "Selections must be unique"
+  "selectionsMustBeUnique": "Selections must be unique",
+  "damageResist": "Damage Resistance"
 }

--- a/src/i18n/it.json
+++ b/src/i18n/it.json
@@ -57,5 +57,6 @@
   "selectionRequired": "Selezione obbligatoria",
   "languageAlreadyKnown": "Lingua già conosciuta",
   "skillAlreadyKnown": "Abilità già conosciuta",
-  "selectionsMustBeUnique": "Le selezioni devono essere uniche"
+  "selectionsMustBeUnique": "Le selezioni devono essere uniche",
+  "damageResist": "Resistenza ai danni"
 }

--- a/src/step3.js
+++ b/src/step3.js
@@ -31,6 +31,7 @@ const pendingRaceChoices = {
   spells: [],
   abilities: [],
   size: null,
+  resist: null,
   alterations: { combo: null, minor: [], major: [] },
 };
 
@@ -47,6 +48,7 @@ function validateRaceChoices() {
   ];
   const allSelects = [...choiceSelects];
   if (pendingRaceChoices.size) allSelects.push(pendingRaceChoices.size);
+  if (pendingRaceChoices.resist) allSelects.push(pendingRaceChoices.resist);
   if (pendingRaceChoices.alterations?.combo)
     allSelects.push(pendingRaceChoices.alterations.combo);
 
@@ -198,6 +200,7 @@ async function selectBaseRace(base) {
   pendingRaceChoices.spells = [];
   pendingRaceChoices.abilities = [];
   pendingRaceChoices.size = null;
+  pendingRaceChoices.resist = null;
   pendingRaceChoices.alterations = { combo: null, minor: [], major: [] };
   const traits = document.getElementById('raceTraits');
   if (traits) traits.innerHTML = '';
@@ -247,6 +250,7 @@ async function renderSelectedRace() {
   pendingRaceChoices.spells = [];
   pendingRaceChoices.abilities = [];
   pendingRaceChoices.size = null;
+  pendingRaceChoices.resist = null;
   pendingRaceChoices.alterations = { combo: null, minor: [], major: [] };
 
   const header = document.createElement('h3');
@@ -423,6 +427,52 @@ async function renderSelectedRace() {
       }
       accordion.appendChild(
         createAccordionItem(t('languages'), langContent, pendingLang > 0)
+      );
+    }
+  }
+
+  if (Array.isArray(currentRaceData.resist) && currentRaceData.resist.length) {
+    const fixed = [];
+    let chooseOpts = null;
+    currentRaceData.resist.forEach((r) => {
+      if (typeof r === 'string') fixed.push(capitalize(r));
+      else if (r.choose) chooseOpts = r.choose.from || [];
+    });
+    if (fixed.length || chooseOpts) {
+      const resistContent = document.createElement('div');
+      const resistEntry = Object.values(entryMap).find(
+        (e) => e.name && /resist/i.test(e.name)
+      );
+      if (resistEntry) {
+        if (resistEntry.description)
+          resistContent.appendChild(createElement('p', resistEntry.description));
+        appendEntries(resistContent, resistEntry.entries);
+        usedEntries.add(resistEntry.name);
+      }
+      if (fixed.length) {
+        resistContent.appendChild(createElement('p', fixed.join(', ')));
+      }
+      if (Array.isArray(chooseOpts) && chooseOpts.length) {
+        const sel = document.createElement('select');
+        sel.innerHTML = `<option value=''>${t('select')}</option>`;
+        chooseOpts.forEach((opt) => {
+          const o = document.createElement('option');
+          o.value = opt;
+          o.textContent = capitalize(opt);
+          sel.appendChild(o);
+        });
+        sel.dataset.type = 'choice';
+        sel.dataset.choice = 'resist';
+        sel.addEventListener('change', validateRaceChoices);
+        resistContent.appendChild(sel);
+        pendingRaceChoices.resist = sel;
+      }
+      accordion.appendChild(
+        createAccordionItem(
+          t('damageResist'),
+          resistContent,
+          !!pendingRaceChoices.resist
+        )
       );
     }
   }
@@ -787,6 +837,24 @@ function confirmRaceSelection() {
     CharacterState.raceChoices.languages.push(sel.value);
     sel.disabled = true;
   });
+  if (Array.isArray(currentRaceData.resist)) {
+    const resists = [];
+    currentRaceData.resist.forEach((r) => {
+      if (typeof r === 'string') resists.push(r);
+    });
+    if (pendingRaceChoices.resist && pendingRaceChoices.resist.value) {
+      resists.push(pendingRaceChoices.resist.value);
+      CharacterState.raceChoices.resist = pendingRaceChoices.resist.value;
+      pendingRaceChoices.resist.disabled = true;
+    } else {
+      CharacterState.raceChoices.resist = '';
+    }
+    if (resists.length) {
+      const set = new Set(CharacterState.system.traits.damageResist || []);
+      resists.forEach((r) => set.add(r));
+      CharacterState.system.traits.damageResist = Array.from(set);
+    }
+  }
   pendingRaceChoices.spells.forEach((sel) => {
     const repl = addUniqueProficiency('cantrips', sel.value, container);
     if (repl) replacements.push(repl);
@@ -829,6 +897,7 @@ function confirmRaceSelection() {
   pendingRaceChoices.spells = [];
   pendingRaceChoices.abilities = [];
   pendingRaceChoices.size = null;
+  pendingRaceChoices.resist = null;
   pendingRaceChoices.alterations = { combo: null, minor: [], major: [] };
   refreshBaseState();
   rebuildFromClasses();
@@ -911,6 +980,17 @@ export async function loadStep3(force = false) {
       CharacterState.raceChoices.spells = [];
       CharacterState.raceChoices.spellAbility = '';
       CharacterState.raceChoices.size = '';
+      const removeRes = [];
+      (currentRaceData.resist || []).forEach((r) => {
+        if (typeof r === 'string') removeRes.push(r);
+      });
+      if (CharacterState.raceChoices.resist)
+        removeRes.push(CharacterState.raceChoices.resist);
+      CharacterState.system.traits.damageResist =
+        (CharacterState.system.traits.damageResist || []).filter(
+          (r) => !removeRes.includes(r)
+        );
+      CharacterState.raceChoices.resist = '';
       CharacterState.raceChoices.alterations = {};
     }
     selectedBaseRace = '';
@@ -921,6 +1001,7 @@ export async function loadStep3(force = false) {
     pendingRaceChoices.spells = [];
     pendingRaceChoices.abilities = [];
     pendingRaceChoices.size = null;
+    pendingRaceChoices.resist = null;
     pendingRaceChoices.alterations = { combo: null, minor: [], major: [] };
     if (CharacterState.system?.details) {
       CharacterState.system.details.race = '';


### PR DESCRIPTION
## Summary
- support damage resistance choices in race selection
- persist chosen resistance and apply to actor traits
- cover selection flow with tests and translations

## Testing
- `npm test` *(fails: missing selection metadata for several races)*
- `node --experimental-vm-modules ./node_modules/jest/bin/jest.js`

------
https://chatgpt.com/codex/tasks/task_e_68b2acdf1ad8832e8e468e9989dce6dc