### PR TITLE
Normalize race artwork slug to race-subrace.png

### DIFF
--- a/assets/races/README.md
+++ b/assets/races/README.md
@@ -1,2 +1,2 @@
 Place race artwork images in this directory using predictable filenames.
-Use lowercase names with hyphens for spaces, e.g. `elf.jpg` or `elf-high.jpg`.
+Use lowercase names with hyphens for spaces, e.g. `elf.png` or `elf-high.png`.

--- a/src/step3.js
+++ b/src/step3.js
@@ -42,6 +42,14 @@ const pendingRaceChoices = {
 
 let raceRenderSeq = 0;
 
+function slugify(name = '') {
+  return name
+    .trim()
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '');
+}
+
 const choiceAccordions = {
   size: null,
   skills: null,
@@ -190,12 +198,12 @@ async function renderBaseRaces(search = '') {
       race = { ...data, name: base };
     }
     if (seq !== raceRenderSeq) return;
-    const slug = base.toLowerCase().replace(/\s+/g, '-');
+    const slug = slugify(base);
     const card = createRaceCard(
       race,
       () => selectBaseRace(base),
       `${base} (${subs.length})`,
-      `assets/races/${slug}.jpg`
+      `assets/races/${slug}.png`
     );
     if (seq !== raceRenderSeq) return;
     container.appendChild(card);
@@ -241,7 +249,7 @@ async function renderSubraceCards(base, search = '') {
     const race = await fetchJsonWithRetry(path, `race at ${path}`);
     if (!race.name.toLowerCase().includes(term)) continue;
     if (seq !== raceRenderSeq) return;
-    const slug = race.name.toLowerCase().replace(/\s+/g, '-');
+    const slug = slugify(race.name);
     const card = createRaceCard(
       race,
       async () => {
@@ -255,7 +263,7 @@ async function renderSubraceCards(base, search = '') {
         validateRaceChoices();
       },
       race.name,
-      `assets/races/${slug}.jpg`
+      `assets/races/${slug}.png`
     );
     if (seq !== raceRenderSeq) return;
     container.appendChild(card);


### PR DESCRIPTION
## Summary
- Strip leading/trailing hyphens in `slugify` to form `race-subrace` image slugs

## Testing
- ❌ `npm test` (missing selection metadata for several races)


------
https://chatgpt.com/codex/tasks/task_e_68b814680a5c832eb43ba702bfa4d936