### PR TITLE
Ensure race trait descriptions display by default

### DIFF
--- a/__tests__/step3.test.js
+++ b/__tests__/step3.test.js
@@ -648,3 +648,71 @@ describe('race skill proficiency choices', () => {
   });
 });
 
+describe('race trait descriptions', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    document.body.innerHTML = `
+      <div id="raceList"></div>
+      <div id="raceFeatures"></div>
+      <div id="raceTraits"></div>
+      <input id="raceSearch" />
+      <button id="changeRace"></button>
+    `;
+    CharacterState.showHelp = false;
+    DATA.races = {
+      Test: [{ name: 'Test', path: 'testRace' }],
+    };
+    const race = {
+      name: 'Test',
+      size: ['S', 'M'],
+      languageProficiencies: [{ common: true }],
+      resist: ['poison'],
+      entries: [
+        { name: 'Size', description: 'size description', entries: ['size entry'] },
+        {
+          name: 'Languages',
+          description: 'language description',
+          entries: ['language entry'],
+        },
+        {
+          name: 'Poison Resistance',
+          description: 'resist description',
+          entries: ['resist entry'],
+        },
+        {
+          name: 'Extra Trait',
+          description: 'trait description',
+          entries: ['trait entry'],
+        },
+      ],
+    };
+    CharacterState.system.traits.languages.value = [];
+    CharacterState.system.traits.damageResist = [];
+    CharacterState.raceChoices = {
+      spells: [],
+      spellAbility: '',
+      size: '',
+      resist: '',
+      tools: [],
+      weapons: [],
+    };
+    mockFetch.mockResolvedValue(race);
+  });
+
+  test('shows descriptions for size, language, resistance, and traits', async () => {
+    await loadStep3(true);
+    await selectBaseRace('Test');
+    document.querySelector('#raceList .class-card').click();
+    await new Promise((r) => setTimeout(r, 0));
+    const text = document.getElementById('raceFeatures').textContent;
+    expect(text).toContain('size description');
+    expect(text).toContain('size entry');
+    expect(text).toContain('language description');
+    expect(text).toContain('language entry');
+    expect(text).toContain('resist description');
+    expect(text).toContain('resist entry');
+    expect(text).toContain('trait description');
+    expect(text).toContain('trait entry');
+  });
+});
+

--- a/src/step3.js
+++ b/src/step3.js
@@ -401,8 +401,8 @@ async function renderSelectedRace() {
       e => e.name && e.name.toLowerCase() === 'size'
     );
     if (sizeEntry) {
-        if (CharacterState.showHelp && sizeEntry.description)
-          sizeContent.appendChild(createElement('p', sizeEntry.description));
+      if (sizeEntry.description)
+        sizeContent.appendChild(createElement('p', sizeEntry.description));
       appendEntries(sizeContent, sizeEntry.entries);
       usedEntries.add(sizeEntry.name);
     }
@@ -671,7 +671,7 @@ async function renderSelectedRace() {
         e => e.name && e.name.toLowerCase() === 'languages'
       );
       if (langEntry) {
-        if (CharacterState.showHelp && langEntry.description)
+        if (langEntry.description)
           langContent.appendChild(createElement('p', langEntry.description));
         appendEntries(langContent, langEntry.entries);
         usedEntries.add(langEntry.name);
@@ -724,7 +724,7 @@ async function renderSelectedRace() {
         (e) => e.name && /resist/i.test(e.name)
       );
       if (resistEntry) {
-        if (CharacterState.showHelp && resistEntry.description)
+        if (resistEntry.description)
           resistContent.appendChild(createElement('p', resistEntry.description));
         appendEntries(resistContent, resistEntry.entries);
         usedEntries.add(resistEntry.name);
@@ -869,7 +869,7 @@ async function renderSelectedRace() {
     if (abilityOpts) {
       const abilityContent = document.createElement('div');
       if (spellEntry) {
-        if (CharacterState.showHelp && spellEntry.description)
+        if (spellEntry.description)
           abilityContent.appendChild(createElement('p', spellEntry.description));
         appendEntries(abilityContent, spellEntry.entries);
         usedEntries.add(spellEntry.name);
@@ -920,7 +920,7 @@ async function renderSelectedRace() {
       };
       const spellContent = document.createElement('div');
       if (spellEntry && !spellEntryUsed) {
-        if (CharacterState.showHelp && spellEntry.description)
+        if (spellEntry.description)
           spellContent.appendChild(createElement('p', spellEntry.description));
         appendEntries(spellContent, spellEntry.entries);
         usedEntries.add(spellEntry.name);
@@ -1010,7 +1010,7 @@ async function renderSelectedRace() {
   Object.values(entryMap).forEach(e => {
     if (!e.name || usedEntries.has(e.name)) return;
     const body = document.createElement('div');
-    if (CharacterState.showHelp && e.description)
+    if (e.description)
       body.appendChild(createElement('p', e.description));
     appendEntries(body, e.entries);
     accordion.appendChild(createAccordionItem(e.name, body));


### PR DESCRIPTION
## Summary
- Always include race trait descriptions for size, languages, damage resistances, spells, and other traits
- Add tests verifying descriptions and entries render without help toggle

## Testing
- `npm test` *(fails: altered.json missing selection metadata for size; changeling.json missing selection metadata for size; dhampir.json missing selection metadata for size; elfsea.json missing selection metadata for languageProficiencies; genasiair.json missing selection metadata for size; genasiearth.json missing selection metadata for size; genasifire.json missing selection metadata for size; genasiwater.json missing selection metadata for size; harengon.json missing selection metadata for size; hexblood.json missing selection metadata for size; Race validation failed.)*
- `node --experimental-vm-modules ./node_modules/jest/bin/jest.js __tests__/step3.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68b60ba31e48832ea091ff5343bf0177