### PR TITLE
Add premade and random character generation modules

### DIFF
--- a/data/premade/fighter.json
+++ b/data/premade/fighter.json
@@ -1,0 +1,31 @@
+{
+  "playerName": "",
+  "name": "Preset Fighter",
+  "type": "character",
+  "classes": [{ "name": "Fighter", "level": 1 }],
+  "feats": [],
+  "equipment": [],
+  "knownSpells": {},
+  "raceChoices": { "spells": [], "spellAbility": "", "size": "Medium", "alterations": {}, "resist": "", "tools": [], "weapons": [] },
+  "bonusAbilities": { "str": 0, "dex": 0, "con": 0, "int": 0, "wis": 0, "cha": 0 },
+  "baseAbilities": { "str": 15, "dex": 14, "con": 13, "int": 10, "wis": 12, "cha": 8 },
+  "system": {
+    "details": { "race": "Human", "background": "Soldier", "origin": "", "age": 30 },
+    "abilities": {
+      "str": { "value": 15 },
+      "dex": { "value": 14 },
+      "con": { "value": 13 },
+      "int": { "value": 10 },
+      "wis": { "value": 12 },
+      "cha": { "value": 8 }
+    },
+    "skills": ["Athletics", "Perception"],
+    "tools": [],
+    "spells": { "cantrips": [], "pact": { "value": 0, "max": 0, "level": 0 } },
+    "traits": { "languages": { "value": ["Common"] } },
+    "expertise": [],
+    "resources": {},
+    "attributes": { "prof": 2 }
+  },
+  "prototypeToken": { "name": "Preset Fighter" }
+}

--- a/data/premade/index.json
+++ b/data/premade/index.json
@@ -1,0 +1,6 @@
+{
+  "characters": [
+    { "file": "fighter.json", "name": "Sample Fighter" },
+    { "file": "wizard.json", "name": "Sample Wizard" }
+  ]
+}

--- a/data/premade/wizard.json
+++ b/data/premade/wizard.json
@@ -1,0 +1,31 @@
+{
+  "playerName": "",
+  "name": "Preset Wizard",
+  "type": "character",
+  "classes": [{ "name": "Wizard", "level": 1 }],
+  "feats": [],
+  "equipment": [],
+  "knownSpells": {},
+  "raceChoices": { "spells": [], "spellAbility": "", "size": "Medium", "alterations": {}, "resist": "", "tools": [], "weapons": [] },
+  "bonusAbilities": { "str": 0, "dex": 0, "con": 0, "int": 0, "wis": 0, "cha": 0 },
+  "baseAbilities": { "str": 8, "dex": 14, "con": 13, "int": 15, "wis": 12, "cha": 10 },
+  "system": {
+    "details": { "race": "Elf", "background": "Sage", "origin": "", "age": 120 },
+    "abilities": {
+      "str": { "value": 8 },
+      "dex": { "value": 14 },
+      "con": { "value": 13 },
+      "int": { "value": 15 },
+      "wis": { "value": 12 },
+      "cha": { "value": 10 }
+    },
+    "skills": ["Arcana", "History"],
+    "tools": [],
+    "spells": { "cantrips": ["Fire Bolt"], "pact": { "value": 0, "max": 0, "level": 0 } },
+    "traits": { "languages": { "value": ["Common", "Elvish"] } },
+    "expertise": [],
+    "resources": {},
+    "attributes": { "prof": 2 }
+  },
+  "prototypeToken": { "name": "Preset Wizard" }
+}

--- a/src/main.js
+++ b/src/main.js
@@ -163,13 +163,15 @@ document.addEventListener("DOMContentLoaded", async () => {
     });
     document
       .getElementById("premadeCharactersBtn")
-      ?.addEventListener("click", () => {
-        console.log("Premade characters module not implemented yet.");
+      ?.addEventListener("click", async () => {
+        const mod = await import('./premade.js');
+        mod.showPremadeSelector();
       });
     document
       .getElementById("randomCharacterBtn")
-      ?.addEventListener("click", () => {
-        console.log("Random character module not implemented yet.");
+      ?.addEventListener("click", async () => {
+        const mod = await import('./random.js');
+        mod.generateRandomCharacter();
       });
     return;
   }
@@ -177,6 +179,20 @@ document.addEventListener("DOMContentLoaded", async () => {
   CharacterState.showHelp = false;
   try {
     CharacterState.showHelp = localStorage.getItem("showHelp") === "1";
+  } catch (e) {
+    /* ignore */
+  }
+
+  let startAtStep7 = false;
+  try {
+    const stored = localStorage.getItem('characterState');
+    if (stored) {
+      const obj = JSON.parse(stored);
+      Object.assign(CharacterState, obj);
+      startAtStep7 = true;
+      currentStep = 7;
+      localStorage.removeItem('characterState');
+    }
   } catch (e) {
     /* ignore */
   }
@@ -238,6 +254,7 @@ document.addEventListener("DOMContentLoaded", async () => {
       loadStep4();
       loadStep5();
       loadStep6();
+      if (startAtStep7) showStep(7);
     })
     .catch((err) => console.error(err));
 

--- a/src/premade.js
+++ b/src/premade.js
@@ -1,0 +1,58 @@
+import { fetchJsonWithRetry } from './data.js';
+
+/**
+ * Display available premade characters and load the selected one.
+ */
+export async function showPremadeSelector() {
+  try {
+    const index = await fetchJsonWithRetry('data/premade/index.json', 'premade index');
+    const list = index.characters || [];
+    const overlay = document.createElement('div');
+    overlay.id = 'premadeSelector';
+    overlay.style.position = 'fixed';
+    overlay.style.top = '0';
+    overlay.style.left = '0';
+    overlay.style.right = '0';
+    overlay.style.bottom = '0';
+    overlay.style.background = 'rgba(0,0,0,0.8)';
+    overlay.style.zIndex = '1000';
+    overlay.style.display = 'flex';
+    overlay.style.flexDirection = 'column';
+    overlay.style.alignItems = 'center';
+    overlay.style.justifyContent = 'center';
+    overlay.style.color = '#fff';
+
+    list.forEach((char) => {
+      const btn = document.createElement('button');
+      btn.textContent = char.name || char.file;
+      btn.className = 'btn';
+      btn.style.margin = '0.5rem';
+      btn.addEventListener('click', async () => {
+        try {
+          const data = await fetchJsonWithRetry(
+            `data/premade/${char.file}`,
+            char.name || char.file
+          );
+          localStorage.setItem('characterState', JSON.stringify(data));
+          window.location.href = 'index.html';
+        } catch (err) {
+          console.error(err);
+        }
+      });
+      overlay.appendChild(btn);
+    });
+
+    const cancel = document.createElement('button');
+    cancel.textContent = 'Cancel';
+    cancel.className = 'btn';
+    cancel.style.margin = '0.5rem';
+    cancel.addEventListener('click', () => overlay.remove());
+    overlay.appendChild(cancel);
+
+    document.body.appendChild(overlay);
+  } catch (err) {
+    console.error(err);
+  }
+}
+
+export default { showPremadeSelector };

--- a/src/random.js
+++ b/src/random.js
@@ -1,0 +1,83 @@
+import {
+  DATA,
+  loadClasses,
+  loadBackgrounds,
+  loadRaces,
+  fetchJsonWithRetry
+} from './data.js';
+
+function randomChoice(arr) {
+  return arr[Math.floor(Math.random() * arr.length)];
+}
+
+/**
+ * Generate a simple random character and store it for the main app to load.
+ */
+export async function generateRandomCharacter() {
+  await Promise.all([loadClasses(), loadBackgrounds(), loadRaces()]);
+
+  const raceGroup = randomChoice(Object.keys(DATA.races));
+  const raceVariant = randomChoice(DATA.races[raceGroup]);
+  const raceDetail = await fetchJsonWithRetry(
+    raceVariant.path,
+    `race at ${raceVariant.path}`
+  );
+
+  const backgroundName = randomChoice(Object.keys(DATA.backgrounds));
+  const background = DATA.backgrounds[backgroundName];
+  const classObj = randomChoice(DATA.classes);
+
+  const baseAbilities = { str: 10, dex: 10, con: 10, int: 10, wis: 10, cha: 10 };
+  const abilities = {};
+  for (const ab of Object.keys(baseAbilities)) {
+    abilities[ab] = { value: baseAbilities[ab] };
+  }
+
+  const character = {
+    playerName: '',
+    name: 'Random Hero',
+    type: 'character',
+    classes: [
+      {
+        name: classObj.name || classObj.className || 'Class',
+        level: 1,
+      },
+    ],
+    feats: [],
+    equipment: [],
+    knownSpells: {},
+    raceChoices: {
+      spells: [],
+      spellAbility: '',
+      size: '',
+      alterations: {},
+      resist: '',
+      tools: [],
+      weapons: [],
+    },
+    bonusAbilities: { str: 0, dex: 0, con: 0, int: 0, wis: 0, cha: 0 },
+    baseAbilities,
+    system: {
+      details: {
+        race: raceDetail.name || raceVariant.name || raceGroup,
+        background: background.name || backgroundName,
+        origin: '',
+        age: 0,
+      },
+      abilities,
+      skills: [],
+      tools: [],
+      spells: { cantrips: [], pact: { value: 0, max: 0, level: 0 } },
+      traits: { languages: { value: [] } },
+      expertise: [],
+      resources: {},
+      attributes: { prof: 2 },
+    },
+    prototypeToken: { name: 'Random Hero' },
+  };
+
+  localStorage.setItem('characterState', JSON.stringify(character));
+  window.location.href = 'index.html';
+}
+
+export default { generateRandomCharacter };


### PR DESCRIPTION
## Summary
- add module to select predefined characters from `data/premade`
- implement random character assembler using existing race/class/background data
- wire landing page buttons to new modules and auto-load Step 7 when a character is preselected

## Testing
- `npm test` *(fails: Race validation failed)*

------
https://chatgpt.com/codex/tasks/task_e_68b569afbed8832e96b9d287cb7b70f1