### PR TITLE
Use fetchJsonWithRetry for equipment loading

### DIFF
--- a/__tests__/equipment.test.js
+++ b/__tests__/equipment.test.js
@@ -17,9 +17,9 @@ describe('equipment rendering', () => {
     );
     global.fetch = (filePath) => {
       if (filePath === 'data/equipment.json') {
-        return Promise.resolve({ json: () => Promise.resolve(equipment) });
+        return Promise.resolve({ ok: true, json: () => Promise.resolve(equipment) });
       }
-      return Promise.resolve({ json: () => Promise.resolve({}) });
+      return Promise.resolve({ ok: true, json: () => Promise.resolve({}) });
     };
     document.body.innerHTML = '<div id="equipmentSelections"></div><button id="confirmEquipment"></button>';
     CharacterState.classes = [{ name: 'Artificer', level: 1 }];

--- a/__tests__/step5.test.js
+++ b/__tests__/step5.test.js
@@ -17,20 +17,16 @@ const showStep = jest.fn();
 jest.unstable_mockModule('../src/main.js', () => ({ showStep }));
 
 const { loadStep5 } = await import('../src/step5.js');
-const { CharacterState } = await import('../src/data.js');
+const { CharacterState, fetchJsonWithRetry } = await import('../src/data.js');
 
 describe('step5 re-entry', () => {
   beforeEach(() => {
     document.body.innerHTML =
       '<div id="equipmentSelections"></div><button id="confirmEquipment"></button>';
-    global.fetch = () =>
-      Promise.resolve({
-        json: () =>
-          Promise.resolve({
-            standard: [],
-            classes: { Test: { fixed: [], choices: [] } }
-          })
-      });
+    fetchJsonWithRetry.mockResolvedValue({
+      standard: [],
+      classes: { Test: { fixed: [], choices: [] } },
+    });
     CharacterState.classes = [{ name: 'Test', level: 1 }];
     showStep.mockClear();
   });

--- a/src/step5.js
+++ b/src/step5.js
@@ -1,4 +1,4 @@
-import { DATA, CharacterState } from './data.js';
+import { DATA, CharacterState, fetchJsonWithRetry } from './data.js';
 import { t } from './i18n.js';
 import * as main from './main.js';
 import { createAccordionItem } from './ui-helpers.js';
@@ -29,16 +29,13 @@ function getSimpleWeapons() {
 
 async function loadEquipmentData() {
   if (!equipmentData) {
-    try {
-      const resp = await fetch('data/equipment.json');
-      if (resp.ok === false) throw new Error(resp.statusText || 'Failed to fetch');
-      equipmentData = await resp.json();
-    } catch (err) {
-      console.error(err);
-      const container = document.getElementById('equipmentSelections');
-      if (container) container.textContent = t('equipmentLoadError');
-      return null;
-    }
+    equipmentData = await fetchJsonWithRetry('data/equipment.json', 'equipment').catch(
+      () => {
+        const container = document.getElementById('equipmentSelections');
+        if (container) container.textContent = t('equipmentLoadError');
+        return null;
+      }
+    );
   }
   return equipmentData;
 }


### PR DESCRIPTION
## Summary
- refactor step5 equipment loading to use fetchJsonWithRetry with UI fallback
- adjust tests to mock fetchJsonWithRetry and align equipment fetch response

## Testing
- `npm test` *(fails: Race validation failed)*
- `node --experimental-vm-modules ./node_modules/jest/bin/jest.js`

------
https://chatgpt.com/codex/tasks/task_e_68b42cc290fc832e91ddf667b7becdcc