### PR TITLE
feat: add field coordinate mapping for PDF export

### DIFF
--- a/assets/field-coords.json
+++ b/assets/field-coords.json
@@ -1,0 +1,16 @@
+{
+  "fields": {
+    "CharacterName": { "x": 100, "y": 750 },
+    "PlayerName": { "x": 100, "y": 730 },
+    "Class": { "x": 100, "y": 710 },
+    "Race": { "x": 100, "y": 690 },
+    "Background": { "x": 100, "y": 670 },
+    "Strength": { "x": 100, "y": 650 },
+    "Dexterity": { "x": 100, "y": 630 },
+    "Constitution": { "x": 100, "y": 610 },
+    "Intelligence": { "x": 100, "y": 590 },
+    "Wisdom": { "x": 100, "y": 570 },
+    "Charisma": { "x": 100, "y": 550 }
+  },
+  "checkboxes": {}
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,8 @@
       "version": "1.0.0",
       "dependencies": {
         "html2canvas": "^1.4.1",
-        "jspdf": "^3.0.1"
+        "jspdf": "^3.0.1",
+        "pdf-lib": "^1.17.1"
       },
       "devDependencies": {
         "@rollup/plugin-commonjs": "^28.0.6",
@@ -1185,6 +1186,24 @@
         "@emnapi/core": "^1.4.3",
         "@emnapi/runtime": "^1.4.3",
         "@tybys/wasm-util": "^0.10.0"
+      }
+    },
+    "node_modules/@pdf-lib/standard-fonts": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@pdf-lib/standard-fonts/-/standard-fonts-1.0.0.tgz",
+      "integrity": "sha512-hU30BK9IUN/su0Mn9VdlVKsWBS6GyhVfqjwl1FjZN4TxP6cCw0jP2w7V3Hf5uX7M0AZJ16vey9yE0ny7Sa59ZA==",
+      "license": "MIT",
+      "dependencies": {
+        "pako": "^1.0.6"
+      }
+    },
+    "node_modules/@pdf-lib/upng": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@pdf-lib/upng/-/upng-1.0.1.tgz",
+      "integrity": "sha512-dQK2FUMQtowVP00mtIksrlZhdFXQZPC+taih1q4CvPZ5vqdxR/LKBaFg0oAfzd1GlHZXXSPdQfzQnt+ViGvEIQ==",
+      "license": "MIT",
+      "dependencies": {
+        "pako": "^1.0.10"
       }
     },
     "node_modules/@pkgjs/parseargs": {
@@ -4241,6 +4260,12 @@
       "dev": true,
       "license": "BlueOak-1.0.0"
     },
+    "node_modules/pako": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/pako/-/pako-1.0.11.tgz",
+      "integrity": "sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw==",
+      "license": "(MIT AND Zlib)"
+    },
     "node_modules/parse-json": {
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-5.2.0.tgz",
@@ -4333,6 +4358,24 @@
       "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/pdf-lib": {
+      "version": "1.17.1",
+      "resolved": "https://registry.npmjs.org/pdf-lib/-/pdf-lib-1.17.1.tgz",
+      "integrity": "sha512-V/mpyJAoTsN4cnP31vc0wfNA1+p20evqqnap0KLoRUN0Yk/p3wN52DOEsL4oBFcLdb76hlpKPtzJIgo67j/XLw==",
+      "license": "MIT",
+      "dependencies": {
+        "@pdf-lib/standard-fonts": "^1.0.0",
+        "@pdf-lib/upng": "^1.0.1",
+        "pako": "^1.0.11",
+        "tslib": "^1.11.1"
+      }
+    },
+    "node_modules/pdf-lib/node_modules/tslib": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+      "license": "0BSD"
     },
     "node_modules/performance-now": {
       "version": "2.1.0",

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
   },
   "dependencies": {
     "html2canvas": "^1.4.1",
-    "jspdf": "^3.0.1"
+    "jspdf": "^3.0.1",
+    "pdf-lib": "^1.17.1"
   }
 }

--- a/src/export-pdf.js
+++ b/src/export-pdf.js
@@ -1,0 +1,56 @@
+import { PDFDocument, StandardFonts } from 'pdf-lib';
+
+export async function exportPdf(state) {
+  const templateBytes = await fetch('assets/PDF Sheet Empty.pdf').then(r => r.arrayBuffer());
+  const { fields, checkboxes } = await fetch('assets/field-coords.json').then(r => r.json());
+  const pdfDoc = await PDFDocument.load(templateBytes);
+  const page = pdfDoc.getPages()[0];
+  const font = await pdfDoc.embedFont(StandardFonts.Helvetica);
+  const fontSize = 12;
+
+  if (fields.CharacterName)
+    page.drawText(state.name || '', { x: fields.CharacterName.x, y: fields.CharacterName.y, size: fontSize, font });
+
+  if (fields.PlayerName)
+    page.drawText(state.playerName || '', { x: fields.PlayerName.x, y: fields.PlayerName.y, size: fontSize, font });
+
+  if (fields.Class) {
+    const classText = (state.classes || []).map(c => `${c.name || ''} ${c.level || ''}`.trim()).join(' / ');
+    page.drawText(classText, { x: fields.Class.x, y: fields.Class.y, size: fontSize, font });
+  }
+
+  if (fields.Race)
+    page.drawText(state.system?.details?.race || '', { x: fields.Race.x, y: fields.Race.y, size: fontSize, font });
+
+  if (fields.Background)
+    page.drawText(state.system?.details?.background || '', { x: fields.Background.x, y: fields.Background.y, size: fontSize, font });
+
+  if (fields.Strength)
+    page.drawText(String(state.system?.abilities?.str?.value ?? ''), { x: fields.Strength.x, y: fields.Strength.y, size: fontSize, font });
+
+  if (fields.Dexterity)
+    page.drawText(String(state.system?.abilities?.dex?.value ?? ''), { x: fields.Dexterity.x, y: fields.Dexterity.y, size: fontSize, font });
+
+  if (fields.Constitution)
+    page.drawText(String(state.system?.abilities?.con?.value ?? ''), { x: fields.Constitution.x, y: fields.Constitution.y, size: fontSize, font });
+
+  if (fields.Intelligence)
+    page.drawText(String(state.system?.abilities?.int?.value ?? ''), { x: fields.Intelligence.x, y: fields.Intelligence.y, size: fontSize, font });
+
+  if (fields.Wisdom)
+    page.drawText(String(state.system?.abilities?.wis?.value ?? ''), { x: fields.Wisdom.x, y: fields.Wisdom.y, size: fontSize, font });
+
+  if (fields.Charisma)
+    page.drawText(String(state.system?.abilities?.cha?.value ?? ''), { x: fields.Charisma.x, y: fields.Charisma.y, size: fontSize, font });
+
+  const bytes = await pdfDoc.save();
+  const blob = new Blob([bytes], { type: 'application/pdf' });
+  const url = URL.createObjectURL(blob);
+  const a = document.createElement('a');
+  a.href = url;
+  a.download = `${state.name || 'character'}.pdf`;
+  a.click();
+  URL.revokeObjectURL(url);
+}
+
+export default exportPdf;

--- a/src/main.js
+++ b/src/main.js
@@ -26,6 +26,7 @@ import { loadStep5, isStepComplete as isStep5Complete } from "./step5.js";
 import { loadStep6, commitAbilities } from "./step6.js";
 import { exportFoundryActor } from "./export.js";
 import { t, initI18n, applyTranslations } from "./i18n.js";
+import { exportPdf } from "./export-pdf.js";
 
 let currentStep = 1;
 let currentStepComplete = false;
@@ -251,6 +252,10 @@ document.addEventListener("DOMContentLoaded", async () => {
     a.download = `${CharacterState.name || "character"}.json`;
     a.click();
     URL.revokeObjectURL(url);
+  });
+
+  document.getElementById("generatePdf")?.addEventListener("click", () => {
+    exportPdf(CharacterState).catch((err) => console.error(err));
   });
 
     // Step 1 inputs ----------------------------------------------------------


### PR DESCRIPTION
## Summary
- add coordinate mapping asset
- implement PDF export with explicit field positioning
- hook up PDF generation to UI

## Testing
- `npm test` *(fails: Race validation failed)*
- `node --experimental-vm-modules ./node_modules/jest/bin/jest.js`


------
https://chatgpt.com/codex/tasks/task_e_68b5557aa380832ebb64484091fb260e