### PR TITLE
Handle feat expertise selections

### DIFF
--- a/__tests__/featExpertise.test.js
+++ b/__tests__/featExpertise.test.js
@@ -1,0 +1,54 @@
+/**
+ * @jest-environment jsdom
+ */
+import { jest } from '@jest/globals';
+
+jest.unstable_mockModule('../src/i18n.js', () => ({ t: (k) => k }));
+
+const CharacterState = { system: { skills: ['Stealth'] }, feats: [] };
+const DATA = {};
+
+jest.unstable_mockModule('../src/data.js', () => ({
+  CharacterState,
+  DATA,
+  loadFeatDetails: async () => ({
+    skillProficiencies: [{ choose: { from: ['arcana', 'acrobatics'] } }],
+    expertise: [{ anyProficientSkill: 1 }],
+    entries: [],
+  }),
+  loadSpells: async () => {},
+  loadOptionalFeatures: async () => {},
+  logCharacterState: jest.fn(),
+}));
+
+const { renderFeatChoices } = await import('../src/feat.js');
+
+describe('feat expertise', () => {
+  beforeEach(() => {
+    CharacterState.system.skills = ['Stealth'];
+    CharacterState.feats = [];
+  });
+
+  test('limits expertise to proficient skills and applies selection', async () => {
+    const div = document.createElement('div');
+    const renderer = await renderFeatChoices('Skill Expert', div, () => {});
+    expect(renderer.skillSelects.length).toBe(1);
+    expect(renderer.expertiseSelects.length).toBe(1);
+
+    let opts = Array.from(renderer.expertiseSelects[0].options).map((o) => o.value);
+    expect(opts).toContain('Stealth');
+    expect(opts).not.toContain('Arcana');
+
+    renderer.skillSelects[0].value = 'arcana';
+    renderer.skillSelects[0].dispatchEvent(new Event('change'));
+    opts = Array.from(renderer.expertiseSelects[0].options).map((o) => o.value);
+    expect(opts).toContain('Arcana');
+
+    renderer.expertiseSelects[0].value = 'Arcana';
+    expect(renderer.isComplete()).toBe(true);
+    renderer.apply();
+    expect(CharacterState.feats[0].expertise).toEqual(['Arcana']);
+    expect(CharacterState.system.skills).toContain('Arcana');
+  });
+});
+


### PR DESCRIPTION
## Summary
- support `expertise` arrays in feats with selects limited to known skills
- store chosen expertise in `CharacterState.feats[*].expertise`
- add tests covering expertise selection and application

## Testing
- `npm test` *(fails: altered.json missing selection metadata for: size, Race validation failed)*
- `node --experimental-vm-modules ./node_modules/jest/bin/jest.js --env=jsdom`


------
https://chatgpt.com/codex/tasks/task_e_68b461be9928832eba5b21df58cd84ec