### PR TITLE
Load equipment globally and guard consumers

### DIFF
--- a/__tests__/featOptionalFeatures.test.js
+++ b/__tests__/featOptionalFeatures.test.js
@@ -21,6 +21,9 @@ jest.unstable_mockModule('../src/data.js', () => ({
   loadOptionalFeatures: async () => {},
   logCharacterState: jest.fn(),
 }));
+jest.unstable_mockModule('../src/step5.js', () => ({
+  loadEquipmentData: jest.fn().mockResolvedValue([]),
+}));
 
 const { renderFeatChoices } = await import('../src/feat.js');
 

--- a/__tests__/proficiencyUtils.test.js
+++ b/__tests__/proficiencyUtils.test.js
@@ -20,6 +20,9 @@ jest.unstable_mockModule('../src/data.js', () => ({
   loadSpells: jest.fn(),
   fetchJsonWithRetry: jest.fn(),
 }));
+jest.unstable_mockModule('../src/step5.js', () => ({
+  loadEquipmentData: jest.fn().mockResolvedValue([]),
+}));
 
 const {
   addUniqueProficiency,

--- a/__tests__/renderAbilityBonuses.test.js
+++ b/__tests__/renderAbilityBonuses.test.js
@@ -27,6 +27,9 @@ jest.unstable_mockModule('../src/data.js', () => ({
   loadOptionalFeatures: async () => {},
   logCharacterState: jest.fn(),
 }));
+jest.unstable_mockModule('../src/step5.js', () => ({
+  loadEquipmentData: jest.fn().mockResolvedValue([]),
+}));
 
 const { renderAbilityBonuses } = await import('../src/feat.js');
 

--- a/__tests__/renderProficiencyChoices.test.js
+++ b/__tests__/renderProficiencyChoices.test.js
@@ -16,6 +16,9 @@ jest.unstable_mockModule('../src/data.js', () => ({
   loadOptionalFeatures: async () => {},
   logCharacterState: jest.fn(),
 }));
+jest.unstable_mockModule('../src/step5.js', () => ({
+  loadEquipmentData: jest.fn().mockResolvedValue([]),
+}));
 
 const { renderProficiencyChoices } = await import('../src/feat.js');
 

--- a/__tests__/renderWeaponChoices.test.js
+++ b/__tests__/renderWeaponChoices.test.js
@@ -24,6 +24,9 @@ jest.unstable_mockModule('../src/data.js', () => ({
   loadOptionalFeatures: async () => {},
   logCharacterState: jest.fn(),
 }));
+jest.unstable_mockModule('../src/step5.js', () => ({
+  loadEquipmentData: jest.fn().mockResolvedValue(DATA.equipment),
+}));
 
 const { renderWeaponChoices } = await import('../src/feat.js');
 
@@ -40,7 +43,7 @@ describe('renderWeaponChoices', () => {
         },
       ],
     };
-    const { weaponSelects } = renderWeaponChoices(feat, div, () => {});
+    const { weaponSelects } = await renderWeaponChoices(feat, div, () => {});
     expect(weaponSelects.length).toBe(4);
     weaponSelects[0].value = 'Longsword';
     weaponSelects[0].dispatchEvent(new Event('change'));

--- a/__tests__/step3.test.js
+++ b/__tests__/step3.test.js
@@ -63,6 +63,9 @@ jest.unstable_mockModule('../src/choice-select-helpers.js', () => ({
 jest.unstable_mockModule('../src/main.js', () => ({
   showStep: mockShowStep,
 }));
+jest.unstable_mockModule('../src/step5.js', () => ({
+  loadEquipmentData: jest.fn().mockResolvedValue([]),
+}));
 
 const {
   renderBaseRaces,

--- a/src/feat.js
+++ b/src/feat.js
@@ -8,6 +8,7 @@ import {
 import { t } from './i18n.js';
 import { addUniqueProficiency } from './proficiency.js';
 import { createElement, capitalize, appendEntries } from './ui-helpers.js';
+import { loadEquipmentData } from './step5.js';
 
 function refreshAbility(ab) {
   const base = CharacterState.baseAbilities?.[ab];
@@ -218,9 +219,10 @@ export function renderProficiencyChoices(feat, wrapper, onChange = () => {}) {
   };
 }
 
-export function renderWeaponChoices(feat, wrapper, onChange = () => {}) {
+export async function renderWeaponChoices(feat, wrapper, onChange = () => {}) {
   const weaponSelects = [];
   if (Array.isArray(feat.weaponProficiencies)) {
+    await loadEquipmentData();
     feat.weaponProficiencies.forEach((entry) => {
       if (entry.choose?.fromFilter) {
         const opts = getWeaponsFromFilter(entry.choose.fromFilter);
@@ -309,7 +311,7 @@ export async function renderFeatChoices(featName, container, onChange = () => {}
     languageSelects,
     saveSelects,
   } = renderProficiencyChoices(feat, wrapper, onChange);
-  const { weaponSelects } = renderWeaponChoices(feat, wrapper, onChange);
+  const { weaponSelects } = await renderWeaponChoices(feat, wrapper, onChange);
 
   const optionalFeatureSelects = [];
   if (Array.isArray(feat.optionalfeatureProgression)) {

--- a/src/proficiency.js
+++ b/src/proficiency.js
@@ -1,5 +1,6 @@
 import { DATA, CharacterState, logCharacterState } from './data.js';
 import { t } from './i18n.js';
+import { loadEquipmentData } from './step5.js';
 
 // full list of skills for replacement handling
 export const ALL_SKILLS = [
@@ -84,10 +85,15 @@ export function getAllOptions(type) {
   if (type === 'tools') return ALL_TOOLS;
   if (type === 'instruments') return ALL_INSTRUMENTS;
   if (type === 'languages') return DATA.languages || [];
-  if (type === 'weapons')
-    return (DATA.equipment || [])
+  if (type === 'weapons') {
+    if (!Array.isArray(DATA.equipment)) {
+      loadEquipmentData();
+      return [];
+    }
+    return DATA.equipment
       .filter((i) => /weapon/i.test(i.type))
       .map((i) => i.name);
+  }
   if (type === 'feats') return DATA.feats || [];
   return [];
 }

--- a/src/step3.js
+++ b/src/step3.js
@@ -6,6 +6,7 @@ import {
   logCharacterState,
   loadSpells
 } from './data.js';
+import { loadEquipmentData } from './step5.js';
 import { refreshBaseState, rebuildFromClasses } from './step2.js';
 import { updateChoiceSelectOptions, filterDuplicateOptions } from './choice-select-helpers.js';
 import { t } from './i18n.js';
@@ -463,6 +464,7 @@ async function renderSelectedRace() {
     }
   }
   if (currentRaceData.weaponProficiencies) {
+    await loadEquipmentData();
     const raceWeapons = [];
     const chooseGroups = [];
     currentRaceData.weaponProficiencies.forEach((obj) => {

--- a/src/step5.js
+++ b/src/step5.js
@@ -29,12 +29,13 @@ function getSimpleWeapons() {
       ];
 }
 
-async function loadEquipmentData() {
+export async function loadEquipmentData() {
   if (equipmentData) return equipmentData;
 
   try {
     const data = await fetchJsonWithRetry('data/equipment.json', 'equipment');
     equipmentData = data;
+    DATA.equipment = data;
     return equipmentData;
   } catch {
     const container = document.getElementById('equipmentSelections');


### PR DESCRIPTION
## Summary
- Expose `loadEquipmentData` and cache equipment on `DATA` for reuse
- Ensure race and feat steps wait for equipment data before building weapon choices
- Fetch equipment metadata when listing weapon proficiencies

## Testing
- `npm test` *(fails: Race validation failed)*

------
https://chatgpt.com/codex/tasks/task_e_68b8b57c421c832ebf298284bb0c3a93