### PR TITLE
Tidy class card spacing with grid gap and padding

### DIFF
--- a/css/site-theme.css
+++ b/css/site-theme.css
@@ -227,7 +227,8 @@ th {
 .class-list {
   display: grid;
   grid-template-columns: repeat(auto-fill, minmax(240px, 1fr));
-  gap: 10px;
+  gap: 20px;
+  padding: 10px 0;
   margin-bottom: 15px;
   justify-content: center;
 }
@@ -362,7 +363,6 @@ th {
   border: 1px solid var(--accent-color);
   border-radius: 8px;
   padding: 15px;
-  margin-bottom: 10px;
   background-color: #fff;
   box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
   width: 100%;


### PR DESCRIPTION
## Summary
- increase `.class-list` grid gap and add optional padding for better spacing
- drop individual `.class-card` bottom margins so grid gap controls spacing

## Testing
- `npm test` *(fails: Race validation failed – missing selection metadata for several races)*
- `node --experimental-vm-modules ./node_modules/jest/bin/jest.js __tests__/step2.test.js __tests__/step3.test.js __tests__/step4.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68b54ad91f10832e87906c99d04204a9