### PR TITLE
Adjust character grid layout and card size

### DIFF
--- a/css/site-theme.css
+++ b/css/site-theme.css
@@ -226,9 +226,10 @@ th {
 
 .class-list {
   display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
-  gap: 1rem;
-  justify-content: center;
+  grid-template-columns: repeat(auto-fill, minmax(240px, 1fr));
+  gap: 1.5rem;
+  max-width: 1100px;
+  margin: 0 auto;
 }
 
 /* Accordion styles */
@@ -359,7 +360,7 @@ th {
 
 .class-card {
   width: 100%;
-  aspect-ratio: 1 / 1;
+  min-height: 240px;
   display: flex;
   flex-direction: column;
   justify-content: space-between;


### PR DESCRIPTION
## Summary
- widen class selection grid to max 4 columns with added spacing
- let class cards grow vertically with a minimum height to avoid overflow

## Testing
- `npm run build` *(fails: Cannot find module 'rollup.config.js')*
- `npm test` *(fails: Race validation failed: missing selection metadata)*

------
https://chatgpt.com/codex/tasks/task_e_68b5a29b3ba8832e91cdf6bd4fd5aaae