### PR TITLE
Add landing page with beginner option

### DIFF
--- a/landing.html
+++ b/landing.html
@@ -1,0 +1,31 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Tales from Ivory - Character Creator</title>
+  <link rel="stylesheet" href="css/site-theme.css" />
+  <link rel="icon" href="assets/Tales-Ivory-Logo-white-white.png" />
+</head>
+<body>
+  <header class="banner">
+    <div class="header-top">
+      <img src="assets/Tales-Ivory-Logo-white-white.png" alt="Tales from Ivory logo" />
+      <h1>Tales from Ivory - Character Creator</h1>
+    </div>
+  </header>
+  <div class="section-divider"></div>
+  <main class="landing-options">
+    <button id="createCharacterBtn" class="btn">Create Character</button>
+    <button id="premadeCharactersBtn" class="btn">Premade Characters</button>
+    <button id="randomCharacterBtn" class="btn">Random Character</button>
+    <div class="form-group">
+      <label>
+        <input type="checkbox" id="beginnerMode" />
+        Beginner? Show Help Text
+      </label>
+    </div>
+  </main>
+  <script type="module" src="src/main.js"></script>
+</body>
+</html>

--- a/src/main.js
+++ b/src/main.js
@@ -77,6 +77,10 @@ function showStep(step) {
       bar.style.width = `${((step - 1) / 6) * 100}%`;
     }
     currentStep = step;
+    if (CharacterState.showHelp) {
+      // Placeholder for contextual help integration
+      console.log(`Help: display guidance for step ${step}`);
+    }
     if (step === 4) loadStep4(true);
     if (step === 5) loadStep5(true);
     if (step === 6) loadStep6(true);
@@ -143,6 +147,39 @@ function renderFinalRecap() {
 }
 
 document.addEventListener("DOMContentLoaded", async () => {
+  const createBtn = document.getElementById("createCharacterBtn");
+  if (createBtn) {
+    const beginnerCheck = document.getElementById("beginnerMode");
+    createBtn.addEventListener("click", () => {
+      const beginner = beginnerCheck?.checked ?? false;
+      CharacterState.showHelp = beginner;
+      try {
+        localStorage.setItem("showHelp", beginner ? "1" : "0");
+      } catch (e) {
+        /* ignore */
+      }
+      window.location.href = "index.html";
+    });
+    document
+      .getElementById("premadeCharactersBtn")
+      ?.addEventListener("click", () => {
+        console.log("Premade characters module not implemented yet.");
+      });
+    document
+      .getElementById("randomCharacterBtn")
+      ?.addEventListener("click", () => {
+        console.log("Random character module not implemented yet.");
+      });
+    return;
+  }
+
+  CharacterState.showHelp = false;
+  try {
+    CharacterState.showHelp = localStorage.getItem("showHelp") === "1";
+  } catch (e) {
+    /* ignore */
+  }
+
   await initI18n();
   applyTranslations();
   for (let i = 1; i <= 7; i++) {


### PR DESCRIPTION
## Summary
- add landing page with buttons for create, premade, random character
- wire up beginner mode flag and stub handlers
- provide placeholder help logging during step navigation

## Testing
- `npm test` *(fails: Race validation failed)*

------
https://chatgpt.com/codex/tasks/task_e_68b552417280832ea241c23d4642f6e6