### PR TITLE
Add toast notification for level cap messages

### DIFF
--- a/__tests__/step2.test.js
+++ b/__tests__/step2.test.js
@@ -5,7 +5,8 @@
 import { jest } from '@jest/globals';
 import * as Step2 from '../src/step2.js';
 import { updateChoiceSelectOptions, updateSkillSelectOptions } from '../src/choice-select-helpers.js';
-import { CharacterState, DATA } from '../src/data.js';
+import { CharacterState, DATA, MAX_CHARACTER_LEVEL } from '../src/data.js';
+import { t } from '../src/i18n.js';
 import { readFileSync } from 'fs';
 import path from 'path';
 import { fileURLToPath } from 'url';
@@ -128,6 +129,34 @@ describe('duplicate selection prevention', () => {
     expect(CharacterState.classes).toHaveLength(1);
     expect(alertMock).toHaveBeenCalled();
     alertMock.mockRestore();
+  });
+});
+
+describe('level cap messaging', () => {
+  test('validateTotalLevel shows toast when exceeding cap', () => {
+    const existing = document.getElementById('toast');
+    if (existing) existing.remove();
+    const result = Step2.validateTotalLevel({
+      level: MAX_CHARACTER_LEVEL + 1,
+    });
+    expect(result).toBe(false);
+    const toast = document.getElementById('toast');
+    expect(toast).not.toBeNull();
+    expect(toast.textContent).toBe(
+      t('levelCap', { max: MAX_CHARACTER_LEVEL })
+    );
+  });
+
+  test('validateTotalLevel permits reaching max level', () => {
+    CharacterState.classes = [{ level: 1 }];
+    const existing = document.getElementById('toast');
+    if (existing) existing.remove();
+    const result = Step2.validateTotalLevel({
+      level: MAX_CHARACTER_LEVEL - 1,
+    });
+    expect(result).toBe(true);
+    const toast = document.getElementById('toast');
+    expect(toast).toBeNull();
   });
 });
 

--- a/css/site-theme.css
+++ b/css/site-theme.css
@@ -182,6 +182,18 @@ th {
   display: none !important;
 }
 
+.toast {
+  position: fixed;
+  top: 1rem;
+  right: 1rem;
+  background-color: var(--primary-color);
+  color: #fff;
+  padding: 0.5rem 1rem;
+  border-radius: 5px;
+  box-shadow: 0 2px 6px rgba(0, 0, 0, 0.2);
+  z-index: 1000;
+}
+
 #stepContainer {
   max-width: 1000px;
   width: 100%;

--- a/src/step2.js
+++ b/src/step2.js
@@ -16,6 +16,7 @@ import {
   createSelectableCard,
   appendEntries,
   markIncomplete,
+  showToast,
 } from './ui-helpers.js';
 import { renderFeatChoices } from './feat.js';
 import { renderSpellChoices } from './spell-select.js';
@@ -135,8 +136,7 @@ function validateTotalLevel(pendingClass) {
   if (existing + pending > MAX_CHARACTER_LEVEL) {
     const allowed = Math.max(0, MAX_CHARACTER_LEVEL - existing);
     if (pendingClass) pendingClass.level = allowed;
-    if (typeof alert !== 'undefined')
-      alert(t('levelCap', { max: MAX_CHARACTER_LEVEL }));
+    showToast(t('levelCap', { max: MAX_CHARACTER_LEVEL }));
     return false;
   }
   return true;
@@ -435,7 +435,8 @@ function renderClassEditor(cls, index) {
   levelSel.value = cls.level || 1;
   levelSel.addEventListener('change', () => {
     const lvl = parseInt(levelSel.value, 10) || 1;
-    if (!validateTotalLevel({ level: lvl })) {
+    const delta = lvl - (cls.level || 1);
+    if (!validateTotalLevel({ level: delta })) {
       levelSel.value = cls.level || 1;
       return;
     }

--- a/src/ui-helpers.js
+++ b/src/ui-helpers.js
@@ -59,6 +59,20 @@ export function appendEntries(container, entries) {
   });
 }
 
+let toastTimeout = null;
+export function showToast(message, duration = 3000) {
+  let toast = document.getElementById('toast');
+  if (!toast) {
+    toast = document.createElement('div');
+    toast.id = 'toast';
+    toast.className = 'toast hidden';
+    document.body.appendChild(toast);
+  }
+  toast.textContent = message;
+  toast.classList.remove('hidden');
+  if (toastTimeout) clearTimeout(toastTimeout);
+  toastTimeout = setTimeout(() => toast.classList.add('hidden'), duration);
+}
 export function createAccordionItem(title, content, isChoice = false, description = '') {
   const item = document.createElement('div');
   item.className = 'accordion-item' + (isChoice ? ' user-choice' : '');


### PR DESCRIPTION
## Summary
- add reusable `showToast` helper for non-blocking notices
- swap level cap `alert` with toast message
- style toast banner and test level cap notification
- fix level-up validation so characters can reach max level

## Testing
- `npm test` *(fails: Race validation failed)*
- `node --experimental-vm-modules ./node_modules/jest/bin/jest.js`


------
https://chatgpt.com/codex/tasks/task_e_68b8460cc9bc832e85b1eb4562e52d92