### PR TITLE
Support class expertise selections

### DIFF
--- a/__tests__/classExpertise.test.js
+++ b/__tests__/classExpertise.test.js
@@ -1,0 +1,40 @@
+/**
+ * @jest-environment jsdom
+ */
+import { jest } from '@jest/globals';
+
+jest.unstable_mockModule('../src/i18n.js', () => ({ t: (k) => k }));
+
+const { updateExpertiseSelectOptions, rebuildFromClasses, refreshBaseState } = await import('../src/step2.js');
+const { CharacterState } = await import('../src/data.js');
+
+describe('class expertise', () => {
+  beforeEach(() => {
+    CharacterState.system.skills = ['Stealth', 'Arcana'];
+    CharacterState.system.expertise = ['Stealth'];
+    CharacterState.classes = [];
+    CharacterState.feats = [];
+  });
+
+  test('updateExpertiseSelectOptions limits to proficient skills and disables taken', () => {
+    const sel1 = document.createElement('select');
+    const sel2 = document.createElement('select');
+    updateExpertiseSelectOptions([sel1, sel2]);
+    const opts = Array.from(sel1.options).map((o) => o.value);
+    expect(opts).toEqual(['', 'Arcana', 'Stealth']);
+    expect(sel1.querySelector("option[value='Stealth']").disabled).toBe(true);
+    sel2.value = 'Arcana';
+    updateExpertiseSelectOptions([sel1, sel2]);
+    expect(sel1.querySelector("option[value='Arcana']").disabled).toBe(true);
+  });
+
+  test('rebuildFromClasses aggregates expertise', () => {
+    CharacterState.system.skills = [];
+    CharacterState.system.expertise = [];
+    refreshBaseState();
+    CharacterState.classes = [{ name: 'Rogue', expertise: [{ id: 'e-1', level: 1, skill: 'Stealth' }], skills: [], choiceSelections: {} }];
+    CharacterState.feats = [{ name: 'Feat', expertise: ['Arcana'] }];
+    rebuildFromClasses();
+    expect(CharacterState.system.expertise.sort()).toEqual(['Arcana', 'Stealth']);
+  });
+});

--- a/__tests__/ui-helpers-links.test.js
+++ b/__tests__/ui-helpers-links.test.js
@@ -1,3 +1,6 @@
+/**
+ * @jest-environment jsdom
+ */
 import { parse5eLinks, appendEntries } from '../src/ui-helpers.js';
 
 describe('parse5eLinks', () => {

--- a/data/classes/bard.json
+++ b/data/classes/bard.json
@@ -326,6 +326,7 @@
       "description": "Choose two skills to gain expertise in",
       "count": 2,
       "type": "skills",
+      "requiresProficiency": true,
       "selection": [
         "Acrobatics",
         "Athletics",
@@ -368,6 +369,7 @@
       "description": "Choose two additional skills to gain expertise in",
       "count": 4,
       "type": "skills",
+      "requiresProficiency": true,
       "selection": [
         "Acrobatics",
         "Athletics",

--- a/data/classes/rogue.json
+++ b/data/classes/rogue.json
@@ -267,6 +267,7 @@
       "description": "Choose two skills to gain expertise in",
       "count": 2,
       "type": "skills",
+      "requiresProficiency": true,
       "selection": [
         "Acrobatics",
         "Athletics",
@@ -299,6 +300,7 @@
       "description": "Choose two additional skills to gain expertise in",
       "count": 4,
       "type": "skills",
+      "requiresProficiency": true,
       "selection": [
         "Acrobatics",
         "Athletics",

--- a/src/data.js
+++ b/src/data.js
@@ -212,6 +212,7 @@ export const CharacterState = {
       cha: { value: 8 },
     },
     skills: [],
+    expertise: [],
     weapons: [],
     currency: { pp: 0, gp: 0, ep: 0, sp: 0, cp: 0 },
     attributes: {


### PR DESCRIPTION
## Summary
- add expertise tracking to character state and rebuild logic
- show expertise choices limited to proficient skills
- test expertise aggregation and option filtering

## Testing
- `node scripts/validate-races.js` (fails: altered.json missing selection metadata for size)
- `node --experimental-vm-modules ./node_modules/jest/bin/jest.js`


------
https://chatgpt.com/codex/tasks/task_e_68b46537a8f8832ea240aeb540488910