### PR TITLE
Track equipment selection validity in step 5

### DIFF
--- a/src/step5.js
+++ b/src/step5.js
@@ -5,6 +5,7 @@ import { createAccordionItem, markIncomplete } from './ui-helpers.js';
 
 let equipmentData;
 let choiceBlocks = [];
+let equipmentSelectionsValid = false;
 
 function getSimpleWeapons() {
   return DATA.simpleWeapons?.length
@@ -245,14 +246,16 @@ function validateEquipmentSelections() {
     markIncomplete(b.element, ok);
     if (!ok) allValid = false;
   });
+  equipmentSelectionsValid = allValid;
   const btn = document.getElementById('confirmEquipment');
-  if (btn) btn.disabled = !allValid;
-  main.setCurrentStepComplete?.(allValid);
-  return allValid;
+  if (btn) btn.disabled = !equipmentSelectionsValid;
+  main.setCurrentStepComplete?.(equipmentSelectionsValid);
+  return equipmentSelectionsValid;
 }
 
 function confirmEquipment() {
-  if (!validateEquipmentSelections()) return;
+  validateEquipmentSelections();
+  if (!equipmentSelectionsValid) return;
   const selections = [];
   (equipmentData.standard || []).forEach((item) => {
     selections.push({ name: item });
@@ -310,6 +313,5 @@ export async function loadStep5(force = false) {
 }
 
 export function isStepComplete() {
-  return Array.isArray(CharacterState.equipment) &&
-    CharacterState.equipment.length > 0;
+  return equipmentSelectionsValid;
 }


### PR DESCRIPTION
## Summary
- track `equipmentSelectionsValid` flag to persist equipment validation
- use flag for step completion, confirmation, and navigation

## Testing
- `npm test` *(fails: altered.json missing selection metadata for: size)*
- `node --experimental-vm-modules ./node_modules/jest/bin/jest.js`


------
https://chatgpt.com/codex/tasks/task_e_68b8a1b4a470832e8f79fd6c40a746cd