### PR TITLE
feat: slugify race artwork paths

### DIFF
--- a/assets/races/README.md
+++ b/assets/races/README.md
@@ -1,2 +1,2 @@
 Place race artwork images in this directory using predictable filenames.
-Use lowercase names with hyphens for spaces, e.g. `elf.jpg` or `elf-high.jpg`.
+Use lowercase names with hyphens for spaces, e.g. `elf.png` or `elf-high.png`.

--- a/src/step3.js
+++ b/src/step3.js
@@ -42,6 +42,10 @@ const pendingRaceChoices = {
 
 let raceRenderSeq = 0;
 
+function slugify(name = '') {
+  return name.trim().toLowerCase().replace(/[^a-z0-9]+/g, '-');
+}
+
 const choiceAccordions = {
   size: null,
   skills: null,
@@ -190,12 +194,12 @@ async function renderBaseRaces(search = '') {
       race = { ...data, name: base };
     }
     if (seq !== raceRenderSeq) return;
-    const slug = base.toLowerCase().replace(/\s+/g, '-');
+    const slug = slugify(base);
     const card = createRaceCard(
       race,
       () => selectBaseRace(base),
       `${base} (${subs.length})`,
-      `assets/races/${slug}.jpg`
+      `assets/races/${slug}.png`
     );
     if (seq !== raceRenderSeq) return;
     container.appendChild(card);
@@ -241,7 +245,7 @@ async function renderSubraceCards(base, search = '') {
     const race = await fetchJsonWithRetry(path, `race at ${path}`);
     if (!race.name.toLowerCase().includes(term)) continue;
     if (seq !== raceRenderSeq) return;
-    const slug = race.name.toLowerCase().replace(/\s+/g, '-');
+    const slug = slugify(race.name);
     const card = createRaceCard(
       race,
       async () => {
@@ -255,7 +259,7 @@ async function renderSubraceCards(base, search = '') {
         validateRaceChoices();
       },
       race.name,
-      `assets/races/${slug}.jpg`
+      `assets/races/${slug}.png`
     );
     if (seq !== raceRenderSeq) return;
     container.appendChild(card);


### PR DESCRIPTION
## Summary
- add a `slugify` helper for race artwork
- switch race card images to `.png` files with slugified names
- update race asset documentation to reflect new naming

## Testing
- `npm test` *(fails: Race validation failed)*

------
https://chatgpt.com/codex/tasks/task_e_68b814680a5c832eb43ba702bfa4d936