### PR TITLE
Prevent double-counting of ability bonuses

### DIFF
--- a/__tests__/asiFeatIntegration.test.js
+++ b/__tests__/asiFeatIntegration.test.js
@@ -55,5 +55,19 @@ describe('ASI and feat bonuses', () => {
     expect(document.getElementById('strRaceModifier').textContent).toBe('3');
     expect(document.getElementById('strFinalScore').textContent).toBe('13');
   });
+
+  test('rebuildFromClasses applies bonuses only once', () => {
+    CharacterState.feats = [{ name: 'TestFeat', ability: { str: 1 } }];
+    CharacterState.classes = [
+      { name: 'Fighter', level: 4, asiBonuses: { str: 2 } },
+    ];
+    refreshBaseState();
+    rebuildFromClasses();
+    expect(CharacterState.system.abilities.str.value).toBe(13);
+    refreshBaseState();
+    rebuildFromClasses();
+    expect(CharacterState.system.abilities.str.value).toBe(13);
+    expect(CharacterState.bonusAbilities.str).toBe(3);
+  });
 });
 

--- a/src/step2.js
+++ b/src/step2.js
@@ -53,7 +53,8 @@ function refreshBaseState() {
     ? CharacterState.feats.map(f => ({ ...f }))
     : [];
   for (const [ab, obj] of Object.entries(CharacterState.system.abilities)) {
-    baseState.abilities[ab] = obj.value || 0;
+    const bonus = CharacterState.bonusAbilities?.[ab] || 0;
+    baseState.abilities[ab] = (obj.value || 0) - bonus;
   }
 }
 


### PR DESCRIPTION
## Summary
- Track base ability scores without feat/ASI bonuses when snapshotting step 2 state
- Add regression test ensuring rebuilds don't apply bonuses multiple times

## Testing
- `npm test` *(fails: altered.json missing selection metadata for: size)*
- `node --experimental-vm-modules ./node_modules/jest/bin/jest.js`


------
https://chatgpt.com/codex/tasks/task_e_68b431818658832ebb16bc3538b4d762