### PR TITLE
feat: add confirmation utility

### DIFF
--- a/__tests__/step2.test.js
+++ b/__tests__/step2.test.js
@@ -7,6 +7,7 @@ import * as Step2 from '../src/step2.js';
 import { updateChoiceSelectOptions, updateSkillSelectOptions } from '../src/choice-select-helpers.js';
 import { CharacterState, DATA, MAX_CHARACTER_LEVEL } from '../src/data.js';
 import { t } from '../src/i18n.js';
+import * as uiHelpers from '../src/ui-helpers.js';
 import { readFileSync } from 'fs';
 import path from 'path';
 import { fileURLToPath } from 'url';
@@ -122,13 +123,15 @@ describe('duplicate selection prevention', () => {
       cantripSelect2.querySelector("option[value='Fire Bolt']").disabled
     ).toBe(true);
   });
-  test('selectClass prevents adding duplicate classes', () => {
+  test('selectClass prevents adding duplicate classes', async () => {
     CharacterState.classes = [{ name: 'Fighter', level: 1 }];
-    const alertMock = jest.spyOn(global, 'alert').mockImplementation(() => {});
-    Step2.selectClass({ name: 'Fighter' });
+    const confirmMock = jest
+      .spyOn(uiHelpers, 'showConfirmation')
+      .mockResolvedValue(true);
+    await Step2.selectClass({ name: 'Fighter' });
     expect(CharacterState.classes).toHaveLength(1);
-    expect(alertMock).toHaveBeenCalled();
-    alertMock.mockRestore();
+    expect(confirmMock).toHaveBeenCalled();
+    confirmMock.mockRestore();
   });
 });
 

--- a/src/data.js
+++ b/src/data.js
@@ -1,4 +1,5 @@
 import { t } from './i18n.js';
+import { showConfirmation } from './ui-helpers.js';
 export const DATA = {};
 
 // Maximum total level a character can reach
@@ -12,16 +13,15 @@ export const MAX_CHARACTER_LEVEL = 20;
  */
 export const fetchJsonCallbacks = {
   onRetry: (msg) =>
-    typeof window !== 'undefined' && typeof window.confirm === 'function'
-      ? window.confirm(msg)
-      : false,
-  onError: (msg) => {
-    if (typeof window !== 'undefined' && typeof window.alert === 'function') {
-      window.alert(msg);
-    } else {
-      console.error(msg);
-    }
-  },
+    showConfirmation(msg, {
+      confirmText: t('retry'),
+      cancelText: t('cancel'),
+    }),
+  onError: (msg) =>
+    showConfirmation(msg, {
+      confirmText: t('ok'),
+      cancelText: null,
+    }),
 };
 
 /**
@@ -50,13 +50,13 @@ export async function fetchJsonWithRetry(
       lastError = err;
       attempts++;
       if (attempts >= maxRetries) break;
-      const retry = callbacks.onRetry(
+      const retry = await callbacks.onRetry(
         t('fetchRetry', { resource: resourceName })
       );
       if (!retry) break;
     }
   }
-  callbacks.onError(t('fetchFailed', { resource: resourceName }));
+  await callbacks.onError(t('fetchFailed', { resource: resourceName }));
   throw lastError;
 }
 

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -88,4 +88,7 @@
   "selectBackgroundToProceed": "Select a background to proceed.",
   "chooseEquipmentToProceed": "Choose your equipment to proceed.",
   "assignAbilityPointsToProceed": "Assign all ability points to proceed."
+  ,"ok": "OK"
+  ,"cancel": "Cancel"
+  ,"retry": "Retry"
 }

--- a/src/i18n/it.json
+++ b/src/i18n/it.json
@@ -88,4 +88,7 @@
   "selectBackgroundToProceed": "Seleziona un background per procedere.",
   "chooseEquipmentToProceed": "Scegli il tuo equipaggiamento per procedere.",
   "assignAbilityPointsToProceed": "Assegna tutti i punti caratteristica per procedere."
+  ,"ok": "OK"
+  ,"cancel": "Annulla"
+  ,"retry": "Riprova"
 }

--- a/src/step2.js
+++ b/src/step2.js
@@ -15,6 +15,7 @@ import {
   createAccordionItem,
   createSelectableCard,
   appendEntries,
+  showConfirmation,
 } from './ui-helpers.js';
 import { inlineWarning, globalToast } from './validation.js';
 import { renderFeatChoices } from './feat.js';
@@ -1077,14 +1078,15 @@ function showClassModal(cls) {
 /**
  * Salva la classe selezionata nel CharacterState
  */
-function selectClass(cls) {
+async function selectClass(cls) {
   const classes = CharacterState.classes || (CharacterState.classes = []);
   if (classes.some(c => c.name === cls.name)) {
-    if (typeof alert !== 'undefined') {
-      alert(t('classAlreadySelected', { name: cls.name }));
-    }
+    await showConfirmation(t('classAlreadySelected', { name: cls.name }), {
+      confirmText: t('ok'),
+      cancelText: null,
+    });
     loadStep2(false);
-    return;
+    return false;
   }
 
   const newCls = {
@@ -1107,6 +1109,7 @@ function selectClass(cls) {
   document.getElementById('selectedClasses')?.classList.remove('hidden');
   loadStep2(false);
   updateStep2Completion();
+  return true;
 }
 
 export {

--- a/src/step6.js
+++ b/src/step6.js
@@ -1,6 +1,7 @@
 import { CharacterState, totalLevel } from './data.js';
 import { t } from './i18n.js';
 import * as main from './main.js';
+import { showConfirmation } from './ui-helpers.js';
 
 const ABILITIES = ['str', 'dex', 'con', 'int', 'wis', 'cha'];
 const COST = { 8:0, 9:1, 10:2, 11:3, 12:4, 13:5, 14:7, 15:9 };
@@ -68,15 +69,18 @@ function adjustAbility(ab, delta) {
   calcRemaining();
 }
 
-function applyBonus() {
+async function applyBonus() {
   const selections = [
     document.getElementById('bonusSelect1')?.value,
     document.getElementById('bonusSelect2')?.value,
     document.getElementById('bonusSelect3')?.value,
   ];
   if (selections.some((v) => !v)) {
-    alert(t('selectThreeAbilities'));
-    return;
+    await showConfirmation(t('selectThreeAbilities'), {
+      confirmText: t('ok'),
+      cancelText: null,
+    });
+    return false;
   }
   const counts = selections.reduce((acc, ab) => {
     acc[ab] = (acc[ab] || 0) + 1;
@@ -87,8 +91,11 @@ function applyBonus() {
     (Object.keys(counts).length === 2 && values.includes(2) && values.includes(1)) ||
     (Object.keys(counts).length === 3 && values.every((v) => v === 1));
   if (!valid) {
-    alert(t('invalidBonusDistribution'));
-    return;
+    await showConfirmation(t('invalidBonusDistribution'), {
+      confirmText: t('ok'),
+      cancelText: null,
+    });
+    return false;
   }
   CharacterState.bonusAbilities = { ...CharacterState.bonusAbilities };
   Object.entries(counts).forEach(([ab, val]) => {
@@ -97,6 +104,7 @@ function applyBonus() {
   });
   ABILITIES.forEach(updateFinal);
   validateAbilities();
+  return true;
 }
 
 export function commitAbilities() {


### PR DESCRIPTION
## Summary
- add reusable showConfirmation toast helper
- use showConfirmation in class selection, ability bonuses, and fetch retry
- expose translated button labels for confirmation dialogs

## Testing
- `npm test` *(fails: altered.json missing selection metadata for: size)*
- `node --experimental-vm-modules ./node_modules/jest/bin/jest.js` *(fails: Test Suites: 15 failed, 15 passed, 30 total)*

------
https://chatgpt.com/codex/tasks/task_e_68b8bc100f44832e833e767d566ecc0f