### PR TITLE
Remove duplicate featRenderer reset in background change handler

### DIFF
--- a/src/step4.js
+++ b/src/step4.js
@@ -421,7 +421,6 @@ export function loadStep4(force = false) {
     pendingSelections.languages = [];
     pendingSelections.feat = null;
     pendingSelections.featRenderer = null;
-    pendingSelections.featRenderer = null;
     const list = document.getElementById('backgroundList');
     list?.classList.remove('hidden');
     const search = document.getElementById('backgroundSearch');


### PR DESCRIPTION
## Summary
- Remove redundant `pendingSelections.featRenderer` assignment in Step 4 background change handler

## Testing
- `npm test` *(fails: Race validation failed)*

------
https://chatgpt.com/codex/tasks/task_e_68b42cb968ac832eba1ddae8bc38143c