### PR TITLE
Show ability modifiers with styled ability boxes

### DIFF
--- a/css/character-sheet.css
+++ b/css/character-sheet.css
@@ -47,3 +47,30 @@
   text-align: center;
   margin-top: 0;
 }
+
+.character-sheet .ability-list {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  justify-content: space-around;
+}
+
+.character-sheet .ability-box {
+  width: 80px;
+  height: 90px;
+  border: 2px solid #000;
+  clip-path: polygon(25% 5%, 75% 5%, 100% 50%, 75% 95%, 25% 95%, 0% 50%);
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  font-weight: bold;
+}
+
+.character-sheet .ability-box .score {
+  font-size: 1.8em;
+}
+
+.character-sheet .ability-box .mod {
+  font-size: 0.8em;
+}

--- a/src/main.js
+++ b/src/main.js
@@ -162,11 +162,13 @@ function renderCharacterSheet() {
 
   const details = CharacterState.system?.details || {};
   const systemAbilities = CharacterState.system?.abilities || {};
-  const abilityRows = ["str", "dex", "con", "int", "wis", "cha"]
-    .map(
-      (ab) =>
-        `<tr><td>${ab.toUpperCase()}</td><td>${systemAbilities[ab]?.value ?? ""}</td></tr>`
-    )
+  const abilityBoxes = ["str", "dex", "con", "int", "wis", "cha"]
+    .map((ab) => {
+      const score = systemAbilities[ab]?.value ?? "";
+      const mod = score === "" ? "" : Math.floor((score - 10) / 2);
+      const modText = mod === "" ? "" : mod >= 0 ? `+${mod}` : `${mod}`;
+      return `<div class="ability-box" data-ab="${ab.toUpperCase()}"><div class="score">${score}</div><div class="mod">${modText}</div></div>`;
+    })
     .join("");
 
   const languagesHtml = summary.languages
@@ -190,10 +192,7 @@ function renderCharacterSheet() {
     </div>
     <section class="abilities">
       <h3>Abilities</h3>
-      <table>
-        <thead><tr><th>Ability</th><th>Score</th></tr></thead>
-        <tbody>${abilityRows}</tbody>
-      </table>
+      <div class="ability-list">${abilityBoxes}</div>
     </section>
     <section class="skills">
       ${summary.skills.length ? `<h3>Skills</h3><ul>${skillsHtml}</ul>` : ""}


### PR DESCRIPTION
## Summary
- Replace ability score table with flexbox layout of `.ability-box` elements
- Style ability boxes with hexagonal border and display ability modifier below score
- Calculate ability modifiers from existing ability scores in `renderCharacterSheet`

## Testing
- `npm test` *(fails: Race validation failed)*
- `node --experimental-vm-modules ./node_modules/jest/bin/jest.js` *(fails: step4.test.js and equipment.test.js)*

------
https://chatgpt.com/codex/tasks/task_e_68b57cc41d78832eb6c46630cb12d8a2