### PR TITLE
Mark skill proficiencies on exported PDF

### DIFF
--- a/src/export-pdf.js
+++ b/src/export-pdf.js
@@ -43,6 +43,19 @@ export async function exportPdf(state) {
   if (fields.Charisma)
     page.drawText(String(state.system?.abilities?.cha?.value ?? ''), { x: fields.Charisma.x, y: fields.Charisma.y, size: fontSize, font });
 
+  const checkboxFontSize = 10;
+  for (const [key, skill] of Object.entries(state.system?.skills || {})) {
+    const skillName = (skill.label || key).replace(/\s+/g, '_');
+    if (skill.proficient && checkboxes[`${skillName}_prof`]) {
+      const { x, y } = checkboxes[`${skillName}_prof`];
+      page.drawText('X', { x, y, size: checkboxFontSize, font });
+    }
+    if (skill.expert && checkboxes[`${skillName}_expert`]) {
+      const { x, y } = checkboxes[`${skillName}_expert`];
+      page.drawText('X', { x, y, size: checkboxFontSize, font });
+    }
+  }
+
   const bytes = await pdfDoc.save();
   const blob = new Blob([bytes], { type: 'application/pdf' });
   const url = URL.createObjectURL(blob);


### PR DESCRIPTION
## Summary
- Add pass to exportPdf to mark skill proficiency/expertise checkboxes when exporting a character sheet PDF

## Testing
- `npm test` *(fails: Race validation failed)*

------
https://chatgpt.com/codex/tasks/task_e_68b556a42fe8832eb661734ed9fe425f