### PR TITLE
Re-render class cards when changing level

### DIFF
--- a/src/step2.js
+++ b/src/step2.js
@@ -496,9 +496,7 @@ function renderClassEditor(cls, index) {
         c.spellItem = newItem;
       }
     });
-    updateExpertiseSelectOptions(
-      document.querySelectorAll("select[data-type='expertise']")
-    );
+    renderSelectedClasses();
     updateStep2Completion();
   });
   card.appendChild(levelSel);


### PR DESCRIPTION
## Summary
- Re-render selected class cards after level changes so new features display
- Remove redundant expertise selector refresh

## Testing
- `npm test` *(fails: Race validation failed)*

------
https://chatgpt.com/codex/tasks/task_e_68b5a2893468832e8b58bf8ebc1342f0