### PR TITLE
Expand layout width and center class grid

### DIFF
--- a/css/site-theme.css
+++ b/css/site-theme.css
@@ -15,7 +15,8 @@ body {
   font-family: 'Roboto', sans-serif;
   background-color: var(--secondary-color);
   margin: 20px auto;
-  max-width: 1000px;
+  max-width: 1200px;
+  width: 90vw;
   color: var(--text-color);
 }
 
@@ -182,7 +183,8 @@ th {
 }
 
 #stepContainer {
-  max-width: 800px;
+  max-width: 1000px;
+  width: 100%;
   margin: 0 auto;
 }
 
@@ -190,7 +192,8 @@ th {
   display: flex;
   align-items: center;
   justify-content: center;
-  max-width: 880px;
+  max-width: 1080px;
+  width: 100%;
   margin: 0 auto;
 }
 
@@ -222,6 +225,7 @@ th {
   grid-template-columns: repeat(auto-fill, minmax(240px, 1fr));
   gap: 10px;
   margin-bottom: 15px;
+  justify-content: center;
 }
 
 /* Accordion styles */


### PR DESCRIPTION
## Summary
- widen overall body layout with a 1200px cap and responsive 90vw width
- enlarge step container and navigation to match new layout width
- center class selection grid to avoid uneven stretching

## Testing
- `npm test` *(fails: altered.json missing selection metadata for: size ... Race validation failed.)*

------
https://chatgpt.com/codex/tasks/task_e_68b46ccc565c832e938d3632baa7140a