### PR TITLE
Prevent next step warning from shifting nav

### DIFF
--- a/__tests__/nextStepWarning.test.js
+++ b/__tests__/nextStepWarning.test.js
@@ -1,0 +1,40 @@
+/**
+ * @jest-environment jsdom
+ */
+import { initNextStepWarning } from '../src/ui-helpers.js';
+
+describe('initNextStepWarning', () => {
+  beforeEach(() => {
+    document.body.innerHTML = `
+      <div id="stepNav">
+        <button id="prevStep"></button>
+        <div id="stepContainer">
+          <div id="step3" class="step"></div>
+        </div>
+        <button id="nextStep" disabled></button>
+      </div>
+    `;
+    global.t = (key) => key;
+    global.CharacterState = { classes: [] };
+  });
+
+  test('warning appended after stepNav and toggles visibility without affecting nav structure', async () => {
+    initNextStepWarning();
+    const stepNav = document.getElementById('stepNav');
+    expect(stepNav.childElementCount).toBe(3);
+
+    const warning = document.getElementById('nextStepWarning');
+    expect(warning).not.toBeNull();
+    expect(stepNav.nextElementSibling).toBe(warning);
+
+    const nextBtn = document.getElementById('nextStep');
+    expect(warning.classList.contains('hidden')).toBe(false);
+
+    nextBtn.disabled = false;
+    await new Promise((r) => setTimeout(r, 0));
+
+    expect(warning.classList.contains('hidden')).toBe(true);
+    expect(stepNav.childElementCount).toBe(3);
+    expect(nextBtn.nextElementSibling).toBeNull();
+  });
+});

--- a/css/site-theme.css
+++ b/css/site-theme.css
@@ -218,6 +218,10 @@ th {
   font-size: 0.9rem;
   text-align: center;
   margin-top: 0.5rem;
+  max-width: 1080px;
+  width: 100%;
+  margin-left: auto;
+  margin-right: auto;
 }
 
 .class-list {

--- a/src/ui-helpers.js
+++ b/src/ui-helpers.js
@@ -148,7 +148,12 @@ export function initNextStepWarning() {
   const warn = document.createElement('div');
   warn.id = 'nextStepWarning';
   warn.className = 'next-step-warning hidden';
-  nextBtn.insertAdjacentElement('afterend', warn);
+  const stepNav = document.getElementById('stepNav');
+  if (stepNav) {
+    stepNav.insertAdjacentElement('afterend', warn);
+  } else {
+    nextBtn.insertAdjacentElement('afterend', warn);
+  }
 
   const messages = {
     step3: t('selectRaceToProceed'),


### PR DESCRIPTION
## Summary
- Append `#nextStepWarning` after `#stepNav` so warning no longer participates in flex layout
- Style warning container for full-width display below navigation controls
- Add unit test ensuring warning placement and visibility toggling

## Testing
- `npm test` *(fails: Race validation failed)*
- `node --experimental-vm-modules ./node_modules/jest/bin/jest.js __tests__/nextStepWarning.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68b46d99a734832e80b1fb2689aad131