### PR TITLE
Handle equipment load failures

### DIFF
--- a/__tests__/step5.test.js
+++ b/__tests__/step5.test.js
@@ -4,33 +4,40 @@
 
 import { jest } from '@jest/globals';
 
-jest.unstable_mockModule('../src/data.js', () => ({
-  DATA: {},
-  CharacterState: { classes: [{ name: 'Test', level: 1 }], equipment: [] },
-  loadSpells: jest.fn(),
-  fetchJsonWithRetry: jest.fn(),
-}));
-
-jest.unstable_mockModule('../src/i18n.js', () => ({ t: (k) => k }));
-
 const showStep = jest.fn();
-jest.unstable_mockModule('../src/main.js', () => ({ showStep }));
+const showErrorBanner = jest.fn();
+let loadStep5;
+let CharacterState;
+let fetchJsonWithRetry;
 
-const { loadStep5 } = await import('../src/step5.js');
-const { CharacterState, fetchJsonWithRetry } = await import('../src/data.js');
+beforeEach(async () => {
+  jest.resetModules();
+  showStep.mockClear();
+  showErrorBanner.mockClear();
+
+  jest.unstable_mockModule('../src/data.js', () => ({
+    DATA: {},
+    CharacterState: { classes: [{ name: 'Test', level: 1 }], equipment: [] },
+    loadSpells: jest.fn(),
+    fetchJsonWithRetry: jest.fn(),
+  }));
+  jest.unstable_mockModule('../src/i18n.js', () => ({ t: (k) => k }));
+  jest.unstable_mockModule('../src/main.js', () => ({ showStep, showErrorBanner }));
+
+  ({ loadStep5 } = await import('../src/step5.js'));
+  ({ CharacterState, fetchJsonWithRetry } = await import('../src/data.js'));
+
+  document.body.innerHTML =
+    '<div id="equipmentSelections"></div><button id="confirmEquipment"></button>';
+
+  fetchJsonWithRetry.mockResolvedValue({
+    standard: [],
+    classes: { Test: { fixed: [], choices: [] } },
+  });
+  CharacterState.classes = [{ name: 'Test', level: 1 }];
+});
 
 describe('step5 re-entry', () => {
-  beforeEach(() => {
-    document.body.innerHTML =
-      '<div id="equipmentSelections"></div><button id="confirmEquipment"></button>';
-    fetchJsonWithRetry.mockResolvedValue({
-      standard: [],
-      classes: { Test: { fixed: [], choices: [] } },
-    });
-    CharacterState.classes = [{ name: 'Test', level: 1 }];
-    showStep.mockClear();
-  });
-
   test('reloading step5 does not duplicate UI or listeners', async () => {
     await loadStep5(true);
     await loadStep5(true);
@@ -41,5 +48,26 @@ describe('step5 re-entry', () => {
     btn.click();
     expect(showStep).toHaveBeenCalledTimes(1);
     expect(showStep).toHaveBeenCalledWith(6);
+  });
+
+  test('failed fetch surfaces error and allows retry', async () => {
+    fetchJsonWithRetry.mockReset();
+    fetchJsonWithRetry
+      .mockRejectedValueOnce(new Error('fail'))
+      .mockResolvedValueOnce({
+        standard: [],
+        classes: { Test: { fixed: [], choices: [] } },
+      });
+
+    await loadStep5(true);
+
+    expect(fetchJsonWithRetry).toHaveBeenCalledTimes(1);
+    expect(showErrorBanner).toHaveBeenCalledWith('equipmentLoadError');
+
+    await loadStep5(true);
+
+    expect(fetchJsonWithRetry).toHaveBeenCalledTimes(2);
+    const accs = document.querySelectorAll('#equipmentSelections .accordion');
+    expect(accs).toHaveLength(1);
   });
 });

--- a/src/main.js
+++ b/src/main.js
@@ -60,6 +60,24 @@ function setCurrentStepComplete(flag) {
 }
 globalThis.setCurrentStepComplete = setCurrentStepComplete;
 
+function showErrorBanner(message) {
+  let banner = document.getElementById('errorBanner');
+  if (!message) {
+    if (banner) banner.remove();
+    return;
+  }
+  if (!banner) {
+    banner = document.createElement('div');
+    banner.id = 'errorBanner';
+    banner.className = 'error-banner';
+    const stepNav = document.getElementById('stepNav');
+    if (stepNav) stepNav.insertAdjacentElement('beforebegin', banner);
+    else document.body.prepend(banner);
+  }
+  banner.textContent = message;
+  banner.classList.remove('hidden');
+}
+
 function showStep(step) {
     const firstVisit = !visitedSteps.has(step);
     visitedSteps.add(step);
@@ -503,4 +521,4 @@ document.addEventListener("DOMContentLoaded", async () => {
     validateStep1();
 });
 
-export { showStep, loadData, setCurrentStepComplete };
+export { showStep, loadData, setCurrentStepComplete, showErrorBanner };

--- a/src/step5.js
+++ b/src/step5.js
@@ -3,7 +3,7 @@ import { t } from './i18n.js';
 import * as main from './main.js';
 import { createAccordionItem, markIncomplete } from './ui-helpers.js';
 
-let equipmentData = null;
+let equipmentData;
 let choiceBlocks = [];
 
 function getSimpleWeapons() {
@@ -28,16 +28,18 @@ function getSimpleWeapons() {
 }
 
 async function loadEquipmentData() {
-  if (!equipmentData) {
-    equipmentData = await fetchJsonWithRetry('data/equipment.json', 'equipment').catch(
-      () => {
-        const container = document.getElementById('equipmentSelections');
-        if (container) container.textContent = t('equipmentLoadError');
-        return null;
-      }
-    );
+  if (equipmentData) return equipmentData;
+
+  try {
+    const data = await fetchJsonWithRetry('data/equipment.json', 'equipment');
+    equipmentData = data;
+    return equipmentData;
+  } catch {
+    const container = document.getElementById('equipmentSelections');
+    if (container) container.textContent = t('equipmentLoadError');
+    main.showErrorBanner?.(t('equipmentLoadError'));
+    return undefined;
   }
-  return equipmentData;
 }
 
 function buildSimpleWeaponSelect(count = 1) {


### PR DESCRIPTION
## Summary
- avoid caching failed equipment fetches and show an error banner on failure
- expose `showErrorBanner` helper from main and use it when equipment loading fails
- test retrying equipment data fetch after an initial failure

## Testing
- `npm test` *(fails: Race validation failed)*
- `node --experimental-vm-modules ./node_modules/jest/bin/jest.js`


------
https://chatgpt.com/codex/tasks/task_e_68b89a95c4a8832eb62f7ebca90983bb