### PR TITLE
Support weapon proficiency choices from filtered equipment in feats

### DIFF
--- a/__tests__/featWeaponProficiencies.test.js
+++ b/__tests__/featWeaponProficiencies.test.js
@@ -1,0 +1,63 @@
+/**
+ * @jest-environment jsdom
+ */
+import { jest } from '@jest/globals';
+
+jest.unstable_mockModule('../src/i18n.js', () => ({ t: (k) => k }));
+
+const CharacterState = { feats: [] };
+const DATA = {
+  equipment: [
+    { name: 'Longsword', type: 'martial weapon', miscellaneous: 'mundane' },
+    { name: 'Shortsword', type: 'martial weapon', miscellaneous: 'mundane' },
+    { name: 'Battleaxe', type: 'martial weapon', miscellaneous: 'mundane' },
+    { name: 'Trident', type: 'martial weapon', miscellaneous: 'mundane' },
+    { name: 'Magic Blaster', type: 'firearm', miscellaneous: 'magical' },
+  ],
+};
+
+jest.unstable_mockModule('../src/data.js', () => ({
+  CharacterState,
+  DATA,
+  loadFeatDetails: async () => ({
+    weaponProficiencies: [
+      { choose: { fromFilter: 'type=martial weapon|miscellaneous=mundane', count: 4 } },
+    ],
+    entries: [],
+  }),
+  loadSpells: async () => {},
+  loadOptionalFeatures: async () => {},
+  logCharacterState: jest.fn(),
+}));
+
+const { renderFeatChoices } = await import('../src/feat.js');
+
+describe('feat weapon proficiencies', () => {
+  beforeEach(() => {
+    CharacterState.feats = [];
+  });
+
+  test('selects unique weapons and applies', async () => {
+    const div = document.createElement('div');
+    const renderer = await renderFeatChoices('Weapon Master', div, () => {});
+    expect(renderer.weaponSelects.length).toBe(4);
+    renderer.weaponSelects[0].value = 'Longsword';
+    renderer.weaponSelects[0].dispatchEvent(new Event('change'));
+    const opts2 = Array.from(renderer.weaponSelects[1].options).map((o) => o.value);
+    expect(opts2).not.toContain('Longsword');
+    renderer.weaponSelects[1].value = 'Shortsword';
+    renderer.weaponSelects[1].dispatchEvent(new Event('change'));
+    renderer.weaponSelects[2].value = 'Battleaxe';
+    renderer.weaponSelects[2].dispatchEvent(new Event('change'));
+    renderer.weaponSelects[3].value = 'Trident';
+    renderer.weaponSelects[3].dispatchEvent(new Event('change'));
+    expect(renderer.isComplete()).toBe(true);
+    renderer.apply();
+    expect(CharacterState.feats[0].weapons).toEqual([
+      'Longsword',
+      'Shortsword',
+      'Battleaxe',
+      'Trident',
+    ]);
+  });
+});

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -31,6 +31,7 @@
   "selectToolForFeat": "Select tool for feat",
   "selectLanguageForFeat": "Select language for feat",
   "selectSaveForFeat": "Select save for feat",
+  "selectWeaponForFeat": "Select weapon for feat",
   "skill": "skill",
   "tool": "tool",
   "language": "language",

--- a/src/i18n/it.json
+++ b/src/i18n/it.json
@@ -31,6 +31,7 @@
   "selectToolForFeat": "Seleziona strumento per il talento",
   "selectLanguageForFeat": "Seleziona lingua per il talento",
   "selectSaveForFeat": "Seleziona tiro salvezza per il talento",
+  "selectWeaponForFeat": "Seleziona arma per il talento",
   "skill": "abilità",
   "tool": "strumento",
   "language": "lingua",


### PR DESCRIPTION
## Summary
- enable feats to select weapons via fromFilter by parsing equipment data
- track chosen weapons in CharacterState
- add translations and tests for weapon proficiency selection

## Testing
- `npm test` *(fails: altered.json missing selection metadata for: size, etc.)*
- `node --experimental-vm-modules ./node_modules/jest/bin/jest.js` *(fails: __tests__/ui-helpers-links.test.js: document is not defined)*


------
https://chatgpt.com/codex/tasks/task_e_68b45f2cc978832e8d88873d88c13e94