### PR TITLE
Add step invalidation to rerender on data changes

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -32,6 +32,28 @@ let currentStep = 1;
 let currentStepComplete = false;
 const visitedSteps = new Set();
 const completedSteps = new Set();
+const invalidatedSteps = new Set();
+
+function invalidateStep(stepNumber) {
+  invalidatedSteps.add(stepNumber);
+  const containers = {
+    3: ["raceList", "raceFeatures", "raceTraits"],
+    4: [
+      "backgroundList",
+      "backgroundSkills",
+      "backgroundTools",
+      "backgroundLanguages",
+      "backgroundFeat",
+      "backgroundFeatures",
+    ],
+    5: ["equipmentSelections"],
+  };
+  const ids = containers[stepNumber] || [];
+  ids.forEach((id) => {
+    const el = document.getElementById(id);
+    if (el) el.innerHTML = "";
+  });
+}
 
 function updateNavButtons() {
   for (let i = 1; i <= 7; i++) {
@@ -79,7 +101,9 @@ function showErrorBanner(message) {
 
 function showStep(step) {
     const firstVisit = !visitedSteps.has(step);
+    const force = invalidatedSteps.has(step);
     visitedSteps.add(step);
+    invalidatedSteps.delete(step);
     for (let i = 1; i <= 7; i++) {
       const el = document.getElementById(`step${i}`);
       if (!el) continue;
@@ -100,10 +124,11 @@ function showStep(step) {
       // Placeholder for contextual help integration
       console.log(`Help: display guidance for step ${step}`);
     }
-    if (step === 3) loadStep3(firstVisit);
-    if (step === 4) loadStep4(firstVisit);
-    if (step === 5) loadStep5(firstVisit);
-    if (step === 6) loadStep6(firstVisit);
+    if (step === 2) loadStep2(firstVisit || force);
+    if (step === 3) loadStep3(firstVisit || force);
+    if (step === 4) loadStep4(firstVisit || force);
+    if (step === 5) loadStep5(firstVisit || force);
+    if (step === 6) loadStep6(firstVisit || force);
     if (step === 7) {
       commitAbilities();
       CharacterState.playerName =
@@ -520,4 +545,4 @@ document.addEventListener("DOMContentLoaded", async () => {
     validateStep1();
 });
 
-export { showStep, loadData, setCurrentStepComplete, showErrorBanner };
+export { showStep, loadData, setCurrentStepComplete, showErrorBanner, invalidateStep };

--- a/src/step2.js
+++ b/src/step2.js
@@ -129,6 +129,10 @@ function rebuildFromClasses() {
   }
   updateSpellSlots();
   updateProficiencyBonus();
+  main.invalidateStep(3);
+  main.invalidateStep(4);
+  main.invalidateStep(5);
+  main.invalidateStep(6);
 }
 
 function validateTotalLevel(pendingClass) {

--- a/src/step3.js
+++ b/src/step3.js
@@ -1264,6 +1264,9 @@ function confirmRaceSelection() {
     return false;
   }
   finalize();
+  main.invalidateStep(4);
+  main.invalidateStep(5);
+  main.invalidateStep(6);
   return true;
 }
 
@@ -1356,6 +1359,9 @@ export async function loadStep3(force = false) {
     }
     refreshBaseState();
     rebuildFromClasses();
+    main.invalidateStep(4);
+    main.invalidateStep(5);
+    main.invalidateStep(6);
     const traits = document.getElementById('raceTraits');
     if (traits) traits.innerHTML = '';
     const list = document.getElementById('raceList');

--- a/src/step4.js
+++ b/src/step4.js
@@ -414,6 +414,8 @@ async function confirmBackgroundSelection() {
   }
 
   finalize();
+  main.invalidateStep(5);
+  main.invalidateStep(6);
   return true;
 }
 
@@ -454,6 +456,8 @@ export function loadStep4(force = false) {
       features.innerHTML = '';
     }
     renderBackgroundList(search?.value);
+    main.invalidateStep(5);
+    main.invalidateStep(6);
   });
 }
 


### PR DESCRIPTION
## Summary
- add `invalidateStep` utility to clear step containers and mark for rerender
- force step loaders when steps are invalidated
- invalidate downstream steps when class, race, or background changes

## Testing
- `npm test` *(fails: Race validation failed)*

------
https://chatgpt.com/codex/tasks/task_e_68b8ab3cadd0832ea9b9688213cc6112