### PR TITLE
fix: load pdf-lib from CDN

### DIFF
--- a/src/export-pdf.js
+++ b/src/export-pdf.js
@@ -1,4 +1,4 @@
-import { PDFDocument, StandardFonts } from 'pdf-lib';
+import { PDFDocument, StandardFonts } from "https://cdn.jsdelivr.net/npm/pdf-lib@1.17.1/dist/pdf-lib.esm.min.js";
 
 export async function exportPdf(state) {
   const templateBytes = await fetch('assets/PDF Sheet Empty.pdf').then(r => r.arrayBuffer());


### PR DESCRIPTION
## Summary
- load pdf-lib directly from jsDelivr CDN to fix bare module specifier error in browser

## Testing
- `npm test` *(fails: Race validation failed due to missing selection metadata)*

------
https://chatgpt.com/codex/tasks/task_e_68b557992868832e9ec1752c12b75b3e