### PR TITLE
Preserve ability bonuses when adding racial increases

### DIFF
--- a/__tests__/asiFeatIntegration.test.js
+++ b/__tests__/asiFeatIntegration.test.js
@@ -69,5 +69,65 @@ describe('ASI and feat bonuses', () => {
     expect(CharacterState.system.abilities.str.value).toBe(13);
     expect(CharacterState.bonusAbilities.str).toBe(3);
   });
+
+  test('racial bonuses merge with existing ability bonuses', () => {
+    CharacterState.feats = [{ name: 'TestFeat', ability: { str: 1 } }];
+    CharacterState.classes = [{ name: 'Fighter', level: 4, asiBonuses: { str: 2 } }];
+    refreshBaseState();
+    rebuildFromClasses();
+
+    document.body.innerHTML = `
+      <div id="step6">
+        <table>
+          <tr>
+            <td>STR</td>
+            <td><button class="btn">+</button><button class="btn">-</button></td>
+            <td><span id="strPoints"></span></td>
+            <td><span id="strBonusModifier"></span></td>
+            <td id="strFinalScore"></td>
+          </tr>
+          <tr>
+            <td>DEX</td>
+            <td><button class="btn">+</button><button class="btn">-</button></td>
+            <td><span id="dexPoints"></span></td>
+            <td><span id="dexBonusModifier"></span></td>
+            <td id="dexFinalScore"></td>
+          </tr>
+          <tr>
+            <td>CON</td>
+            <td><button class="btn">+</button><button class="btn">-</button></td>
+            <td><span id="conPoints"></span></td>
+            <td><span id="conBonusModifier"></span></td>
+            <td id="conFinalScore"></td>
+          </tr>
+        </table>
+        <select id="bonusSelect1">
+          <option value=""></option>
+          <option value="dex">DEX</option>
+        </select>
+        <select id="bonusSelect2">
+          <option value=""></option>
+          <option value="dex">DEX</option>
+        </select>
+        <select id="bonusSelect3">
+          <option value=""></option>
+          <option value="con">CON</option>
+        </select>
+        <button id="applyBonus">apply</button>
+      </div>
+    `;
+
+    document.getElementById('bonusSelect1').value = 'dex';
+    document.getElementById('bonusSelect2').value = 'dex';
+    document.getElementById('bonusSelect3').value = 'con';
+
+    loadStep6(true);
+    document.getElementById('applyBonus').click();
+
+    expect(CharacterState.bonusAbilities.str).toBe(3);
+    expect(CharacterState.bonusAbilities.dex).toBe(2);
+    expect(CharacterState.bonusAbilities.con).toBe(1);
+    expect(document.getElementById('strBonusModifier').textContent).toBe('3');
+  });
 });
 

--- a/src/step6.js
+++ b/src/step6.js
@@ -90,9 +90,10 @@ function applyBonus() {
     alert(t('invalidBonusDistribution'));
     return;
   }
-  CharacterState.bonusAbilities = {};
+  CharacterState.bonusAbilities = { ...CharacterState.bonusAbilities };
   Object.entries(counts).forEach(([ab, val]) => {
-    CharacterState.bonusAbilities[ab] = val;
+    CharacterState.bonusAbilities[ab] =
+      (CharacterState.bonusAbilities[ab] || 0) + val;
   });
   ABILITIES.forEach(updateFinal);
   validateAbilities();


### PR DESCRIPTION
## Summary
- Merge racial ability bonuses with existing ASI and feat bonuses instead of resetting them
- Add integration test ensuring racial bonuses don't overwrite prior ASI/feat bonuses

## Testing
- `npm run validate:races` *(fails: altered.json missing selection metadata for: size, ...)*
- `node --experimental-vm-modules ./node_modules/jest/bin/jest.js`


------
https://chatgpt.com/codex/tasks/task_e_68b5e26a15ec832eae43110fe21d3989