### PR TITLE
Handle more subclass name formats

### DIFF
--- a/__tests__/slugifySubclass.test.js
+++ b/__tests__/slugifySubclass.test.js
@@ -1,0 +1,18 @@
+let slugifySubclass;
+
+beforeAll(async () => {
+  global.document = { addEventListener: () => {} };
+  ({ slugifySubclass } = await import('../src/step2.js'));
+});
+
+describe('slugifySubclass', () => {
+  test.each([
+    ['Path of the Ancestral Guardian', 'ancestral_guardian'],
+    ['Circle of the Land (Desert)', 'desert'],
+    ['Purple Dragon Knight (Banneret)', 'purple_dragon_knight_banneret'],
+    ['The Undying', 'undying'],
+    ['The Order of the Awakened', 'awakened'],
+  ])('%s -> %s', (input, expected) => {
+    expect(slugifySubclass(input)).toBe(expected);
+  });
+});

--- a/src/step2.js
+++ b/src/step2.js
@@ -191,15 +191,31 @@ function updateFeatSelectOptions() {
   });
 }
 
+/**
+ * Convert a subclass name into the slug used for data files.
+ *
+ * Handles several common naming patterns:
+ * - Leading articles like "The" (e.g. "The Undying" → "undying")
+ * - Standard subclass prefixes such as "Path of the", "Oath of the",
+ *   "College of", etc. (e.g. "Path of the Beast" → "beast")
+ * - Druid land circles where the terrain type is in parentheses
+ *   ("Circle of the Land (Desert)" → "desert")
+ * - Trailing descriptors like "Domain" or "Tradition"
+ * - Parenthetical notes are folded into the slug
+ *   ("Purple Dragon Knight (Banneret)" → "purple_dragon_knight_banneret")
+ */
 function slugifySubclass(name = '') {
   return name
-    .replace(/^(Path|Oath|Circle|College|Order|Domain|Way|School) of (the )?/i, '')
+    .replace(/^Circle of the Land\s*/i, '')
     .replace(/^The /i, '')
+    .replace(/^(Path|Oath|Circle|College|Order|Domain|Way|School) of (the )?/i, '')
     .replace(/ (Domain|Tradition)$/i, '')
+    .replace(/\s*\(([^)]+)\)/g, ' $1')
     .replace(/[’']/g, '')
     .trim()
     .toLowerCase()
-    .replace(/[^a-z0-9]+/g, '_');
+    .replace(/[^a-z0-9]+/g, '_')
+    .replace(/^_+|_+$/g, '');
 }
 
 async function loadSubclassData(cls) {
@@ -1096,4 +1112,5 @@ export {
   rebuildFromClasses,
   selectClass,
   renderClassEditor,
+  slugifySubclass,
 };


### PR DESCRIPTION
## Summary
- expand `slugifySubclass` to handle more prefixes and parenthetical notes
- export `slugifySubclass` and document supported patterns
- add tests for common subclass name formats

## Testing
- `npm test` (fails: Race validation failed)
- `node --experimental-vm-modules ./node_modules/jest/bin/jest.js`


------
https://chatgpt.com/codex/tasks/task_e_68b846bd9464832eb6654e5ba5683aea