### PR TITLE
Add features, spells, and backstory sections

### DIFF
--- a/__tests__/summary-features-backstory.test.js
+++ b/__tests__/summary-features-backstory.test.js
@@ -1,0 +1,44 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import { jest } from '@jest/globals';
+
+jest.unstable_mockModule('../src/export-pdf.js', () => ({ exportPdf: jest.fn() }));
+
+const { CharacterState } = await import('../src/data.js');
+await import('../src/main.js');
+
+describe('renderCharacterSheet features and backstory', () => {
+  test('features and backstory appear in summary', () => {
+    document.body.innerHTML = '<div id="characterSheet"></div>';
+    Object.assign(CharacterState, {
+      playerName: 'Tester',
+      name: 'Hero',
+      classes: [],
+      feats: [{ name: 'Brave' }],
+      equipment: [],
+      system: {
+        details: { origin: 'Born in a small village.', age: '', race: '', background: '' },
+        abilities: {
+          str: { value: 8 },
+          dex: { value: 8 },
+          con: { value: 8 },
+          int: { value: 8 },
+          wis: { value: 8 },
+          cha: { value: 8 },
+        },
+        traits: { languages: { value: [] } },
+        tools: [],
+        skills: [],
+      },
+      knownSpells: {},
+    });
+    renderCharacterSheet();
+    const html = document.getElementById('characterSheet').innerHTML;
+    expect(html).toContain('<h3>Features</h3>');
+    expect(html).toContain('Brave');
+    expect(html).toContain('<h3>Backstory</h3>');
+    expect(html).toContain('Born in a small village.');
+  });
+});

--- a/css/character-sheet.css
+++ b/css/character-sheet.css
@@ -25,6 +25,14 @@
 .character-sheet .spells { grid-area: spells; }
 .character-sheet .backstory { grid-area: backstory; }
 
+.character-sheet .features,
+.character-sheet .spells,
+.character-sheet .backstory {
+  height: 250px;
+  overflow-y: auto;
+  border: 2px solid #000;
+}
+
 .character-sheet section {
   border: 1px solid #000;
   padding: 8px;

--- a/index.html
+++ b/index.html
@@ -302,6 +302,15 @@
         <h2>Step 7: Recap & Esportazione</h2>
         <div id="characterSheet" class="character-sheet"></div>
         <div class="form-group">
+          <label for="backstoryInput">Backstory:</label>
+          <textarea
+            id="backstoryInput"
+            class="form-control"
+            rows="4"
+            placeholder="Describe the character's backstory"
+          ></textarea>
+        </div>
+        <div class="form-group">
           <button id="downloadJson" class="btn btn-primary">Download JSON</button>
         </div>
         <div class="form-group">

--- a/src/main.js
+++ b/src/main.js
@@ -88,6 +88,10 @@ function showStep(step) {
     if (step === 7) {
       commitAbilities();
       renderCharacterSheet();
+      const backstoryInput = document.getElementById("backstoryInput");
+      if (backstoryInput) {
+        backstoryInput.value = CharacterState.system.details.origin || "";
+      }
     }
 
     const prevBtn = document.getElementById("prevStep");
@@ -198,7 +202,8 @@ function renderCharacterSheet() {
       ${summary.skills.length ? `<h3>Skills</h3><ul>${skillsHtml}</ul>` : ""}
     </section>
     <section class="features">
-      ${summary.features.length ? `<h3>Features</h3><ul>${featuresHtml}</ul>` : ""}
+      <h3>Features</h3>
+      <ul>${featuresHtml}</ul>
     </section>
     <section class="equipment">
       ${summary.equipment.length ? `<h3>Equipment</h3><ul>${equipmentHtml}</ul>` : ""}
@@ -208,7 +213,8 @@ function renderCharacterSheet() {
       ${summary.tools.length ? `<h3>Tools</h3><ul>${toolsHtml}</ul>` : ""}
     </section>
     <section class="spells">
-      ${summary.spells.length ? `<h3>Spells</h3><ul>${spellsHtml}</ul>` : ""}
+      <h3>Spells</h3>
+      <ul>${spellsHtml}</ul>
     </section>
     <section class="backstory">
       <h3>Backstory</h3>
@@ -348,6 +354,14 @@ document.addEventListener("DOMContentLoaded", async () => {
     renderCharacterSheet();
     exportPdf(CharacterState).catch((err) => console.error(err));
   });
+
+  const backstoryEl = document.getElementById("backstoryInput");
+  if (backstoryEl) {
+    backstoryEl.addEventListener("input", () => {
+      CharacterState.system.details.origin = backstoryEl.value;
+      renderCharacterSheet();
+    });
+  }
 
     // Step 1 inputs ----------------------------------------------------------
     const userNameEl = document.getElementById("userName");


### PR DESCRIPTION
## Summary
- Always show character sheet sections for features, spells, and backstory
- Style these sections as scrollable boxes
- Allow backstory text entry on the recap step
- Test rendering for features and backstory

## Testing
- `npm test` (fails: Race validation failed)
- `node --experimental-vm-modules ./node_modules/jest/bin/jest.js` (fails: step4.test.js: TypeError, equipment.test.js: Cannot find module html2canvas)


------
https://chatgpt.com/codex/tasks/task_e_68b57dbc40d8832e9917652402d38e67