### PR TITLE
Add responsive character sheet header

### DIFF
--- a/css/character-sheet.css
+++ b/css/character-sheet.css
@@ -16,7 +16,19 @@
   gap: 10px;
 }
 
-.character-sheet .sheet-header { grid-area: header; }
+.character-sheet .char-header {
+  grid-area: header;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+
+.character-sheet .char-header > div {
+  flex: 1 1 150px;
+  border: 1px solid #000;
+  padding: 4px;
+  box-sizing: border-box;
+}
 .character-sheet .abilities { grid-area: abilities; }
 .character-sheet .skills { grid-area: skills; }
 .character-sheet .features { grid-area: features; }

--- a/src/main.js
+++ b/src/main.js
@@ -225,13 +225,13 @@ function renderCharacterSheet() {
   const spellsHtml = summary.spells.map((s) => `<li>${s}</li>`).join("");
 
   container.innerHTML = `
-    <div class="sheet-header">
-      <h2>${CharacterState.name || ""}</h2>
-      <p><strong>Player:</strong> ${CharacterState.playerName || ""}</p>
-      <p><strong>Race:</strong> ${details.race || ""}</p>
-      <p><strong>Background:</strong> ${details.background || ""}</p>
-      <p><strong>Class:</strong> ${classText}</p>
-    </div>
+    <header class="char-header">
+      <div><strong>Name:</strong> ${CharacterState.name || ""}</div>
+      <div><strong>Class & Level:</strong> ${classText}</div>
+      <div><strong>Race:</strong> ${details.race || ""}</div>
+      <div><strong>Background:</strong> ${details.background || ""}</div>
+      <div><strong>Age:</strong> ${details.age || ""}</div>
+    </header>
     <section class="abilities">
       <h3>Abilities</h3>
       <div class="ability-list">${abilityBoxes}</div>


### PR DESCRIPTION
## Summary
- Replace text-based sheet header with structured `char-header` showing name, class & level, race, background, and age.
- Style new header and its fields with flex layout and bordered boxes for PDF-friendly display.

## Testing
- `npm test` *(fails: Race validation failed)*
- `node --experimental-vm-modules ./node_modules/jest/bin/jest.js` *(fails: some Jest suites failing, e.g., step4 and equipment tests)*

------
https://chatgpt.com/codex/tasks/task_e_68b594f3a7f4832e8777a5a67138b991