### PR TITLE
Add reset helpers for race and background selections

### DIFF
--- a/src/step3.js
+++ b/src/step3.js
@@ -40,6 +40,19 @@ const pendingRaceChoices = {
   alterations: { combo: null, minor: [], major: [] },
 };
 
+export function resetPendingRaceChoices() {
+  pendingRaceChoices.subrace = '';
+  pendingRaceChoices.skills = [];
+  pendingRaceChoices.languages = [];
+  pendingRaceChoices.spells = [];
+  pendingRaceChoices.abilities = [];
+  pendingRaceChoices.tools = [];
+  pendingRaceChoices.weapons = [];
+  pendingRaceChoices.size = null;
+  pendingRaceChoices.resist = null;
+  pendingRaceChoices.alterations = { combo: null, minor: [], major: [] };
+}
+
 let raceRenderSeq = 0;
 
 function slugify(name = '') {
@@ -213,16 +226,7 @@ async function renderBaseRaces(search = '') {
 async function selectBaseRace(base) {
   selectedBaseRace = base;
   currentRaceData = null;
-  pendingRaceChoices.subrace = '';
-  pendingRaceChoices.skills = [];
-  pendingRaceChoices.languages = [];
-  pendingRaceChoices.spells = [];
-  pendingRaceChoices.abilities = [];
-  pendingRaceChoices.tools = [];
-  pendingRaceChoices.weapons = [];
-  pendingRaceChoices.size = null;
-  pendingRaceChoices.resist = null;
-  pendingRaceChoices.alterations = { combo: null, minor: [], major: [] };
+  resetPendingRaceChoices();
   for (const k in choiceAccordions) choiceAccordions[k] = null;
   const traits = document.getElementById('raceTraits');
   if (traits) traits.innerHTML = '';
@@ -273,15 +277,7 @@ async function renderSelectedRace() {
   const accordion = document.getElementById('raceFeatures');
   if (!currentRaceData || !accordion) return;
   accordion.innerHTML = '';
-  pendingRaceChoices.skills = [];
-  pendingRaceChoices.languages = [];
-  pendingRaceChoices.spells = [];
-  pendingRaceChoices.abilities = [];
-  pendingRaceChoices.tools = [];
-  pendingRaceChoices.weapons = [];
-  pendingRaceChoices.size = null;
-  pendingRaceChoices.resist = null;
-  pendingRaceChoices.alterations = { combo: null, minor: [], major: [] };
+  resetPendingRaceChoices();
 
   const header = document.createElement('h3');
   header.textContent = currentRaceData.name;
@@ -1228,16 +1224,7 @@ function confirmRaceSelection() {
   if (pendingRaceChoices.size) {
     pendingRaceChoices.size.disabled = true;
   }
-
-  pendingRaceChoices.skills = [];
-  pendingRaceChoices.languages = [];
-  pendingRaceChoices.spells = [];
-  pendingRaceChoices.abilities = [];
-  pendingRaceChoices.tools = [];
-  pendingRaceChoices.weapons = [];
-  pendingRaceChoices.size = null;
-  pendingRaceChoices.resist = null;
-  pendingRaceChoices.alterations = { combo: null, minor: [], major: [] };
+  resetPendingRaceChoices();
   refreshBaseState();
   rebuildFromClasses();
   const finalize = () => {
@@ -1272,6 +1259,7 @@ function confirmRaceSelection() {
 }
 
 export async function loadStep3(force = false) {
+  if (force) resetPendingRaceChoices();
   await loadRaces();
   const container = document.getElementById('raceList');
   let searchInput = document.getElementById('raceSearch');
@@ -1344,16 +1332,7 @@ export async function loadStep3(force = false) {
     }
     selectedBaseRace = '';
     currentRaceData = null;
-    pendingRaceChoices.subrace = '';
-    pendingRaceChoices.skills = [];
-    pendingRaceChoices.languages = [];
-    pendingRaceChoices.spells = [];
-    pendingRaceChoices.abilities = [];
-    pendingRaceChoices.tools = [];
-    pendingRaceChoices.weapons = [];
-    pendingRaceChoices.size = null;
-    pendingRaceChoices.resist = null;
-    pendingRaceChoices.alterations = { combo: null, minor: [], major: [] };
+    resetPendingRaceChoices();
     if (CharacterState.system?.details) {
       CharacterState.system.details.race = '';
       CharacterState.system.details.subrace = '';

--- a/src/step4.js
+++ b/src/step4.js
@@ -26,6 +26,14 @@ const pendingSelections = {
   feat: null,
   featRenderer: null,
 };
+
+export function resetPendingSelections() {
+  pendingSelections.skills = [];
+  pendingSelections.tools = [];
+  pendingSelections.languages = [];
+  pendingSelections.feat = null;
+  pendingSelections.featRenderer = null;
+}
 const choiceAccordions = {
   skills: null,
   tools: null,
@@ -90,12 +98,7 @@ function selectBackground(bg) {
   }
   features.classList.remove('hidden');
   features.innerHTML = '';
-
-  pendingSelections.skills = [];
-  pendingSelections.tools = [];
-  pendingSelections.languages = [];
-  pendingSelections.feat = null;
-  pendingSelections.featRenderer = null;
+  resetPendingSelections();
   choiceAccordions.skills = null;
   choiceAccordions.tools = null;
   choiceAccordions.languages = null;
@@ -387,13 +390,9 @@ async function confirmBackgroundSelection() {
     pendingSelections.feat.disabled = true;
   }
 
-    pendingSelections.skills = [];
-    pendingSelections.tools = [];
-    pendingSelections.languages = [];
-    pendingSelections.feat = null;
-    pendingSelections.featRenderer = null;
+  resetPendingSelections();
 
-    refreshBaseState();
+  refreshBaseState();
   rebuildFromClasses();
 
   const finalize = () => {
@@ -421,6 +420,7 @@ async function confirmBackgroundSelection() {
 }
 
 export function loadStep4(force = false) {
+  if (force) resetPendingSelections();
   const container = document.getElementById('backgroundList');
   let searchInput = document.getElementById('backgroundSearch');
   if (!container) return;
@@ -442,11 +442,7 @@ export function loadStep4(force = false) {
   const changeBtn = document.getElementById('changeBackground');
   changeBtn?.addEventListener('click', () => {
     currentBackgroundData = null;
-    pendingSelections.skills = [];
-    pendingSelections.tools = [];
-    pendingSelections.languages = [];
-    pendingSelections.feat = null;
-    pendingSelections.featRenderer = null;
+    resetPendingSelections();
     const list = document.getElementById('backgroundList');
     list?.classList.remove('hidden');
     const search = document.getElementById('backgroundSearch');


### PR DESCRIPTION
## Summary
- add `resetPendingRaceChoices` and `resetPendingSelections` to clear pending selection state
- invoke these resetters when re-rendering steps or when changing selections

## Testing
- `npm test` *(fails: Race validation failed)*

------
https://chatgpt.com/codex/tasks/task_e_68b8aeba44f4832ea7de0e7eb18ff250