### PR TITLE
Unify validation with reusable helpers

### DIFF
--- a/src/step2.js
+++ b/src/step2.js
@@ -15,9 +15,8 @@ import {
   createAccordionItem,
   createSelectableCard,
   appendEntries,
-  markIncomplete,
-  showToast,
 } from './ui-helpers.js';
+import { inlineWarning, globalToast } from './validation.js';
 import { renderFeatChoices } from './feat.js';
 import { renderSpellChoices } from './spell-select.js';
 import { pendingReplacements } from './proficiency.js';
@@ -142,7 +141,7 @@ function validateTotalLevel(pendingClass) {
   if (existing + pending > MAX_CHARACTER_LEVEL) {
     const allowed = Math.max(0, MAX_CHARACTER_LEVEL - existing);
     if (pendingClass) pendingClass.level = allowed;
-    showToast(t('levelCap', { max: MAX_CHARACTER_LEVEL }));
+    globalToast('levelCap', { max: MAX_CHARACTER_LEVEL });
     return false;
   }
   return true;
@@ -433,7 +432,7 @@ function renderClassEditor(cls, index) {
   card.className = 'saved-class';
   card.classList.add('needs-selection');
   cls.element = card;
-  markIncomplete(card, !classHasPendingChoices(cls));
+  inlineWarning(card, !classHasPendingChoices(cls));
 
   const header = document.createElement('div');
   const title = document.createElement('h3');
@@ -915,7 +914,7 @@ export function updateStep2Completion() {
     progressBar.style.width = `${width}%`;
   }
   (CharacterState.classes || []).forEach((cls) => {
-    if (cls.element) markIncomplete(cls.element, !classHasPendingChoices(cls));
+    if (cls.element) inlineWarning(cls.element, !classHasPendingChoices(cls));
   });
   main.setCurrentStepComplete?.(complete);
 }

--- a/src/step3.js
+++ b/src/step3.js
@@ -22,8 +22,8 @@ import {
   capitalize,
   appendEntries,
   createElement,
-  markIncomplete,
 } from './ui-helpers.js';
+import { inlineWarning } from './validation.js';
 
 let selectedBaseRace = '';
 let currentRaceData = null;
@@ -76,66 +76,39 @@ const choiceAccordions = {
 };
 
 function validateRaceChoices() {
-  const choiceSelects = [
-    ...pendingRaceChoices.skills,
-    ...pendingRaceChoices.languages,
-    ...pendingRaceChoices.spells,
-    ...pendingRaceChoices.abilities,
-    ...pendingRaceChoices.tools,
-    ...pendingRaceChoices.weapons,
-    ...(pendingRaceChoices.alterations?.minor || []),
-    ...(pendingRaceChoices.alterations?.major || []),
-  ];
-  const allSelects = [...choiceSelects];
-  if (pendingRaceChoices.size) allSelects.push(pendingRaceChoices.size);
-  if (pendingRaceChoices.resist) allSelects.push(pendingRaceChoices.resist);
-  if (pendingRaceChoices.alterations?.combo)
-    allSelects.push(pendingRaceChoices.alterations.combo);
+  const check = (arr, container) =>
+    inlineWarning(container, arr.length === 0 || arr.every((s) => s.value), arr);
 
-  allSelects.forEach((sel) => sel.removeAttribute('title'));
+  const skillValid = check(pendingRaceChoices.skills, choiceAccordions.skills);
+  const langValid = check(pendingRaceChoices.languages, choiceAccordions.languages);
+  const spellValid = check(pendingRaceChoices.spells, choiceAccordions.spells);
+  const abilityValid = check(pendingRaceChoices.abilities, choiceAccordions.abilities);
+  const toolValid = check(pendingRaceChoices.tools, choiceAccordions.tools);
+  const weaponValid = check(pendingRaceChoices.weapons, choiceAccordions.weapons);
 
-  const missing = allSelects.filter((s) => !s.value);
-  if (CharacterState.showHelp) {
-    missing.forEach((s) => {
-      s.title = t('selectionRequired');
-    });
-  }
+  const sizeValid = inlineWarning(
+    choiceAccordions.size,
+    !pendingRaceChoices.size || pendingRaceChoices.size.value,
+    pendingRaceChoices.size
+  );
 
-  const isGroupValid = (arr) => arr.length === 0 || arr.every((s) => s.value);
+  const resistValid = inlineWarning(
+    choiceAccordions.resist,
+    !pendingRaceChoices.resist || pendingRaceChoices.resist.value,
+    pendingRaceChoices.resist
+  );
 
-  const skillValid = isGroupValid(pendingRaceChoices.skills);
-  markIncomplete(choiceAccordions.skills, skillValid);
-
-  const langValid = isGroupValid(pendingRaceChoices.languages);
-  markIncomplete(choiceAccordions.languages, langValid);
-
-  const spellValid = isGroupValid(pendingRaceChoices.spells);
-  markIncomplete(choiceAccordions.spells, spellValid);
-
-  const abilityValid = isGroupValid(pendingRaceChoices.abilities);
-  markIncomplete(choiceAccordions.abilities, abilityValid);
-
-  const toolValid = isGroupValid(pendingRaceChoices.tools);
-  markIncomplete(choiceAccordions.tools, toolValid);
-
-  const weaponValid = isGroupValid(pendingRaceChoices.weapons);
-  markIncomplete(choiceAccordions.weapons, weaponValid);
-
-  const sizeValid =
-    !pendingRaceChoices.size || pendingRaceChoices.size.value;
-  markIncomplete(choiceAccordions.size, sizeValid);
-
-  const resistValid =
-    !pendingRaceChoices.resist || pendingRaceChoices.resist.value;
-  markIncomplete(choiceAccordions.resist, resistValid);
-
-  const altComboValid =
-    !pendingRaceChoices.alterations.combo ||
-    pendingRaceChoices.alterations.combo.value;
-  const altMinorValid = pendingRaceChoices.alterations.minor.every((s) => s.value);
-  const altMajorValid = pendingRaceChoices.alterations.major.every((s) => s.value);
-  const altValid = altComboValid && altMinorValid && altMajorValid;
-  markIncomplete(choiceAccordions.alterations, altValid);
+  const altFields = [
+    pendingRaceChoices.alterations.combo,
+    ...pendingRaceChoices.alterations.minor,
+    ...pendingRaceChoices.alterations.major,
+  ].filter(Boolean);
+  const altValid =
+    (!pendingRaceChoices.alterations.combo ||
+      pendingRaceChoices.alterations.combo.value) &&
+    pendingRaceChoices.alterations.minor.every((s) => s.value) &&
+    pendingRaceChoices.alterations.major.every((s) => s.value);
+  inlineWarning(choiceAccordions.alterations, altValid, altFields);
 
   const valid =
     skillValid &&

--- a/src/step4.js
+++ b/src/step4.js
@@ -13,8 +13,8 @@ import {
   createAccordionItem,
   createSelectableCard,
   appendEntries,
-  markIncomplete,
 } from './ui-helpers.js';
+import { inlineWarning } from './validation.js';
 import { addUniqueProficiency, pendingReplacements } from './proficiency.js';
 import { renderFeatChoices } from './feat.js';
 
@@ -300,23 +300,32 @@ function selectBackground(bg) {
 }
 
 function validateBackgroundChoices() {
-  const skillValid = pendingSelections.skills.every((s) => s.value);
-  markIncomplete(choiceAccordions.skills, skillValid);
+  const check = (arr, container) =>
+    inlineWarning(container, arr.every((s) => s.value), arr);
 
-  const toolValid = pendingSelections.tools.every((s) => s.value);
-  markIncomplete(choiceAccordions.tools, toolValid);
-
-  const langValid = pendingSelections.languages.every((s) => s.value);
-  markIncomplete(choiceAccordions.languages, langValid);
+  const skillValid = check(pendingSelections.skills, choiceAccordions.skills);
+  const toolValid = check(pendingSelections.tools, choiceAccordions.tools);
+  const langValid = check(pendingSelections.languages, choiceAccordions.languages);
 
   let featValid = true;
   if (pendingSelections.feat) {
+    const featFields = [pendingSelections.feat];
     featValid = !!pendingSelections.feat.value;
     if (featValid && pendingSelections.featRenderer) {
       featValid = pendingSelections.featRenderer.isComplete();
+      featFields.push(
+        ...(pendingSelections.featRenderer.abilitySelects || []),
+        ...(pendingSelections.featRenderer.skillSelects || []),
+        ...(pendingSelections.featRenderer.toolSelects || []),
+        ...(pendingSelections.featRenderer.languageSelects || []),
+        ...(pendingSelections.featRenderer.spellSelects || []),
+        ...(pendingSelections.featRenderer.optionalFeatureSelects || [])
+      );
     }
+    inlineWarning(choiceAccordions.feat, featValid, featFields);
+  } else {
+    inlineWarning(choiceAccordions.feat, true);
   }
-  markIncomplete(choiceAccordions.feat, featValid);
 
   const allValid = skillValid && toolValid && langValid && featValid;
   main.setCurrentStepComplete?.(allValid);

--- a/src/step5.js
+++ b/src/step5.js
@@ -1,7 +1,8 @@
 import { DATA, CharacterState, fetchJsonWithRetry } from './data.js';
 import { t } from './i18n.js';
 import * as main from './main.js';
-import { createAccordionItem, markIncomplete } from './ui-helpers.js';
+import { createAccordionItem } from './ui-helpers.js';
+import { inlineWarning } from './validation.js';
 
 let equipmentData;
 let choiceBlocks = [];
@@ -243,7 +244,7 @@ function validateEquipmentSelections() {
   let allValid = true;
   choiceBlocks.forEach((b) => {
     const ok = b.validator();
-    markIncomplete(b.element, ok);
+    inlineWarning(b.element, ok);
     if (!ok) allValid = false;
   });
   equipmentSelectionsValid = allValid;

--- a/src/validation.js
+++ b/src/validation.js
@@ -1,0 +1,39 @@
+import { t } from './i18n.js';
+import { showToast, markIncomplete } from './ui-helpers.js';
+
+/**
+ * Apply inline validation to a section and optional fields.
+ * Marks the container as incomplete and sets titles on empty fields.
+ * @param {HTMLElement} container
+ * @param {boolean} isValid
+ * @param {HTMLElement|HTMLElement[]} fields
+ * @param {string} key translation key for the warning message
+ * @returns {boolean} isValid
+ */
+export function inlineWarning(
+  container,
+  isValid,
+  fields = [],
+  key = 'selectionRequired'
+) {
+  markIncomplete(container, isValid);
+  const arr = Array.isArray(fields) ? fields.filter(Boolean) : [fields].filter(Boolean);
+  arr.forEach((f) => {
+    f.removeAttribute?.('title');
+    if (!isValid && !f.value && globalThis.CharacterState?.showHelp) {
+      f.title = t(key);
+    }
+  });
+  return isValid;
+}
+
+/**
+ * Display a translated toast message.
+ * @param {string} key translation key
+ * @param {object} params interpolation parameters
+ * @param {number} duration display duration in ms
+ */
+export function globalToast(key, params = {}, duration = 3000) {
+  showToast(t(key, params), duration);
+}
+


### PR DESCRIPTION
## Summary
- Add `validation.js` with helpers for inline warnings and translated toasts
- Refactor Steps 2–5 to use new helpers for consistent validation styling

## Testing
- `npm test` *(fails: Race validation failed)*
- `node --experimental-vm-modules ./node_modules/jest/bin/jest.js` *(fails: missing html2canvas module and invalidateStep errors)*

------
https://chatgpt.com/codex/tasks/task_e_68b8b0356238832e9e4655817a42eac5