### PR TITLE
feat: add feat spell selection support

### DIFF
--- a/src/step2.js
+++ b/src/step2.js
@@ -371,22 +371,26 @@ function handleASISelection(sel, container, entry, cls) {
       entry.featRenderer = null;
       featChoicesDiv.innerHTML = '';
       if (featSel.value) {
-        entry.featRenderer = await renderFeatChoices(featSel.value, featChoicesDiv);
+        const onFeatChange = () => {
+          if (entry.featRenderer?.isComplete()) {
+            entry.featRenderer.apply();
+            rebuildFromClasses();
+          }
+          updateStep2Completion();
+        };
+        entry.featRenderer = await renderFeatChoices(
+          featSel.value,
+          featChoicesDiv,
+          onFeatChange
+        );
         const all = [
           ...(entry.featRenderer.abilitySelects || []),
           ...(entry.featRenderer.skillSelects || []),
           ...(entry.featRenderer.toolSelects || []),
           ...(entry.featRenderer.languageSelects || []),
+          ...(entry.featRenderer.spellSelects || []),
         ];
-        all.forEach(s =>
-          s.addEventListener('change', () => {
-            if (entry.featRenderer.isComplete()) {
-              entry.featRenderer.apply();
-              rebuildFromClasses();
-            }
-            updateStep2Completion();
-          })
-        );
+        all.forEach((s) => s.addEventListener('change', onFeatChange));
       }
       compileClassFeatures(cls);
       rebuildFromClasses();

--- a/src/step4.js
+++ b/src/step4.js
@@ -257,14 +257,21 @@ function selectBackground(bg) {
       pendingSelections.featRenderer = null;
       featChoicesDiv.innerHTML = '';
       if (sel.value) {
-        pendingSelections.featRenderer = await renderFeatChoices(sel.value, featChoicesDiv);
+        pendingSelections.featRenderer = await renderFeatChoices(
+          sel.value,
+          featChoicesDiv,
+          validateBackgroundChoices
+        );
         const all = [
           ...(pendingSelections.featRenderer.abilitySelects || []),
           ...(pendingSelections.featRenderer.skillSelects || []),
           ...(pendingSelections.featRenderer.toolSelects || []),
-          ...(pendingSelections.featRenderer.languageSelects || [])
+          ...(pendingSelections.featRenderer.languageSelects || []),
+          ...(pendingSelections.featRenderer.spellSelects || []),
         ];
-        all.forEach((s) => s.addEventListener('change', validateBackgroundChoices));
+        all.forEach((s) =>
+          s.addEventListener('change', validateBackgroundChoices)
+        );
       }
       validateBackgroundChoices();
     });


### PR DESCRIPTION
## Summary
- handle feat.additionalSpells with class, cantrip, and level1 spell selects
- wire feat spell selections into background and class validation

## Testing
- `npm test` *(fails: Race validation failed)*

------
https://chatgpt.com/codex/tasks/task_e_68b43bb50edc832ea61b63555d846849