### PR TITLE
Render feature and choice descriptions regardless of help toggle

### DIFF
--- a/__tests__/step2.test.js
+++ b/__tests__/step2.test.js
@@ -130,14 +130,14 @@ describe('duplicate selection prevention', () => {
   });
 });
 
-describe('choice feature descriptions', () => {
-  test('Fighting Style accordion includes feature description and select', () => {
+describe('feature descriptions', () => {
+  test('Fighting Style and Second Wind descriptions render', () => {
     const __dirname = path.dirname(fileURLToPath(import.meta.url));
     const fighterData = JSON.parse(
       readFileSync(path.join(__dirname, '../data/classes/fighter.json'), 'utf8')
     );
     DATA.classes = [fighterData];
-    CharacterState.showHelp = true;
+    CharacterState.showHelp = false;
     const cls = {
       name: 'Fighter',
       level: 1,
@@ -154,10 +154,19 @@ describe('choice feature descriptions', () => {
       item.querySelector('.accordion-header').textContent.includes('Fighting Style')
     );
     expect(fsItem).toBeTruthy();
-    const body = fsItem.querySelector('.accordion-content');
-    expect(body.textContent).toContain(
+    const fsBody = fsItem.querySelector('.accordion-content');
+    expect(fsBody.textContent).toContain(
       'Adopt a particular style of fighting as your specialty.'
     );
-    expect(body.querySelector('select')).not.toBeNull();
+    expect(fsBody.querySelector('select')).not.toBeNull();
+
+    const swItem = items.find(item =>
+      item.querySelector('.accordion-header').textContent.includes('Second Wind')
+    );
+    expect(swItem).toBeTruthy();
+    const swBody = swItem.querySelector('.accordion-content');
+    expect(swBody.textContent).toContain(
+      'Use a bonus action to regain hit points equal to 1d10 + your fighter level once per short or long rest.'
+    );
   });
 });

--- a/src/step2.js
+++ b/src/step2.js
@@ -633,12 +633,12 @@ function renderClassEditor(cls, index) {
         const fIdx = features.findIndex(f => f.name === choice.name);
         if (fIdx >= 0) {
           const feature = features.splice(fIdx, 1)[0];
-          if (CharacterState.showHelp && feature.description)
+          if (feature.description)
             cContainer.appendChild(createElement('p', feature.description));
           appendEntries(cContainer, feature.entries);
         }
 
-        if (CharacterState.showHelp && choice.description)
+        if (choice.description)
           cContainer.appendChild(createElement('p', choice.description));
         appendEntries(cContainer, choice.entries);
         const count = choice.count || 1;
@@ -773,7 +773,7 @@ function renderClassEditor(cls, index) {
       });
       features.forEach(f => {
         const body = document.createElement('div');
-        if (CharacterState.showHelp && f.description)
+        if (f.description)
           body.appendChild(createElement('p', f.description));
         appendEntries(body, f.entries);
         accordion.appendChild(


### PR DESCRIPTION
## Summary
- Remove `CharacterState.showHelp` gating for feature and choice descriptions
- Always append descriptions before entry content
- Test that descriptions render without enabling help

## Testing
- ❌ `npm test` (Race validation failed)
- ✅ `NODE_OPTIONS=--experimental-vm-modules npx jest __tests__/step2.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68b608bf6b78832e92c138135326204d