### PR TITLE
Add 5eTools link parser and tests

### DIFF
--- a/__tests__/ui-helpers-links.test.js
+++ b/__tests__/ui-helpers-links.test.js
@@ -1,0 +1,32 @@
+import { parse5eLinks, appendEntries } from '../src/ui-helpers.js';
+
+describe('parse5eLinks', () => {
+  test('converts condition token to anchor', () => {
+    const input = 'You are {@condition charmed}.';
+    const result = parse5eLinks(input);
+    expect(result).toBe(
+      'You are <a href="https://5e.tools/#conditions:charmed" target="_blank" rel="noopener noreferrer">charmed</a>.'
+    );
+  });
+
+  test('leaves unknown token unchanged', () => {
+    const input = 'An {@unknown foo} token.';
+    expect(parse5eLinks(input)).toBe(input);
+  });
+});
+
+describe('appendEntries', () => {
+  test('uses parse5eLinks for string entries', () => {
+    document.body.innerHTML = '<div id="c"></div>';
+    const container = document.getElementById('c');
+    appendEntries(container, ['{@spell Fireball}']);
+
+    const link = container.querySelector('a');
+    expect(link).not.toBeNull();
+    expect(link.getAttribute('href')).toBe(
+      'https://5e.tools/#spells:fireball'
+    );
+    expect(link.textContent).toBe('Fireball');
+  });
+});
+

--- a/src/ui-helpers.js
+++ b/src/ui-helpers.js
@@ -10,17 +10,51 @@ export function createElement(tag, text) {
   return el;
 }
 
+export function parse5eLinks(str) {
+  const TOKEN_URLS = {
+    spell: 'spells',
+    condition: 'conditions',
+    item: 'items',
+    class: 'classes',
+    skill: 'skills',
+    feat: 'feats',
+    race: 'races',
+    background: 'backgrounds',
+    monster: 'bestiary',
+  };
+
+  return (str || '').replace(/\{@(\w+)\s([^}|]+)(?:\|[^}]+)?}/g, (match, type, name) => {
+    const base = TOKEN_URLS[type.toLowerCase()];
+    if (!base) return match;
+    const slug = encodeURIComponent(name.trim().toLowerCase());
+    return `<a href="https://5e.tools/#${base}:${slug}" target="_blank" rel="noopener noreferrer">${name}</a>`;
+  });
+}
+
 export function appendEntries(container, entries) {
   (entries || []).forEach(e => {
     if (!e) return;
     if (typeof e === 'string') {
-      container.appendChild(createElement('p', e));
+      const p = document.createElement('p');
+      p.innerHTML = parse5eLinks(e);
+      container.appendChild(p);
     } else if (typeof e === 'object') {
-      if (e.description) container.appendChild(createElement('p', e.description));
-      if (typeof e.entry === 'string') container.appendChild(createElement('p', e.entry));
+      if (e.description) {
+        const p = document.createElement('p');
+        p.innerHTML = parse5eLinks(e.description);
+        container.appendChild(p);
+      }
+      if (typeof e.entry === 'string') {
+        const p = document.createElement('p');
+        p.innerHTML = parse5eLinks(e.entry);
+        container.appendChild(p);
+      }
       if (Array.isArray(e.entries)) appendEntries(container, e.entries);
-      else if (e.name && !e.entry && !e.entries && !e.description)
-        container.appendChild(createElement('p', e.name));
+      else if (e.name && !e.entry && !e.entries && !e.description) {
+        const p = document.createElement('p');
+        p.innerHTML = parse5eLinks(e.name);
+        container.appendChild(p);
+      }
     }
   });
 }


### PR DESCRIPTION
## Summary
- parse 5eTools tokens like {@spell fireball} into anchor tags
- render parsed links when appending UI entries
- add unit tests for link parsing

## Testing
- `npm test` *(fails: Race validation failed)*
- `node --experimental-vm-modules ./node_modules/jest/bin/jest.js __tests__/ui-helpers-links.test.js --env=jsdom`


------
https://chatgpt.com/codex/tasks/task_e_68b45cf84634832e9c77ff670fbf5b5e