### PR TITLE
Invalidate dependent steps when data changes

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -55,6 +55,14 @@ function invalidateStep(stepNumber) {
   });
 }
 
+function invalidateStepsFrom(stepNumber) {
+  for (let i = stepNumber; i <= 7; i++) {
+    visitedSteps.delete(i);
+    completedSteps.delete(i);
+  }
+  updateNavButtons();
+}
+
 function updateNavButtons() {
   for (let i = 1; i <= 7; i++) {
     const btn = document.getElementById(`btnStep${i}`);
@@ -63,9 +71,10 @@ function updateNavButtons() {
       btn.disabled = false;
       continue;
     }
+    const prevInvalid = invalidatedSteps.has(i - 1);
     const isVisited = visitedSteps.has(i);
     const prevCompleted = completedSteps.has(i - 1);
-    btn.disabled = !(isVisited || prevCompleted);
+    btn.disabled = prevInvalid || !(isVisited || prevCompleted);
   }
 }
 
@@ -545,4 +554,11 @@ document.addEventListener("DOMContentLoaded", async () => {
     validateStep1();
 });
 
-export { showStep, loadData, setCurrentStepComplete, showErrorBanner, invalidateStep };
+export {
+  showStep,
+  loadData,
+  setCurrentStepComplete,
+  showErrorBanner,
+  invalidateStep,
+  invalidateStepsFrom,
+};

--- a/src/step2.js
+++ b/src/step2.js
@@ -133,6 +133,7 @@ function rebuildFromClasses() {
   main.invalidateStep(4);
   main.invalidateStep(5);
   main.invalidateStep(6);
+  main.invalidateStepsFrom(3);
 }
 
 function validateTotalLevel(pendingClass) {

--- a/src/step3.js
+++ b/src/step3.js
@@ -1267,6 +1267,7 @@ function confirmRaceSelection() {
   main.invalidateStep(4);
   main.invalidateStep(5);
   main.invalidateStep(6);
+  main.invalidateStepsFrom(4);
   return true;
 }
 
@@ -1362,6 +1363,7 @@ export async function loadStep3(force = false) {
     main.invalidateStep(4);
     main.invalidateStep(5);
     main.invalidateStep(6);
+    main.invalidateStepsFrom(4);
     const traits = document.getElementById('raceTraits');
     if (traits) traits.innerHTML = '';
     const list = document.getElementById('raceList');

--- a/src/step4.js
+++ b/src/step4.js
@@ -416,6 +416,7 @@ async function confirmBackgroundSelection() {
   finalize();
   main.invalidateStep(5);
   main.invalidateStep(6);
+  main.invalidateStepsFrom(5);
   return true;
 }
 
@@ -458,6 +459,7 @@ export function loadStep4(force = false) {
     renderBackgroundList(search?.value);
     main.invalidateStep(5);
     main.invalidateStep(6);
+    main.invalidateStepsFrom(5);
   });
 }
 


### PR DESCRIPTION
## Summary
- add helper to invalidate completed/visited steps from a given point
- call invalidation when class, race, or background choices change
- ensure navigation buttons disable when prerequisites are invalidated

## Testing
- `npm test` *(fails: altered.json missing selection metadata for: size)*

------
https://chatgpt.com/codex/tasks/task_e_68b8acc82ce0832e8a6dd7311a465437