### PR TITLE
Show incomplete warning only on user-choice accordions

### DIFF
--- a/css/site-theme.css
+++ b/css/site-theme.css
@@ -310,7 +310,7 @@ th {
   padding: 0.5em;
 }
 
-.needs-selection.incomplete .accordion-header::before {
+.needs-selection.incomplete .accordion-item.user-choice > .accordion-header::before {
   content: "\26A0";
   color: #e74c3c;
   margin-right: 0.25em;


### PR DESCRIPTION
## Summary
- limit incomplete warning icon to accordion items with `user-choice` class

## Testing
- `npm test` *(fails: altered.json missing selection metadata for: size, changeling.json missing selection metadata for: size, dhampir.json missing selection metadata for: size, elfsea.json missing selection metadata for: languageProficiencies, genasiair.json missing selection metadata for: size, genasiearth.json missing selection metadata for: size, genasifire.json missing selection metadata for: size, genasiwater.json missing selection metadata for: size, harengon.json missing selection metadata for: size, hexblood.json missing selection metadata for: size)*
- manual DOM check verifying only `.user-choice` headers match the warning selector

------
https://chatgpt.com/codex/tasks/task_e_68b4592179a4832e8250ed2807f4971d