### PR TITLE
Enhance recap with detailed character information

### DIFF
--- a/__tests__/equipment.test.js
+++ b/__tests__/equipment.test.js
@@ -2,8 +2,12 @@
  * @jest-environment jsdom
  */
 
-import { loadStep5 } from '../src/step5.js';
-import { CharacterState } from '../src/data.js';
+import { jest } from '@jest/globals';
+
+jest.unstable_mockModule('../src/export-pdf.js', () => ({ exportPdf: jest.fn() }));
+
+const { loadStep5 } = await import('../src/step5.js');
+const { CharacterState } = await import('../src/data.js');
 import fs from 'fs';
 import path from 'path';
 import { fileURLToPath } from 'url';

--- a/__tests__/fixtures/sample-actor.json
+++ b/__tests__/fixtures/sample-actor.json
@@ -20,7 +20,7 @@
       "prof": 2,
       "movement": { "walk": 30 }
     },
-    "details": { "background": "Sage", "race": "Elf", "alignment": "", "origin": "Earth", "age": 30 },
+    "details": { "background": "Sage", "race": "Elf", "alignment": "", "origin": "Earth", "age": 30, "backstory": "" },
     "traits": {
       "size": "med",
       "senses": { "darkvision": 0 },

--- a/__tests__/step4.test.js
+++ b/__tests__/step4.test.js
@@ -12,6 +12,7 @@ jest.unstable_mockModule('../src/data.js', () => ({
       tools: [],
       traits: { languages: { value: [] } },
     },
+    showHelp: true,
   },
   logCharacterState: jest.fn(),
   fetchJsonWithRetry: jest.fn(),

--- a/__tests__/summary-features-backstory.test.js
+++ b/__tests__/summary-features-backstory.test.js
@@ -15,11 +15,20 @@ describe('renderCharacterSheet features and backstory', () => {
     Object.assign(CharacterState, {
       playerName: 'Tester',
       name: 'Hero',
-      classes: [],
+      classes: [
+        { name: 'Fighter', level: 1, features: [{ name: 'Second Wind' }] },
+      ],
+      raceFeatures: ['Darkvision'],
       feats: [{ name: 'Brave' }],
       equipment: [],
       system: {
-        details: { origin: 'Born in a small village.', age: '', race: '', background: '' },
+        details: {
+          origin: 'Village',
+          backstory: 'Born in a small village.',
+          age: '',
+          race: '',
+          background: '',
+        },
         abilities: {
           str: { value: 8 },
           dex: { value: 8 },
@@ -38,6 +47,8 @@ describe('renderCharacterSheet features and backstory', () => {
     const html = document.getElementById('characterSheet').innerHTML;
     expect(html).toContain('<h3>Features</h3>');
     expect(html).toContain('Brave');
+    expect(html).toContain('Second Wind');
+    expect(html).toContain('Darkvision');
     expect(html).toContain('<h3>Backstory</h3>');
     expect(html).toContain('Born in a small village.');
   });

--- a/__tests__/summary-skills-expertise.test.js
+++ b/__tests__/summary-skills-expertise.test.js
@@ -9,17 +9,14 @@ jest.unstable_mockModule('../src/export-pdf.js', () => ({ exportPdf: jest.fn() }
 const { CharacterState } = await import('../src/data.js');
 await import('../src/main.js');
 
-describe('renderCharacterSheet spells', () => {
-  test('spells appear in summary', () => {
+describe('renderCharacterSheet skill expertise', () => {
+  test('expertise shows two checked boxes', () => {
     document.body.innerHTML = '<div id="characterSheet"></div>';
     Object.assign(CharacterState, {
       playerName: 'Tester',
-      name: 'Mage',
+      name: 'Rogue',
       classes: [],
-      feats: [
-        { name: 'Magic Initiate', spells: { cantrips: ['Prestidigitation'], level1: 'Shield' } },
-      ],
-      raceChoices: { spells: ['Gust of Wind'] },
+      feats: [],
       equipment: [],
       system: {
         details: { origin: '', backstory: '', age: '', race: '', background: '' },
@@ -33,18 +30,19 @@ describe('renderCharacterSheet spells', () => {
         },
         traits: { languages: { value: [] } },
         tools: [],
-        skills: [],
-        spells: { cantrips: ['Light'] },
+        skills: ['Stealth'],
+        expertise: ['Stealth'],
       },
-      knownSpells: { Wizard: { 1: ['Magic Missile'] } },
+      knownSpells: {},
     });
     renderCharacterSheet();
-    const html = document.getElementById('characterSheet').innerHTML;
-    expect(html).toContain('<h3>Spells</h3>');
-    expect(html).toContain('Magic Missile');
-    expect(html).toContain('Shield');
-    expect(html).toContain('Light');
-    expect(html).toContain('Gust of Wind');
-    expect(html).toContain('Prestidigitation');
+    const li = [...document.querySelectorAll('section.skills li')].find(el =>
+      el.textContent.includes('Stealth')
+    );
+    expect(li).toBeTruthy();
+    const boxes = li.querySelectorAll('input[type="checkbox"]');
+    expect(boxes.length).toBe(2);
+    expect(boxes[0].checked).toBe(true);
+    expect(boxes[1].checked).toBe(true);
   });
 });

--- a/src/data.js
+++ b/src/data.js
@@ -186,6 +186,7 @@ export const CharacterState = {
   equipment: [],
   knownSpells: {},
   showHelp: false,
+  raceFeatures: [],
   raceChoices: {
     spells: [],
     spellAbility: '',
@@ -230,6 +231,7 @@ export const CharacterState = {
       alignment: "",
       origin: "",
       age: 0,
+      backstory: "",
     },
     traits: {
       size: "med",

--- a/src/export.js
+++ b/src/export.js
@@ -166,6 +166,7 @@ export function exportFoundryActor(state) {
   if (!actor.system.details) actor.system.details = {};
   actor.system.details.origin = state.system?.details?.origin || "";
   actor.system.details.age = state.system?.details?.age ?? 0;
+  actor.system.details.backstory = state.system?.details?.backstory || "";
 
   if (state.system?.details?.race) {
     actor.items.push({ name: state.system.details.race, type: "race", system: {} });

--- a/src/step3.js
+++ b/src/step3.js
@@ -1056,6 +1056,9 @@ function confirmRaceSelection() {
 
   CharacterState.system.details.race = selectedBaseRace;
   CharacterState.system.details.subrace = currentRaceData.name;
+  CharacterState.raceFeatures = (currentRaceData.entries || [])
+    .filter((e) => typeof e === 'object' && e.name)
+    .map((e) => e.name);
 
   const sizeMap = { T: 'tiny', S: 'sm', M: 'med', L: 'lg', H: 'huge', G: 'grg' };
   if (currentRaceData.size) {
@@ -1385,6 +1388,7 @@ export async function loadStep3(force = false) {
       CharacterState.raceChoices.spells = [];
       CharacterState.raceChoices.spellAbility = '';
       CharacterState.raceChoices.size = '';
+      CharacterState.raceFeatures = [];
       const removeRes = [];
       (currentRaceData.resist || []).forEach((r) => {
         if (typeof r === 'string') removeRes.push(r);


### PR DESCRIPTION
## Summary
- Display player name, character name, origin, age, and expanded features on the recap
- Include spells from all sources and show skill expertise with dual checkboxes
- Preserve race features and backstory in export data

## Testing
- `npm test` *(fails: altered.json missing selection metadata)*
- `node --experimental-vm-modules ./node_modules/jest/bin/jest.js`

------
https://chatgpt.com/codex/tasks/task_e_68b598eab680832ea2d13a01063a45c3