### PR TITLE
feat: allow adding saving throw proficiency via feat choices

### DIFF
--- a/__tests__/featSavingThrowProficiencies.test.js
+++ b/__tests__/featSavingThrowProficiencies.test.js
@@ -1,0 +1,47 @@
+/**
+ * @jest-environment jsdom
+ */
+import { jest } from '@jest/globals';
+
+jest.unstable_mockModule('../src/i18n.js', () => ({ t: (k) => k }));
+
+const CharacterState = { system: { attributes: { saves: ['dex'] } }, feats: [] };
+const DATA = {};
+
+jest.unstable_mockModule('../src/data.js', () => ({
+  CharacterState,
+  DATA,
+  loadFeatDetails: async () => ({
+    savingThrowProficiencies: [
+      { choose: { from: ['str', 'dex'] } },
+    ],
+    entries: [],
+  }),
+  loadSpells: async () => {},
+  loadOptionalFeatures: async () => {},
+  logCharacterState: jest.fn(),
+}));
+
+const { renderFeatChoices } = await import('../src/feat.js');
+
+describe('feat saving throw proficiencies', () => {
+  beforeEach(() => {
+    CharacterState.system.attributes.saves = ['dex'];
+    CharacterState.feats = [];
+  });
+
+  test('selects and applies save proficiency', async () => {
+    const div = document.createElement('div');
+    const renderer = await renderFeatChoices('TestFeat', div, () => {});
+    expect(renderer.saveSelects.length).toBe(1);
+    const sel = renderer.saveSelects[0];
+    const opts = Array.from(sel.options).map((o) => o.value);
+    expect(opts).toContain('str');
+    expect(opts).not.toContain('dex');
+    expect(renderer.isComplete()).toBe(false);
+    sel.value = 'str';
+    expect(renderer.isComplete()).toBe(true);
+    renderer.apply();
+    expect(CharacterState.system.attributes.saves).toContain('str');
+  });
+});

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -30,6 +30,7 @@
   "selectSkillForFeat": "Select skill for feat",
   "selectToolForFeat": "Select tool for feat",
   "selectLanguageForFeat": "Select language for feat",
+  "selectSaveForFeat": "Select save for feat",
   "skill": "skill",
   "tool": "tool",
   "language": "language",

--- a/src/i18n/it.json
+++ b/src/i18n/it.json
@@ -30,6 +30,7 @@
   "selectSkillForFeat": "Seleziona abilità per il talento",
   "selectToolForFeat": "Seleziona strumento per il talento",
   "selectLanguageForFeat": "Seleziona lingua per il talento",
+  "selectSaveForFeat": "Seleziona tiro salvezza per il talento",
   "skill": "abilità",
   "tool": "strumento",
   "language": "lingua",


### PR DESCRIPTION
## Summary
- handle `savingThrowProficiencies` in feat choices and track chosen save
- add `selectSaveForFeat` translations
- test saving throw proficiency selection

## Testing
- `node --experimental-vm-modules ./node_modules/jest/bin/jest.js __tests__/featSavingThrowProficiencies.test.js`
- `npm test` *(fails: Race validation failed)*

------
https://chatgpt.com/codex/tasks/task_e_68b45dd77524832e85a6e866daf3ee86