### PR TITLE
Include class feature descriptions in choice accordions

### DIFF
--- a/__tests__/step2.test.js
+++ b/__tests__/step2.test.js
@@ -4,7 +4,10 @@
 
 import { jest } from '@jest/globals';
 import * as Step2 from '../src/step2.js';
-import { CharacterState } from '../src/data.js';
+import { CharacterState, DATA } from '../src/data.js';
+import { readFileSync } from 'fs';
+import path from 'path';
+import { fileURLToPath } from 'url';
 
 describe('duplicate selection prevention', () => {
   beforeEach(() => {
@@ -124,5 +127,37 @@ describe('duplicate selection prevention', () => {
     expect(CharacterState.classes).toHaveLength(1);
     expect(alertMock).toHaveBeenCalled();
     alertMock.mockRestore();
+  });
+});
+
+describe('choice feature descriptions', () => {
+  test('Fighting Style accordion includes feature description and select', () => {
+    const __dirname = path.dirname(fileURLToPath(import.meta.url));
+    const fighterData = JSON.parse(
+      readFileSync(path.join(__dirname, '../data/classes/fighter.json'), 'utf8')
+    );
+    DATA.classes = [fighterData];
+    CharacterState.showHelp = true;
+    const cls = {
+      name: 'Fighter',
+      level: 1,
+      fixed_proficiencies: [],
+      skill_choices: [],
+      spellcasting: {},
+      skills: [],
+      choiceSelections: {},
+      expertise: [],
+    };
+    const card = Step2.renderClassEditor(cls, 0);
+    const items = Array.from(card.querySelectorAll('.accordion-item'));
+    const fsItem = items.find(item =>
+      item.querySelector('.accordion-header').textContent.includes('Fighting Style')
+    );
+    expect(fsItem).toBeTruthy();
+    const body = fsItem.querySelector('.accordion-content');
+    expect(body.textContent).toContain(
+      'Adopt a particular style of fighting as your specialty.'
+    );
+    expect(body.querySelector('select')).not.toBeNull();
   });
 });

--- a/src/step2.js
+++ b/src/step2.js
@@ -618,23 +618,26 @@ function renderClassEditor(cls, index) {
     }
 
     for (let lvl = 1; lvl <= (cls.level || 1); lvl++) {
-      const levelChoices = (clsDef.choices || []).filter(c => c.level === lvl);
+      const levelChoices = [
+        ...(clsDef.choices || []).filter(c => c.level === lvl),
+        ...(cls.subclassData?.choices || []).filter(c => c.level === lvl),
+      ];
       const features = [
         ...(clsDef.features_by_level?.[lvl] || []),
         ...(cls.subclassData?.features_by_level?.[lvl] || []),
-      ].filter(f => !levelChoices.some(c => c.name === f.name));
-      features.forEach(f => {
-        const body = document.createElement('div');
-        if (CharacterState.showHelp && f.description)
-          body.appendChild(createElement('p', f.description));
-        appendEntries(body, f.entries);
-        accordion.appendChild(
-          createAccordionItem(`${t('level')} ${lvl}: ${f.name}`, body)
-        );
-      });
+      ];
 
       levelChoices.forEach(choice => {
         const cContainer = document.createElement('div');
+
+        const fIdx = features.findIndex(f => f.name === choice.name);
+        if (fIdx >= 0) {
+          const feature = features.splice(fIdx, 1)[0];
+          if (CharacterState.showHelp && feature.description)
+            cContainer.appendChild(createElement('p', feature.description));
+          appendEntries(cContainer, feature.entries);
+        }
+
         if (CharacterState.showHelp && choice.description)
           cContainer.appendChild(createElement('p', choice.description));
         appendEntries(cContainer, choice.entries);
@@ -766,6 +769,15 @@ function renderClassEditor(cls, index) {
             cContainer,
             true
           )
+        );
+      });
+      features.forEach(f => {
+        const body = document.createElement('div');
+        if (CharacterState.showHelp && f.description)
+          body.appendChild(createElement('p', f.description));
+        appendEntries(body, f.entries);
+        accordion.appendChild(
+          createAccordionItem(`${t('level')} ${lvl}: ${f.name}`, body)
         );
       });
     }
@@ -1146,4 +1158,5 @@ export {
   refreshBaseState,
   rebuildFromClasses,
   selectClass,
+  renderClassEditor,
 };


### PR DESCRIPTION
## Summary
- show matching class or subclass feature text before choice controls
- support subclass choices and avoid duplicate feature accordions
- test Fighting Style choice for feature description and select UI

## Testing
- `npm test` *(fails: Race validation failed)*
- `node --experimental-vm-modules ./node_modules/jest/bin/jest.js __tests__/step2.test.js`

------
https://chatgpt.com/codex/tasks/task_e_68b5f948f944832e9142c0714b9e5411