### PR TITLE
refactor: use module exports for step 2 completion

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -58,7 +58,6 @@ function setCurrentStepComplete(flag) {
   }
   updateNavButtons();
 }
-globalThis.setCurrentStepComplete = setCurrentStepComplete;
 
 function showErrorBanner(message) {
   let banner = document.getElementById('errorBanner');

--- a/src/spell-select.js
+++ b/src/spell-select.js
@@ -1,5 +1,6 @@
 import { CharacterState, updateSpellSlots, loadSpells } from './data.js';
 import { t } from './i18n.js';
+import { updateStep2Completion } from './step2.js';
 
 export function updateSpellSelectOptions(selects) {
   const counts = new Map();
@@ -66,7 +67,7 @@ export function renderSpellChoices(cls) {
         updateSpellSelectOptions(selects);
         apply();
         updateWarning();
-        globalThis.updateStep2Completion?.();
+        updateStep2Completion();
       });
       selects.push(sel);
       container.appendChild(sel);
@@ -113,7 +114,7 @@ export function renderSpellChoices(cls) {
   loadSpells().then((data) => {
     spells = data;
     build();
-    globalThis.updateStep2Completion?.();
+    updateStep2Completion();
   });
 
   return { element: container, isComplete, apply };

--- a/src/step2.js
+++ b/src/step2.js
@@ -26,6 +26,7 @@ import {
   updateChoiceSelectOptions,
   updateSkillSelectOptions,
 } from './choice-select-helpers.js';
+import * as main from './main.js';
 
 const abilityMap = {
   Strength: 'str',
@@ -893,7 +894,7 @@ function classHasPendingChoices(cls) {
   return false;
 }
 
-function updateStep2Completion() {
+export function updateStep2Completion() {
   const btnStep3 = document.getElementById('btnStep3');
   const btnStep4 = document.getElementById('btnStep4');
   const progressBar = document.getElementById('progressBar');
@@ -911,10 +912,8 @@ function updateStep2Completion() {
   (CharacterState.classes || []).forEach((cls) => {
     if (cls.element) markIncomplete(cls.element, !classHasPendingChoices(cls));
   });
-  globalThis.setCurrentStepComplete?.(complete);
+  main.setCurrentStepComplete?.(complete);
 }
-
-globalThis.updateStep2Completion = updateStep2Completion;
 
 export function isStepComplete() {
   const incomplete = (CharacterState.classes || []).some(classHasPendingChoices);


### PR DESCRIPTION
## Summary
- export `updateStep2Completion` from step2 module
- import and invoke the step completion helpers directly rather than via `globalThis`
- drop global exposure for `setCurrentStepComplete`

## Testing
- `npm test` *(fails: Race validation failed)*
- `npm run build` *(fails: Cannot find module 'rollup.config.js')*


------
https://chatgpt.com/codex/tasks/task_e_68b8a4b0747c832e9621e861d8f09f84