### PR TITLE
Warn when class choices incomplete before continuing

### DIFF
--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -78,6 +78,7 @@
   "selectThreeAbilities": "Select three abilities for bonus scores",
   "invalidBonusDistribution": "Invalid bonus distribution",
   "selectClassToProceed": "Select a class to proceed.",
+  "completeClassChoicesToProceed": "Complete class choices to proceed.",
   "selectRaceToProceed": "Select a race to proceed.",
   "selectBackgroundToProceed": "Select a background to proceed.",
   "chooseEquipmentToProceed": "Choose your equipment to proceed.",

--- a/src/i18n/it.json
+++ b/src/i18n/it.json
@@ -78,6 +78,7 @@
   "selectThreeAbilities": "Seleziona tre caratteristiche per i punteggi bonus",
   "invalidBonusDistribution": "Distribuzione dei bonus non valida",
   "selectClassToProceed": "Seleziona una classe per procedere.",
+  "completeClassChoicesToProceed": "Completa le scelte della classe per procedere.",
   "selectRaceToProceed": "Seleziona una razza per procedere.",
   "selectBackgroundToProceed": "Seleziona un background per procedere.",
   "chooseEquipmentToProceed": "Scegli il tuo equipaggiamento per procedere.",

--- a/src/ui-helpers.js
+++ b/src/ui-helpers.js
@@ -117,7 +117,6 @@ export function initNextStepWarning() {
   nextBtn.insertAdjacentElement('afterend', warn);
 
   const messages = {
-    step2: t('selectClassToProceed'),
     step3: t('selectRaceToProceed'),
     step4: t('selectBackgroundToProceed'),
     step5: t('chooseEquipmentToProceed'),
@@ -126,7 +125,17 @@ export function initNextStepWarning() {
 
   const updateWarning = () => {
     const active = document.querySelector('.step:not(.hidden)');
-    const msg = active ? messages[active.id] : null;
+    let msg = active ? messages[active.id] : null;
+
+    if (active?.id === 'step2' && nextBtn.disabled) {
+      const hasClass = (globalThis.CharacterState?.classes || []).length > 0;
+      if (!hasClass) {
+        msg = t('selectClassToProceed');
+      } else if (document.querySelector('#step2 .needs-selection.incomplete')) {
+        msg = t('completeClassChoicesToProceed');
+      }
+    }
+
     if (nextBtn.disabled && msg) {
       warn.textContent = msg;
       warn.classList.remove('hidden');
@@ -144,6 +153,7 @@ export function initNextStepWarning() {
   if (stepContainer) {
     new MutationObserver(updateWarning).observe(stepContainer, {
       attributes: true,
+      childList: true,
       subtree: true,
       attributeFilter: ['class'],
     });


### PR DESCRIPTION
## Summary
- add `completeClassChoicesToProceed` translation key for English and Italian
- show new warning when class options remain unselected
- update warning logic to react when class choices change

## Testing
- `npm test` *(fails: Race validation failed)*
- `node --experimental-vm-modules ./node_modules/jest/bin/jest.js`


------
https://chatgpt.com/codex/tasks/task_e_68b459c819bc832ea9fe982bbf9d3b5e