### PR TITLE
Preserve state when revisiting steps

### DIFF
--- a/__tests__/showStep.test.js
+++ b/__tests__/showStep.test.js
@@ -1,0 +1,92 @@
+/**
+ * @jest-environment jsdom
+ */
+import { jest } from '@jest/globals';
+
+const loadStep3 = jest.fn();
+const loadStep4 = jest.fn();
+const loadStep5 = jest.fn();
+const loadStep6 = jest.fn();
+
+jest.unstable_mockModule('../src/step4.js', () => ({
+  loadStep4,
+  isStepComplete: jest.fn(),
+  confirmStep: jest.fn(),
+}));
+
+jest.unstable_mockModule('../src/step5.js', () => ({
+  loadStep5,
+  isStepComplete: jest.fn(),
+}));
+
+jest.unstable_mockModule('../src/step6.js', () => ({
+  loadStep6,
+  commitAbilities: jest.fn(),
+}));
+
+jest.unstable_mockModule('../src/data.js', () => ({
+  DATA: {},
+  CharacterState: {},
+  loadClasses: jest.fn(),
+  loadBackgrounds: jest.fn(),
+  fetchJsonWithRetry: jest.fn(),
+}));
+
+jest.unstable_mockModule('../src/step2.js', () => ({
+  loadStep2: jest.fn(),
+  rebuildFromClasses: jest.fn(),
+  refreshBaseState: jest.fn(),
+  isStepComplete: jest.fn(),
+  confirmStep: jest.fn(),
+}));
+
+jest.unstable_mockModule('../src/step3.js', () => ({
+  loadStep3,
+  isStepComplete: jest.fn(),
+  confirmStep: jest.fn(),
+}));
+
+jest.unstable_mockModule('../src/i18n.js', () => ({
+  t: (k) => k,
+  initI18n: jest.fn(),
+  applyTranslations: jest.fn(),
+}));
+
+jest.unstable_mockModule('../src/export.js', () => ({
+  exportFoundryActor: jest.fn(),
+}));
+
+jest.unstable_mockModule('../src/export-pdf.js', () => ({
+  exportPdf: jest.fn(),
+}));
+
+const { showStep } = await import('../src/main.js');
+
+beforeEach(() => {
+  document.body.innerHTML = `
+    <div id="step3"></div>
+    <div id="step4"></div>
+    <div id="step5"></div>
+    <div id="progressBar"></div>
+  `;
+  loadStep3.mockClear();
+  loadStep4.mockClear();
+  loadStep5.mockClear();
+  loadStep6.mockClear();
+});
+
+test('loadStep3-5 receive firstVisit flag correctly', () => {
+  showStep(3);
+  showStep(3);
+  showStep(4);
+  showStep(4);
+  showStep(5);
+  showStep(5);
+  expect(loadStep3).toHaveBeenNthCalledWith(1, true);
+  expect(loadStep3).toHaveBeenNthCalledWith(2, false);
+  expect(loadStep4).toHaveBeenNthCalledWith(1, true);
+  expect(loadStep4).toHaveBeenNthCalledWith(2, false);
+  expect(loadStep5).toHaveBeenNthCalledWith(1, true);
+  expect(loadStep5).toHaveBeenNthCalledWith(2, false);
+});
+

--- a/src/main.js
+++ b/src/main.js
@@ -61,6 +61,7 @@ function setCurrentStepComplete(flag) {
 globalThis.setCurrentStepComplete = setCurrentStepComplete;
 
 function showStep(step) {
+    const firstVisit = !visitedSteps.has(step);
     visitedSteps.add(step);
     for (let i = 1; i <= 7; i++) {
       const el = document.getElementById(`step${i}`);
@@ -82,9 +83,10 @@ function showStep(step) {
       // Placeholder for contextual help integration
       console.log(`Help: display guidance for step ${step}`);
     }
-    if (step === 4) loadStep4(true);
-    if (step === 5) loadStep5(true);
-    if (step === 6) loadStep6(true);
+    if (step === 3) loadStep3(firstVisit);
+    if (step === 4) loadStep4(firstVisit);
+    if (step === 5) loadStep5(firstVisit);
+    if (step === 6) loadStep6(firstVisit);
     if (step === 7) {
       commitAbilities();
       CharacterState.playerName =


### PR DESCRIPTION
## Summary
- Track whether each step is visited for the first time before adding it to `visitedSteps`
- Pass that flag into `loadStep3`, `loadStep4`, `loadStep5`, and `loadStep6` so revisiting steps preserves selections
- Expand tests ensuring `showStep` sends the correct first-visit flag for steps 3–5

## Testing
- `npm test` *(fails: Race validation failed)*
- `node --experimental-vm-modules ./node_modules/jest/bin/jest.js __tests__/showStep.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68b60472c12c832e946122e817608e1b