### PR TITLE
refactor duplicate option handling

### DIFF
--- a/__tests__/choice-select-helpers.test.js
+++ b/__tests__/choice-select-helpers.test.js
@@ -1,0 +1,61 @@
+/**
+ * @jest-environment jsdom
+ */
+import { CharacterState } from '../src/data.js';
+import { updateChoiceSelectOptions } from '../src/choice-select-helpers.js';
+
+describe('updateChoiceSelectOptions duplicate prevention', () => {
+  beforeEach(() => {
+    CharacterState.system = {
+      skills: [],
+      tools: [],
+      weapons: [],
+      traits: { languages: { value: [] } },
+      spells: { cantrips: [] },
+    };
+  });
+
+  function createSelect(options) {
+    const sel = document.createElement('select');
+    const blank = document.createElement('option');
+    blank.value = '';
+    sel.appendChild(blank);
+    options.forEach((opt) => {
+      const o = document.createElement('option');
+      o.value = opt;
+      o.textContent = opt;
+      sel.appendChild(o);
+    });
+    return sel;
+  }
+
+  test('prevents duplicate race languages', () => {
+    const sel1 = createSelect(['Elvish', 'Dwarvish']);
+    const sel2 = createSelect(['Elvish', 'Dwarvish']);
+    sel1.value = 'Elvish';
+    const selects = [sel1, sel2];
+    updateChoiceSelectOptions(selects, 'languages');
+    expect(sel2.querySelector("option[value='Elvish']").disabled).toBe(true);
+    expect(sel1.querySelector("option[value='Dwarvish']").disabled).toBe(false);
+  });
+
+  test('prevents duplicate background tools', () => {
+    const sel1 = createSelect(["Smith's Tools", "Cobbler's Tools"]);
+    const sel2 = createSelect(["Smith's Tools", "Cobbler's Tools"]);
+    sel1.value = "Smith's Tools";
+    const selects = [sel1, sel2];
+    updateChoiceSelectOptions(selects, 'tools');
+    expect(sel2.querySelector("option[value=\"Smith's Tools\"]").disabled).toBe(true);
+    expect(sel1.querySelector("option[value=\"Cobbler's Tools\"]").disabled).toBe(false);
+  });
+
+  test('prevents duplicate class skills', () => {
+    const sel1 = createSelect(['Acrobatics', 'Athletics']);
+    const sel2 = createSelect(['Acrobatics', 'Athletics']);
+    sel1.value = 'Acrobatics';
+    const selects = [sel1, sel2];
+    updateChoiceSelectOptions(selects, 'skills');
+    expect(sel2.querySelector("option[value='Acrobatics']").disabled).toBe(true);
+    expect(sel1.querySelector("option[value='Athletics']").disabled).toBe(false);
+  });
+});

--- a/__tests__/step2.test.js
+++ b/__tests__/step2.test.js
@@ -4,6 +4,7 @@
 
 import { jest } from '@jest/globals';
 import * as Step2 from '../src/step2.js';
+import { updateChoiceSelectOptions, updateSkillSelectOptions } from '../src/choice-select-helpers.js';
 import { CharacterState, DATA } from '../src/data.js';
 import { readFileSync } from 'fs';
 import path from 'path';
@@ -38,7 +39,7 @@ describe('duplicate selection prevention', () => {
     const skillSelects = [skillSelect1, skillSelect2];
     const choiceSkillSelects = [choiceSelect];
 
-    Step2.updateSkillSelectOptions(skillSelects, choiceSkillSelects);
+    updateSkillSelectOptions(skillSelects, choiceSkillSelects);
 
     expect(
       skillSelect2.querySelector("option[value='Acrobatics']").disabled
@@ -63,7 +64,7 @@ describe('duplicate selection prevention', () => {
     const skillSelects = [skillSelect];
     const choiceSelects = [choiceSelect1, choiceSelect2];
 
-    Step2.updateChoiceSelectOptions(
+    updateChoiceSelectOptions(
       choiceSelects,
       'skills',
       skillSelects,
@@ -90,10 +91,10 @@ describe('duplicate selection prevention', () => {
     skillSelect1.value = 'Acrobatics';
     const skillSelects = [skillSelect1, skillSelect2];
 
-    Step2.updateSkillSelectOptions(skillSelects);
+    updateSkillSelectOptions(skillSelects);
 
     skillSelect2.value = 'Athletics';
-    Step2.updateSkillSelectOptions(skillSelects);
+    updateSkillSelectOptions(skillSelects);
 
     expect(skillSelect1.value).toBe('Acrobatics');
     expect(skillSelect2.value).toBe('Athletics');
@@ -106,10 +107,10 @@ describe('duplicate selection prevention', () => {
     cantripSelect1.value = 'Fire Bolt';
     const selects = [cantripSelect1, cantripSelect2];
 
-    Step2.updateChoiceSelectOptions(selects, 'cantrips');
+    updateChoiceSelectOptions(selects, 'cantrips');
 
     cantripSelect2.value = 'Light';
-    Step2.updateChoiceSelectOptions(selects, 'cantrips');
+    updateChoiceSelectOptions(selects, 'cantrips');
 
     expect(cantripSelect1.value).toBe('Fire Bolt');
     expect(cantripSelect2.value).toBe('Light');

--- a/__tests__/step3.test.js
+++ b/__tests__/step3.test.js
@@ -51,8 +51,13 @@ jest.unstable_mockModule('../src/data.js', () => ({
 jest.unstable_mockModule('../src/step2.js', () => ({
   refreshBaseState: jest.fn(),
   rebuildFromClasses: jest.fn(),
-  updateChoiceSelectOptions: jest.fn(),
   loadStep2: jest.fn(),
+}));
+
+jest.unstable_mockModule('../src/choice-select-helpers.js', () => ({
+  updateChoiceSelectOptions: jest.fn(),
+  filterDuplicateOptions: jest.fn(),
+  updateSkillSelectOptions: jest.fn(),
 }));
 
 jest.unstable_mockModule('../src/main.js', () => ({

--- a/__tests__/step4.test.js
+++ b/__tests__/step4.test.js
@@ -24,7 +24,12 @@ jest.unstable_mockModule('../src/data.js', () => ({
 jest.unstable_mockModule('../src/step2.js', () => ({
   refreshBaseState: jest.fn(),
   rebuildFromClasses: jest.fn(),
+}));
+
+jest.unstable_mockModule('../src/choice-select-helpers.js', () => ({
   updateChoiceSelectOptions: jest.fn(),
+  filterDuplicateOptions: jest.fn(),
+  updateSkillSelectOptions: jest.fn(),
 }));
 
 jest.unstable_mockModule('../src/i18n.js', () => ({ t: (k) => k }));

--- a/src/choice-select-helpers.js
+++ b/src/choice-select-helpers.js
@@ -1,0 +1,64 @@
+import { CharacterState } from './data.js';
+import { getProficiencyList } from './proficiency.js';
+
+export function filterDuplicateOptions(selects, existingValues = [], otherSelects = []) {
+  const counts = new Map();
+  const add = (val) => {
+    if (!val) return;
+    counts.set(val, (counts.get(val) || 0) + 1);
+  };
+  const subtract = (val) => {
+    if (!val) return;
+    const newCount = (counts.get(val) || 0) - 1;
+    if (newCount <= 0) counts.delete(val);
+    else counts.set(val, newCount);
+  };
+
+  existingValues.forEach(add);
+
+  selects.forEach((sel) => subtract(sel.value));
+  otherSelects.forEach((sel) => subtract(sel.value));
+
+  selects.forEach((sel) => add(sel.value));
+  otherSelects.forEach((sel) => add(sel.value));
+
+  selects.forEach((sel) => {
+    Array.from(sel.options).forEach((opt) => {
+      if (!opt.value) return;
+      const count = counts.get(opt.value) || 0;
+      const isCurrent = sel.value === opt.value;
+      opt.disabled = !isCurrent && count > 0;
+    });
+
+    const currentCount = counts.get(sel.value) || 0;
+    if (sel.value && currentCount > 1) {
+      sel.value = '';
+      sel.dispatchEvent(new Event('change'));
+    }
+  });
+}
+
+export function updateChoiceSelectOptions(
+  selects,
+  type,
+  skillSelectsList = [],
+  allSkillChoiceSelects = [],
+) {
+  if (type === 'skills') {
+    const otherSelects = [
+      ...skillSelectsList,
+      ...allSkillChoiceSelects.filter((sel) => !selects.includes(sel)),
+    ];
+    filterDuplicateOptions(selects, getProficiencyList('skills'), otherSelects);
+  } else {
+    filterDuplicateOptions(selects, getProficiencyList(type));
+  }
+}
+
+export function updateSkillSelectOptions(skillSelectsList, choiceSkillSelectsList = []) {
+  filterDuplicateOptions(
+    skillSelectsList,
+    CharacterState.system.skills,
+    choiceSkillSelectsList,
+  );
+}

--- a/src/step2.js
+++ b/src/step2.js
@@ -19,7 +19,12 @@ import {
 } from './ui-helpers.js';
 import { renderFeatChoices } from './feat.js';
 import { renderSpellChoices } from './spell-select.js';
-import { pendingReplacements, getProficiencyList } from './proficiency.js';
+import { pendingReplacements } from './proficiency.js';
+import {
+  filterDuplicateOptions,
+  updateChoiceSelectOptions,
+  updateSkillSelectOptions,
+} from './choice-select-helpers.js';
 
 const abilityMap = {
   Strength: 'str',
@@ -135,68 +140,6 @@ function validateTotalLevel(pendingClass) {
     return false;
   }
   return true;
-}
-
-function filterDuplicateOptions(selects, existingValues = [], otherSelects = []) {
-  const counts = new Map();
-  const add = val => {
-    if (!val) return;
-    counts.set(val, (counts.get(val) || 0) + 1);
-  };
-  const subtract = val => {
-    if (!val) return;
-    const newCount = (counts.get(val) || 0) - 1;
-    if (newCount <= 0) counts.delete(val);
-    else counts.set(val, newCount);
-  };
-
-  existingValues.forEach(add);
-
-  selects.forEach(sel => subtract(sel.value));
-  otherSelects.forEach(sel => subtract(sel.value));
-
-  selects.forEach(sel => add(sel.value));
-  otherSelects.forEach(sel => add(sel.value));
-
-  selects.forEach(sel => {
-    Array.from(sel.options).forEach(opt => {
-      if (!opt.value) return;
-      const count = counts.get(opt.value) || 0;
-      const isCurrent = sel.value === opt.value;
-      opt.disabled = !isCurrent && count > 0;
-    });
-
-    const currentCount = counts.get(sel.value) || 0;
-    if (sel.value && currentCount > 1) {
-      sel.value = '';
-      sel.dispatchEvent(new Event('change'));
-    }
-  });
-}
-
-function updateSkillSelectOptions(skillSelectsList, choiceSkillSelectsList = []) {
-  filterDuplicateOptions(
-    skillSelectsList,
-    CharacterState.system.skills,
-    choiceSkillSelectsList
-  );
-}
-
-function updateChoiceSelectOptions(
-  selects,
-  type,
-  skillSelectsList = [],
-  allSkillChoiceSelects = []
-) {
-  if (type === 'skills') {
-    const otherSelects = [
-      ...skillSelectsList,
-      ...allSkillChoiceSelects.filter(sel => !selects.includes(sel)),
-    ];
-    filterDuplicateOptions(selects, getProficiencyList('skills'), otherSelects);
-  } else {
-    filterDuplicateOptions(selects, getProficiencyList(type));
-  }
 }
 
 function updateExpertiseSelectOptions(selects) {
@@ -1147,8 +1090,6 @@ function selectClass(cls) {
 }
 
 export {
-  updateSkillSelectOptions,
-  updateChoiceSelectOptions,
   updateExpertiseSelectOptions,
   validateTotalLevel,
   refreshBaseState,

--- a/src/step4.js
+++ b/src/step4.js
@@ -4,7 +4,8 @@ import {
   logCharacterState,
   fetchJsonWithRetry
 } from './data.js';
-import { refreshBaseState, rebuildFromClasses, updateChoiceSelectOptions } from './step2.js';
+import { refreshBaseState, rebuildFromClasses } from './step2.js';
+import { updateChoiceSelectOptions } from './choice-select-helpers.js';
 import { t } from './i18n.js';
 import * as main from './main.js';
 import {


### PR DESCRIPTION
## Summary
- extract filterDuplicateOptions and updateChoiceSelectOptions into new choice-select helper
- switch race and background steps to use shared helpers
- cover duplicate prevention with unit tests for races, backgrounds, and classes

## Testing
- `npm test` *(fails: altered.json missing selection metadata for: size; Race validation failed.)*
- `node --experimental-vm-modules ./node_modules/jest/bin/jest.js`

------
https://chatgpt.com/codex/tasks/task_e_68b80a393248832e960b76a9df133fab