### PR TITLE
feat: add optional feature selection for feats

### DIFF
--- a/__tests__/classSearch.test.js
+++ b/__tests__/classSearch.test.js
@@ -37,6 +37,7 @@ jest.unstable_mockModule('../src/data.js', () => {
     loadSpells: jest.fn(),
     fetchJsonWithRetry: jest.fn(),
     loadFeatDetails: jest.fn(),
+    loadOptionalFeatures: jest.fn(),
   };
 });
 

--- a/__tests__/featOptionalFeatures.test.js
+++ b/__tests__/featOptionalFeatures.test.js
@@ -1,0 +1,44 @@
+/**
+ * @jest-environment jsdom
+ */
+import { jest } from '@jest/globals';
+
+jest.unstable_mockModule('../src/i18n.js', () => ({ t: (k) => k }));
+
+const CharacterState = { feats: [] };
+const DATA = { optionalFeatures: { TEST: ['OptA', 'OptB'] } };
+
+jest.unstable_mockModule('../src/data.js', () => ({
+  CharacterState,
+  DATA,
+  loadFeatDetails: async () => ({
+    optionalfeatureProgression: [
+      { name: 'Test', featureType: ['TEST'], progression: { '*': 1 } },
+    ],
+    entries: [],
+  }),
+  loadSpells: async () => {},
+  loadOptionalFeatures: async () => {},
+  logCharacterState: jest.fn(),
+}));
+
+const { renderFeatChoices } = await import('../src/feat.js');
+
+describe('feat optional features', () => {
+  beforeEach(() => {
+    CharacterState.feats = [];
+  });
+
+  test('requires selection and saves to CharacterState', async () => {
+    const div = document.createElement('div');
+    const renderer = await renderFeatChoices('TestFeat', div, () => {});
+    expect(renderer.optionalFeatureSelects.length).toBe(1);
+    expect(renderer.isComplete()).toBe(false);
+    const sel = renderer.optionalFeatureSelects[0];
+    sel.value = 'OptB';
+    expect(renderer.isComplete()).toBe(true);
+    renderer.apply();
+    expect(CharacterState.feats[0].optionalFeatures).toEqual(['OptB']);
+  });
+});
+

--- a/__tests__/step4.test.js
+++ b/__tests__/step4.test.js
@@ -17,6 +17,7 @@ jest.unstable_mockModule('../src/data.js', () => ({
   fetchJsonWithRetry: jest.fn(),
   loadSpells: jest.fn(),
   loadFeatDetails: jest.fn(),
+  loadOptionalFeatures: jest.fn(),
 }));
 
 jest.unstable_mockModule('../src/step2.js', () => ({

--- a/data/optionalfeatures.json
+++ b/data/optionalfeatures.json
@@ -1,0 +1,35 @@
+{
+  "FS:F": [
+    "Archery",
+    "Blind Fighting",
+    "Defense",
+    "Dueling",
+    "Great Weapon Fighting",
+    "Protection",
+    "Two-Weapon Fighting"
+  ],
+  "EI": [
+    "Agonizing Blast",
+    "Armor of Shadows",
+    "Beast Speech",
+    "Devil's Sight"
+  ],
+  "MM": [
+    "Careful Spell",
+    "Distant Spell",
+    "Empowered Spell",
+    "Extended Spell",
+    "Quickened Spell",
+    "Subtle Spell",
+    "Twinned Spell"
+  ],
+  "MV:B": [
+    "Disarming Attack",
+    "Evasive Footwork",
+    "Feinting Attack",
+    "Lunging Attack",
+    "Parry",
+    "Precision Attack",
+    "Trip Attack"
+  ]
+}

--- a/src/data.js
+++ b/src/data.js
@@ -165,6 +165,18 @@ export async function loadSpells() {
   return DATA.spells;
 }
 
+/**
+ * Fetches optional feature lists keyed by feature type.
+ */
+export async function loadOptionalFeatures() {
+  if (DATA.optionalFeatures) return DATA.optionalFeatures;
+  DATA.optionalFeatures = await fetchJsonWithRetry(
+    'data/optionalfeatures.json',
+    'optional features'
+  );
+  return DATA.optionalFeatures;
+}
+
 export const CharacterState = {
   playerName: "",
   name: "",

--- a/src/step2.js
+++ b/src/step2.js
@@ -255,6 +255,7 @@ function compileClassFeatures(cls) {
           name: `${name}: ${e.option}`,
           abilities: e.abilities,
           feat: e.feat,
+          optionalFeatures: e.optionalFeatures,
           description: choiceDef?.description || '',
           entries: choiceDef?.entries || [],
         });
@@ -374,6 +375,10 @@ function handleASISelection(sel, container, entry, cls) {
         const onFeatChange = () => {
           if (entry.featRenderer?.isComplete()) {
             entry.featRenderer.apply();
+            entry.optionalFeatures =
+              entry.featRenderer.optionalFeatureSelects?.map(
+                (s) => s.value
+              );
             rebuildFromClasses();
           }
           updateStep2Completion();
@@ -389,6 +394,7 @@ function handleASISelection(sel, container, entry, cls) {
           ...(entry.featRenderer.toolSelects || []),
           ...(entry.featRenderer.languageSelects || []),
           ...(entry.featRenderer.spellSelects || []),
+          ...(entry.featRenderer.optionalFeatureSelects || []),
         ];
         all.forEach((s) => s.addEventListener('change', onFeatChange));
       }

--- a/src/step4.js
+++ b/src/step4.js
@@ -268,6 +268,7 @@ function selectBackground(bg) {
           ...(pendingSelections.featRenderer.toolSelects || []),
           ...(pendingSelections.featRenderer.languageSelects || []),
           ...(pendingSelections.featRenderer.spellSelects || []),
+          ...(pendingSelections.featRenderer.optionalFeatureSelects || []),
         ];
         all.forEach((s) =>
           s.addEventListener('change', validateBackgroundChoices)


### PR DESCRIPTION
## Summary
- load optional feature data and expose loader
- allow feats to select and store optional features
- track optional feature choices in class and background flows

## Testing
- `npm test` *(fails: Race validation failed)*
- `node --experimental-vm-modules ./node_modules/jest/bin/jest.js`

------
https://chatgpt.com/codex/tasks/task_e_68b45aaf9408832ea4eb7662b564c9fa