### PR TITLE
Prevent change button listener duplication

### DIFF
--- a/src/step3.js
+++ b/src/step3.js
@@ -1243,31 +1243,36 @@ export async function loadStep3(force = false) {
     });
   }
 
-  const changeBtn = document.getElementById('changeRace');
-  changeBtn?.addEventListener('click', async () => {
-    selectedBaseRace = '';
-    currentRaceData = null;
-    resetPendingRaceChoices();
-    if (preRaceState) {
-      Object.assign(CharacterState, structuredClone(preRaceState));
-      preRaceState = null;
-      refreshBaseState();
-      rebuildFromClasses();
-      main.invalidateStep(4);
-      main.invalidateStep(5);
-      main.invalidateStep(6);
-      main.invalidateStepsFrom(4);
-    }
-    const traits = document.getElementById('raceTraits');
-    if (traits) traits.innerHTML = '';
-    const list = document.getElementById('raceList');
-    const features = document.getElementById('raceFeatures');
-    list?.classList.remove('hidden');
-    features?.classList.add('hidden');
-    searchInput?.classList.remove('hidden');
-    await renderBaseRaces(searchInput?.value);
-    validateRaceChoices();
-  });
+  let changeBtn = document.getElementById('changeRace');
+  if (changeBtn) {
+    const newBtn = changeBtn.cloneNode(true);
+    changeBtn.parentNode.replaceChild(newBtn, changeBtn);
+    changeBtn = newBtn;
+    changeBtn.addEventListener('click', async () => {
+      selectedBaseRace = '';
+      currentRaceData = null;
+      resetPendingRaceChoices();
+      if (preRaceState) {
+        Object.assign(CharacterState, structuredClone(preRaceState));
+        preRaceState = null;
+        refreshBaseState();
+        rebuildFromClasses();
+        main.invalidateStep(4);
+        main.invalidateStep(5);
+        main.invalidateStep(6);
+        main.invalidateStepsFrom(4);
+      }
+      const traits = document.getElementById('raceTraits');
+      if (traits) traits.innerHTML = '';
+      const list = document.getElementById('raceList');
+      const features = document.getElementById('raceFeatures');
+      list?.classList.remove('hidden');
+      features?.classList.add('hidden');
+      searchInput?.classList.remove('hidden');
+      await renderBaseRaces(searchInput?.value);
+      validateRaceChoices();
+    });
+  }
 }
 
 export function isStepComplete() {

--- a/src/step4.js
+++ b/src/step4.js
@@ -448,24 +448,29 @@ export function loadStep4(force = false) {
       renderBackgroundList(e.target.value);
     });
   }
-  const changeBtn = document.getElementById('changeBackground');
-  changeBtn?.addEventListener('click', () => {
-    currentBackgroundData = null;
-    resetPendingSelections();
-    const list = document.getElementById('backgroundList');
-    list?.classList.remove('hidden');
-    const search = document.getElementById('backgroundSearch');
-    search?.classList.remove('hidden');
-    const features = document.getElementById('backgroundFeatures');
-    if (features) {
-      features.classList.add('hidden');
-      features.innerHTML = '';
-    }
-    renderBackgroundList(search?.value);
-    main.invalidateStep(5);
-    main.invalidateStep(6);
-    main.invalidateStepsFrom(5);
-  });
+  let changeBtn = document.getElementById('changeBackground');
+  if (changeBtn) {
+    const newBtn = changeBtn.cloneNode(true);
+    changeBtn.parentNode.replaceChild(newBtn, changeBtn);
+    changeBtn = newBtn;
+    changeBtn.addEventListener('click', () => {
+      currentBackgroundData = null;
+      resetPendingSelections();
+      const list = document.getElementById('backgroundList');
+      list?.classList.remove('hidden');
+      const search = document.getElementById('backgroundSearch');
+      search?.classList.remove('hidden');
+      const features = document.getElementById('backgroundFeatures');
+      if (features) {
+        features.classList.add('hidden');
+        features.innerHTML = '';
+      }
+      renderBackgroundList(search?.value);
+      main.invalidateStep(5);
+      main.invalidateStep(6);
+      main.invalidateStepsFrom(5);
+    });
+  }
 }
 
 export function isStepComplete() {


### PR DESCRIPTION
## Summary
- avoid stacking click handlers on race and background change buttons by cloning nodes before adding listeners
- verify race change handler doesn't multiply after repeated step loads

## Testing
- `npm test` *(fails: altered.json missing selection metadata for: size)*
- `node --experimental-vm-modules ./node_modules/jest/bin/jest.js __tests__/step3.test.js` *(fails: race size selection – Expected: true Received: false)*

------
https://chatgpt.com/codex/tasks/task_e_68b8b8513f6c832e904d10daebd5d76b