### PR TITLE
Support race alteration selection with limits

### DIFF
--- a/data/races/altered.json
+++ b/data/races/altered.json
@@ -28,35 +28,37 @@
   "languageProficiencies": [
     { "common": true, "anyStandard": 1 }
   ],
-  "minorAlterations": [
-    "Aquatic Adaptation",
-    "Altered Metabolism",
-    "Darkvision",
-    "Fleet of Foot",
-    "Glider",
-    "Natural Weapon",
-    "Nimble Climber",
-    "Mutated Eyes",
-    "Silent Speech",
-    "Skilled",
-    "Strong-Minded",
-    "Supernatural Resistance"
-  ],
-  "majorAlterations": [
-    "Amorphous",
-    "Augmented Toughness",
-    "Blind Sense",
-    "Magical Affinity",
-    "Massive Build",
-    "Painful Regeneration",
-    "Secondary Arms",
-    "Shapechanger",
-    "Unnatural Armor"
-  ],
-  "alterationCombinations": [
-    { "minor": 3 },
-    { "minor": 2, "major": 1 }
-  ],
+  "minorAlterations": {
+    "allowed": [3, 2],
+    "options": [
+      "Aquatic Adaptation",
+      "Altered Metabolism",
+      "Darkvision",
+      "Fleet of Foot",
+      "Glider",
+      "Natural Weapon",
+      "Nimble Climber",
+      "Mutated Eyes",
+      "Silent Speech",
+      "Skilled",
+      "Strong-Minded",
+      "Supernatural Resistance"
+    ]
+  },
+  "majorAlterations": {
+    "allowed": [0, 1],
+    "options": [
+      "Amorphous",
+      "Augmented Toughness",
+      "Blind Sense",
+      "Magical Affinity",
+      "Massive Build",
+      "Painful Regeneration",
+      "Secondary Arms",
+      "Shapechanger",
+      "Unnatural Armor"
+    ]
+  },
   "entries": [
     {
       "name": "Size",

--- a/src/step3.js
+++ b/src/step3.js
@@ -428,13 +428,23 @@ async function renderSelectedRace() {
   }
 
   if (
-    currentRaceData.minorAlterations?.length ||
-    currentRaceData.majorAlterations?.length
+    currentRaceData.minorAlterations?.options?.length ||
+    currentRaceData.majorAlterations?.options?.length
   ) {
     const alterContent = document.createElement('div');
     const comboSel = document.createElement('select');
     comboSel.innerHTML = `<option value=''>${t('select')}</option>`;
-    (currentRaceData.alterationCombinations || []).forEach((combo, idx) => {
+    const minorAllowed = currentRaceData.minorAlterations?.allowed || [];
+    const majorAllowed = currentRaceData.majorAlterations?.allowed || [];
+    const combos = [];
+    const len = Math.max(minorAllowed.length, majorAllowed.length);
+    for (let i = 0; i < len; i++) {
+      combos.push({
+        minor: minorAllowed[i] || 0,
+        major: majorAllowed[i] || 0,
+      });
+    }
+    combos.forEach((combo, idx) => {
       const parts = [];
       if (combo.minor) parts.push(`${combo.minor} Minor`);
       if (combo.major) parts.push(`${combo.major} Major`);
@@ -448,8 +458,7 @@ async function renderSelectedRace() {
       pendingRaceChoices.alterations.major = [];
       while (comboSel.nextSibling)
         comboSel.parentNode.removeChild(comboSel.nextSibling);
-      const combo =
-        (currentRaceData.alterationCombinations || [])[comboSel.value];
+      const combo = combos[comboSel.value];
       if (!combo) {
         validateRaceChoices();
         return;
@@ -457,7 +466,7 @@ async function renderSelectedRace() {
       for (let i = 0; i < (combo.minor || 0); i++) {
         const sel = document.createElement('select');
         sel.innerHTML = `<option value=''>${t('select')}</option>`;
-        (currentRaceData.minorAlterations || []).forEach((opt) => {
+        (currentRaceData.minorAlterations?.options || []).forEach((opt) => {
           const o = document.createElement('option');
           o.value = opt;
           o.textContent = opt;
@@ -471,7 +480,7 @@ async function renderSelectedRace() {
       for (let i = 0; i < (combo.major || 0); i++) {
         const sel = document.createElement('select');
         sel.innerHTML = `<option value=''>${t('select')}</option>`;
-        (currentRaceData.majorAlterations || []).forEach((opt) => {
+        (currentRaceData.majorAlterations?.options || []).forEach((opt) => {
           const o = document.createElement('option');
           o.value = opt;
           o.textContent = opt;
@@ -819,6 +828,14 @@ function confirmRaceSelection() {
     const p = document.createElement('p');
     p.textContent = `Alterations: ${chosen.join(', ')}`;
     container.appendChild(p);
+    const featureContainer = pendingRaceChoices.alterations.combo
+      ? pendingRaceChoices.alterations.combo.parentNode
+      : null;
+    if (featureContainer) {
+      const pf = document.createElement('p');
+      pf.textContent = `Alterations: ${chosen.join(', ')}`;
+      featureContainer.appendChild(pf);
+    }
   }
   if (pendingRaceChoices.size) {
     pendingRaceChoices.size.disabled = true;


### PR DESCRIPTION
## Summary
- Allow Altered race to define minor and major alterations with explicit counts
- Render alteration combo selections and persist chosen options
- Show selected alterations in race features accordion for confirmation

## Testing
- ⚠️ `npm test` (fails: altered.json missing selection metadata and other race validation errors)
- ✅ `node --experimental-vm-modules ./node_modules/jest/bin/jest.js`


------
https://chatgpt.com/codex/tasks/task_e_68b2acdfb668832e93a5f650d4b593af