### PR TITLE
Add Blood Hunter subclasses

### DIFF
--- a/data/classes/bloodhunter.json
+++ b/data/classes/bloodhunter.json
@@ -4,7 +4,10 @@
   "hit_die": "d10",
   "hp_at_1st_level": "10 + your Constitution modifier",
   "hp_at_higher_levels": "1d10 (or 6) + your Constitution modifier per Blood Hunter level after 1st",
-  "saving_throws": ["Dexterity", "Intelligence"],
+  "saving_throws": [
+    "Dexterity",
+    "Intelligence"
+  ],
   "skill_proficiencies": {
     "choose": 3,
     "options": [
@@ -18,15 +21,37 @@
       "Survival"
     ]
   },
-  "weapon_proficiencies": ["simple weapons", "martial weapons"],
-  "armor_proficiencies": ["light armor", "medium armor", "shields"],
-  "tool_proficiencies": ["alchemist's supplies"],
+  "weapon_proficiencies": [
+    "simple weapons",
+    "martial weapons"
+  ],
+  "armor_proficiencies": [
+    "light armor",
+    "medium armor",
+    "shields"
+  ],
+  "tool_proficiencies": [
+    "alchemist's supplies"
+  ],
   "multiclassing": {
-    "prerequisites": {"Intelligence": 13, "Strength": 13, "Dexterity": 13},
+    "prerequisites": {
+      "Intelligence": 13,
+      "Strength": 13,
+      "Dexterity": 13
+    },
     "proficiencies": {
-      "weapons": ["simple weapons", "martial weapons"],
-      "armor": ["light armor", "medium armor", "shields"],
-      "tools": ["alchemist's supplies"]
+      "weapons": [
+        "simple weapons",
+        "martial weapons"
+      ],
+      "armor": [
+        "light armor",
+        "medium armor",
+        "shields"
+      ],
+      "tools": [
+        "alchemist's supplies"
+      ]
     }
   },
   "features_by_level": {
@@ -176,10 +201,51 @@
     ]
   },
   "subclasses": [
-    {"name": "Order of the Ghostslayer", "features": []},
-    {"name": "Order of the Lycan", "features": []},
-    {"name": "Order of the Mutant", "features": []},
-    {"name": "Order of the Profane Soul", "features": []}
+    {
+      "name": "Order of the Ghostslayer",
+      "features": [
+        "Rite of the Dawn",
+        "Curse Specialist",
+        "Aether Walk",
+        "Brand of Sundering",
+        "Blood Curse of the Exorcist",
+        "Rite Revival"
+      ]
+    },
+    {
+      "name": "Order of the Lycan",
+      "features": [
+        "Heightened Senses",
+        "Hybrid Transformation",
+        "Stalker's Prowess",
+        "Advanced Transformation",
+        "Brand of the Voracious",
+        "Hybrid Transformation Mastery"
+      ]
+    },
+    {
+      "name": "Order of the Mutant",
+      "features": [
+        "Mutagencraft",
+        "Strange Metabolism",
+        "Brand of Axiom",
+        "Blood Curse of Corrosion",
+        "Exalted Mutation"
+      ]
+    },
+    {
+      "name": "Order of the Profane Soul",
+      "features": [
+        "Otherworldly Patron",
+        "Pact Magic",
+        "Rite Focus",
+        "Mystic Frenzy",
+        "Revealed Arcana",
+        "Brand of the Sapping Scar",
+        "Unsealed Arcana",
+        "Blood Curse of the Souleater"
+      ]
+    }
   ],
   "choices": [
     {

--- a/data/subclasses/ghostslayer.json
+++ b/data/subclasses/ghostslayer.json
@@ -1,0 +1,40 @@
+{
+  "name": "Order of the Ghostslayer",
+  "description": "The oldest blood hunter order, obsessed with understanding death and annihilating undead threats.",
+  "features_by_level": {
+    "3": [
+      {
+        "name": "Rite of the Dawn",
+        "description": "Gain the Rite of the Dawn, dealing radiant rite damage, shedding light, granting necrotic resistance, and dealing an extra hemocraft die to undead."
+      },
+      {
+        "name": "Curse Specialist",
+        "description": "Gain an additional use of Blood Maledict, and your blood curses can target creatures without blood."
+      }
+    ],
+    "7": [
+      {
+        "name": "Aether Walk",
+        "description": "Step into the veil between planes, moving through creatures and objects for rounds equal to your Hemocraft modifier; once per rest, twice at 15th level."
+      }
+    ],
+    "11": [
+      {
+        "name": "Brand of Sundering",
+        "description": "Branded foes take an additional hemocraft die of rite damage and cannot move through creatures or objects if they are incorporeal."
+      }
+    ],
+    "15": [
+      {
+        "name": "Blood Curse of the Exorcist",
+        "description": "You gain the Blood Curse of the Exorcist. It does not count against your blood curses known."
+      }
+    ],
+    "18": [
+      {
+        "name": "Rite Revival",
+        "description": "If reduced to 0 hit points with a rite active, end all rites to drop to 1 hit point instead."
+      }
+    ]
+  }
+}

--- a/data/subclasses/lycan.json
+++ b/data/subclasses/lycan.json
@@ -1,0 +1,40 @@
+{
+  "name": "Order of the Lycan",
+  "description": "Blood hunters who embrace the curse of lycanthropy, mastering a hybrid form to unleash bestial power without losing control.",
+  "features_by_level": {
+    "3": [
+      {
+        "name": "Heightened Senses",
+        "description": "You have advantage on Wisdom (Perception) checks that rely on hearing or smell."
+      },
+      {
+        "name": "Hybrid Transformation",
+        "description": "As a bonus action, transform into a hybrid form for up to 1 hour, gaining feral might, resilient hide, predatory strikes, and bloodlust."
+      }
+    ],
+    "7": [
+      {
+        "name": "Stalker's Prowess",
+        "description": "Your speed and jump distance increase, and your hybrid form gains improved predatory strikes that are magical when a rite is active."
+      }
+    ],
+    "11": [
+      {
+        "name": "Advanced Transformation",
+        "description": "You can use Hybrid Transformation twice per rest and gain regeneration while below half hit points."
+      }
+    ],
+    "15": [
+      {
+        "name": "Brand of the Voracious",
+        "description": "You have advantage on bloodlust saves in hybrid form, and attacks against creatures you have branded have advantage."
+      }
+    ],
+    "18": [
+      {
+        "name": "Hybrid Transformation Mastery",
+        "description": "Use Hybrid Transformation without limit, and it lasts until you choose to end it; gain the Blood Curse of the Howl."
+      }
+    ]
+  }
+}

--- a/data/subclasses/mutant.json
+++ b/data/subclasses/mutant.json
@@ -1,0 +1,36 @@
+{
+  "name": "Order of the Mutant",
+  "description": "Alchemical savants who modify their blood with unstable mutagens to adapt to any foe.",
+  "features_by_level": {
+    "3": [
+      {
+        "name": "Mutagencraft",
+        "description": "Master mutagen formulas and concoct mutagens that grant benefits with side effects until your next rest."
+      }
+    ],
+    "7": [
+      {
+        "name": "Strange Metabolism",
+        "description": "Gain immunity to poison damage and the poisoned condition, and once per long rest ignore a mutagen's side effect for 1 minute."
+      }
+    ],
+    "11": [
+      {
+        "name": "Brand of Axiom",
+        "description": "Brand dispels illusions and invisibility, prevents shapechanging, and can revert a creature to its true form."
+      }
+    ],
+    "15": [
+      {
+        "name": "Blood Curse of Corrosion",
+        "description": "You gain the Blood Curse of Corrosion, which doesn't count against your blood curses known."
+      }
+    ],
+    "18": [
+      {
+        "name": "Exalted Mutation",
+        "description": "As a bonus action, replace an active mutagen with another you know a number of times per long rest equal to your Hemocraft modifier."
+      }
+    ]
+  }
+}

--- a/data/subclasses/profane_soul.json
+++ b/data/subclasses/profane_soul.json
@@ -1,0 +1,48 @@
+{
+  "name": "Order of the Profane Soul",
+  "description": "Blood hunters who forge pacts with otherworldly patrons, blending hemocraft with warlock magic.",
+  "features_by_level": {
+    "3": [
+      {
+        "name": "Otherworldly Patron",
+        "description": "Choose a patron that augments your subclass features."
+      },
+      {
+        "name": "Pact Magic",
+        "description": "Gain warlock-style spellcasting using the Profane Soul progression."
+      },
+      {
+        "name": "Rite Focus",
+        "description": "While a rite is active, your weapon serves as a spellcasting focus and grants a patron-specific benefit."
+      }
+    ],
+    "7": [
+      {
+        "name": "Mystic Frenzy",
+        "description": "After casting a cantrip, make one weapon attack as a bonus action."
+      },
+      {
+        "name": "Revealed Arcana",
+        "description": "Your patron grants a distinctive spell you can cast once per rest using a pact slot."
+      }
+    ],
+    "11": [
+      {
+        "name": "Brand of the Sapping Scar",
+        "description": "Branded creatures have disadvantage on saving throws against your warlock spells."
+      }
+    ],
+    "15": [
+      {
+        "name": "Unsealed Arcana",
+        "description": "Your patron grants an additional spell you can cast once without expending a spell slot per long rest."
+      }
+    ],
+    "18": [
+      {
+        "name": "Blood Curse of the Souleater",
+        "description": "You gain the Blood Curse of the Souleater, which doesn't count against your blood curses known."
+      }
+    ]
+  }
+}


### PR DESCRIPTION
## Summary
- add Order of the Ghostslayer subclass
- add Order of the Lycan subclass
- add Order of the Mutant subclass
- add Order of the Profane Soul subclass

## Testing
- `npm test` *(fails: changeling.json missing selection metadata for: size; dhampir.json missing selection metadata for: size; elfsea.json missing selection metadata for: languageProficiencies; genasiair.json missing selection metadata for: size; genasiearth.json missing selection metadata for: size; genasifire.json missing selection metadata for: size; genasiwater.json missing selection metadata for: size; harengon.json missing selection metadata for: size; hexblood.json missing selection metadata for: size; Race validation failed.)*
- `npm run build` *(fails: Cannot find module 'rollup.config.js')*

------
https://chatgpt.com/codex/tasks/task_e_68b7e95af438832ea33e4a0ebf1a2f3b