### PR TITLE
Fix skill proficiency application for race choices

### DIFF
--- a/src/step3.js
+++ b/src/step3.js
@@ -729,19 +729,19 @@ function confirmRaceSelection() {
   const replacements = [];
   if (currentRaceData.skillProficiencies) {
     currentRaceData.skillProficiencies.forEach((obj) => {
-      for (const k in obj)
-        if (obj[k]) {
-          const val = capitalize(k);
-          const sel = addUniqueProficiency('skills', val, container);
-          if (sel) {
-            sel.dataset.proftype = 'skills';
-            replacements.push(sel);
-          } else {
-            CharacterState.raceChoices.skills =
-              CharacterState.raceChoices.skills || [];
-            CharacterState.raceChoices.skills.push(val);
-          }
+      for (const k in obj) {
+        if (k === 'choose' || k === 'any' || !obj[k]) continue;
+        const val = capitalize(k);
+        const sel = addUniqueProficiency('skills', val, container);
+        if (sel) {
+          sel.dataset.proftype = 'skills';
+          replacements.push(sel);
+        } else {
+          CharacterState.raceChoices.skills =
+            CharacterState.raceChoices.skills || [];
+          CharacterState.raceChoices.skills.push(val);
         }
+      }
     });
   }
   pendingRaceChoices.skills.forEach((sel) => {


### PR DESCRIPTION
## Summary
- ignore `any` and `choose` placeholders when applying race skill proficiencies

## Testing
- `npm test` *(fails: Race validation failed)*

------
https://chatgpt.com/codex/tasks/task_e_68b425551ea8832eb83ded62869bcf14