### PR TITLE
Capture extra FCC data in exports

### DIFF
--- a/__tests__/export.test.js
+++ b/__tests__/export.test.js
@@ -82,4 +82,30 @@ describe("exportFoundryActor", () => {
     const exported = exportFoundryActor(state);
     expect(exported).toEqual(template);
   });
+
+  test("exports tools, skills, and feats in flags", () => {
+    const state = {
+      playerName: "Bob",
+      name: "Tester",
+      type: "character",
+      feats: [{ name: "Alert" }, "Lucky"],
+      system: {
+        abilities: {},
+        tools: ["Thieves' Tools"],
+        skills: ["Stealth"],
+        attributes: {},
+        spells: {},
+        traits: { languages: { value: [] } },
+        details: {},
+      },
+      baseAbilities: {},
+      bonusAbilities: {},
+      prototypeToken: {},
+    };
+
+    const exported = exportFoundryActor(state);
+    expect(exported.flags.fcc.tools).toEqual(["Thieves' Tools"]);
+    expect(exported.flags.fcc.skills).toEqual(["Stealth"]);
+    expect(exported.flags.fcc.feats).toEqual(["Alert", "Lucky"]);
+  });
 });

--- a/__tests__/fixtures/sample-actor.json
+++ b/__tests__/fixtures/sample-actor.json
@@ -62,7 +62,10 @@
       "baseAbilities": { "str": 8, "dex": 8, "con": 8, "int": 8, "wis": 8, "cha": 8 },
       "languages": ["Common", "Elvish"],
       "raceChoices": { "spells": [], "spellAbility": "", "size": "", "alterations": {}, "resist": "", "tools": [], "weapons": [], "languages": [] },
-      "knownSpells": {}
+      "knownSpells": {},
+      "tools": [],
+      "skills": [],
+      "feats": ["Lucky"]
     }
   }
 }

--- a/src/export.js
+++ b/src/export.js
@@ -156,6 +156,9 @@ export function exportFoundryActor(state) {
         languages: clone(state.system?.traits?.languages?.value || []),
         raceChoices: clone(state.raceChoices || {}),
         knownSpells: clone(state.knownSpells || {}),
+        tools: clone(state.system.tools || []),
+        skills: clone(state.system.skills || []),
+        feats: clone((state.feats || []).map((f) => f.name || f)),
       },
     },
   };


### PR DESCRIPTION
## Summary
- include tools, skills, and feats arrays in exported `flags.fcc`
- add tests to ensure these fields persist in exported JSON

## Testing
- `npm test` *(fails: Race validation failed)*
- `node --experimental-vm-modules ./node_modules/jest/bin/jest.js` *(fails: step4.test.js and equipment.test.js)*
- `node --experimental-vm-modules ./node_modules/jest/bin/jest.js __tests__/export.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68b5773fc5e0832e9c79ccb674b9f27a