### PR TITLE
Add source tags and inline backstory editing to recap

### DIFF
--- a/__tests__/summary-features-backstory.test.js
+++ b/__tests__/summary-features-backstory.test.js
@@ -46,9 +46,9 @@ describe('renderCharacterSheet features and backstory', () => {
     renderCharacterSheet();
     const html = document.getElementById('characterSheet').innerHTML;
     expect(html).toContain('<h3>Features</h3>');
-    expect(html).toContain('Brave');
-    expect(html).toContain('Second Wind');
-    expect(html).toContain('Darkvision');
+    expect(html).toContain('Brave (Feat)');
+    expect(html).toContain('Second Wind (Class: Fighter)');
+    expect(html).toContain('Darkvision (Race)');
     expect(html).toContain('<h3>Backstory</h3>');
     expect(html).toContain('Born in a small village.');
   });

--- a/__tests__/summary-spells.test.js
+++ b/__tests__/summary-spells.test.js
@@ -41,10 +41,10 @@ describe('renderCharacterSheet spells', () => {
     renderCharacterSheet();
     const html = document.getElementById('characterSheet').innerHTML;
     expect(html).toContain('<h3>Spells</h3>');
-    expect(html).toContain('Magic Missile');
-    expect(html).toContain('Shield');
-    expect(html).toContain('Light');
-    expect(html).toContain('Gust of Wind');
-    expect(html).toContain('Prestidigitation');
+    expect(html).toContain('Magic Missile (Class: Wizard)');
+    expect(html).toContain('Shield (Feat: Magic Initiate)');
+    expect(html).toContain('Light (Class)');
+    expect(html).toContain('Gust of Wind (Race)');
+    expect(html).toContain('Prestidigitation (Feat: Magic Initiate)');
   });
 });

--- a/css/character-sheet.css
+++ b/css/character-sheet.css
@@ -83,7 +83,7 @@
   display: flex;
   flex-direction: column;
   align-items: center;
-  justify-content: center;
+  justify-content: space-around;
   font-weight: bold;
 }
 
@@ -92,6 +92,10 @@
 }
 
 .character-sheet .ability-box .mod {
+  font-size: 0.8em;
+}
+
+.character-sheet .ability-box .label {
   font-size: 0.8em;
 }
 

--- a/index.html
+++ b/index.html
@@ -302,15 +302,6 @@
         <h2>Step 7: Recap & Esportazione</h2>
         <div id="characterSheet" class="character-sheet"></div>
         <div class="form-group">
-          <label for="backstoryInput">Backstory:</label>
-          <textarea
-            id="backstoryInput"
-            class="form-control"
-            rows="4"
-            placeholder="Describe the character's backstory"
-          ></textarea>
-        </div>
-        <div class="form-group">
           <button id="downloadJson" class="btn btn-primary">Download JSON</button>
         </div>
         <div class="form-group">

--- a/src/data.js
+++ b/src/data.js
@@ -187,6 +187,10 @@ export const CharacterState = {
   knownSpells: {},
   showHelp: false,
   raceFeatures: [],
+  proficiencySources: {
+    languages: {},
+    tools: {},
+  },
   raceChoices: {
     spells: [],
     spellAbility: '',

--- a/src/feat.js
+++ b/src/feat.js
@@ -528,14 +528,19 @@ export async function renderFeatChoices(featName, container, onChange = () => {}
       featObj.tools = [];
       toolSelects.forEach((sel) => {
         featObj.tools.push(sel.value);
-        addUniqueProficiency('tools', sel.value, container);
+        addUniqueProficiency('tools', sel.value, container, `Feat: ${feat.name}`);
       });
     }
     if (languageSelects.length) {
       featObj.languages = [];
       languageSelects.forEach((sel) => {
         featObj.languages.push(sel.value);
-        addUniqueProficiency('languages', sel.value, container);
+        addUniqueProficiency(
+          'languages',
+          sel.value,
+          container,
+          `Feat: ${feat.name}`
+        );
       });
     }
     if (weaponSelects.length) {

--- a/src/proficiency.js
+++ b/src/proficiency.js
@@ -100,11 +100,18 @@ export function pendingReplacements(type) {
   );
 }
 
-export function addUniqueProficiency(type, value, container) {
+export function addUniqueProficiency(type, value, container, source = '') {
   if (!value) return null;
   const list = getProficiencyList(type);
   if (!list.includes(value)) {
     list.push(value);
+    if (source) {
+      CharacterState.proficiencySources = CharacterState.proficiencySources || {};
+      const map =
+        (CharacterState.proficiencySources[type] =
+          CharacterState.proficiencySources[type] || {});
+      map[value] = source;
+    }
     logCharacterState();
     return null;
   }

--- a/src/step3.js
+++ b/src/step3.js
@@ -1137,7 +1137,12 @@ function confirmRaceSelection() {
       for (const k in obj)
         if (k !== 'any' && k !== 'choose' && obj[k]) {
           const val = capitalize(k);
-          const sel = addUniqueProficiency('tools', val, container);
+          const sel = addUniqueProficiency(
+            'tools',
+            val,
+            container,
+            'Race'
+          );
           if (sel) {
             sel.dataset.proftype = 'tools';
             replacements.push(sel);
@@ -1150,7 +1155,7 @@ function confirmRaceSelection() {
     });
   }
   pendingRaceChoices.tools.forEach((sel) => {
-    const repl = addUniqueProficiency('tools', sel.value, container);
+    const repl = addUniqueProficiency('tools', sel.value, container, 'Race');
     if (repl) {
       repl.dataset.proftype = 'tools';
       replacements.push(repl);
@@ -1205,7 +1210,12 @@ function confirmRaceSelection() {
       for (const k in obj)
         if (k !== 'anyStandard' && obj[k]) {
           const val = capitalize(k);
-          const sel = addUniqueProficiency('languages', val, container);
+          const sel = addUniqueProficiency(
+            'languages',
+            val,
+            container,
+            'Race'
+          );
           if (sel) {
             sel.dataset.proftype = 'languages';
             replacements.push(sel);
@@ -1218,7 +1228,12 @@ function confirmRaceSelection() {
     });
   }
   pendingRaceChoices.languages.forEach((sel) => {
-    const repl = addUniqueProficiency('languages', sel.value, container);
+    const repl = addUniqueProficiency(
+      'languages',
+      sel.value,
+      container,
+      'Race'
+    );
     if (repl) {
       repl.dataset.proftype = 'languages';
       replacements.push(repl);

--- a/src/step4.js
+++ b/src/step4.js
@@ -340,12 +340,12 @@ async function confirmBackgroundSelection() {
 
   if (Array.isArray(currentBackgroundData.tools)) {
     currentBackgroundData.tools.forEach((t) => {
-      const sel = addUniqueProficiency('tools', t, container);
+      const sel = addUniqueProficiency('tools', t, container, 'Background');
       if (sel) replacements.push(sel);
     });
   }
   pendingSelections.tools.forEach((sel) => {
-    const repl = addUniqueProficiency('tools', sel.value, container);
+    const repl = addUniqueProficiency('tools', sel.value, container, 'Background');
     if (repl) replacements.push(repl);
     sel.disabled = true;
   });
@@ -356,12 +356,22 @@ async function confirmBackgroundSelection() {
   }
   if (Array.isArray(currentBackgroundData.languages)) {
     currentBackgroundData.languages.forEach((l) => {
-      const sel = addUniqueProficiency('languages', l, container);
+      const sel = addUniqueProficiency(
+        'languages',
+        l,
+        container,
+        'Background'
+      );
       if (sel) replacements.push(sel);
     });
   }
   pendingSelections.languages.forEach((sel) => {
-    const repl = addUniqueProficiency('languages', sel.value, container);
+    const repl = addUniqueProficiency(
+      'languages',
+      sel.value,
+      container,
+      'Background'
+    );
     if (repl) replacements.push(repl);
     sel.disabled = true;
   });


### PR DESCRIPTION
## Summary
- show ability scores with explicit three-letter labels
- tag features, languages, tools, and spells with their origins in the recap
- allow editing backstory directly within the recap and better capture player name

## Testing
- `npm test` *(fails: Race validation failed)*
- `node --experimental-vm-modules ./node_modules/jest/bin/jest.js`

------
https://chatgpt.com/codex/tasks/task_e_68b59df1cea0832e9a52b748b9fc06ec