### PR TITLE
Refactor DOM construction to avoid innerHTML

### DIFF
--- a/src/feat.js
+++ b/src/feat.js
@@ -32,7 +32,7 @@ export function renderAbilityBonuses(feat, wrapper, onChange = () => {}) {
         const from = ab.choose.from || [];
         for (let i = 0; i < amount; i++) {
           const sel = document.createElement('select');
-          sel.innerHTML = `<option value=''>${t('selectAbilityForFeat')}</option>`;
+          sel.replaceChildren(new Option(t('selectAbilityForFeat'), ''));
           from.forEach((opt) => {
             const o = document.createElement('option');
             o.value = opt;
@@ -81,7 +81,7 @@ export function renderProficiencyChoices(feat, wrapper, onChange = () => {}) {
         const from = entry.choose.from || entry.choose.options || [];
         for (let i = 0; i < amount; i++) {
           const sel = document.createElement('select');
-          sel.innerHTML = `<option value=''>${t(labelKey)}</option>`;
+          sel.replaceChildren(new Option(t(labelKey), ''));
           from.forEach((opt) => {
             const o = document.createElement('option');
             o.value = opt;
@@ -104,7 +104,7 @@ export function renderProficiencyChoices(feat, wrapper, onChange = () => {}) {
       const count = entry.anyProficientSkill || 0;
       for (let i = 0; i < count; i++) {
         const sel = document.createElement('select');
-        sel.innerHTML = `<option value=''>${t('selectSkillForFeat')}</option>`;
+        sel.replaceChildren(new Option(t('selectSkillForFeat'), ''));
         wrapper.appendChild(sel);
         expertiseSelects.push(sel);
         sel.addEventListener('change', () => {
@@ -139,7 +139,7 @@ export function renderProficiencyChoices(feat, wrapper, onChange = () => {}) {
         for (let i = 0; i < amount; i++) {
           const sel = document.createElement('select');
           sel.dataset.opts = JSON.stringify(from);
-          sel.innerHTML = `<option value=''>${t('selectSaveForFeat')}</option>`;
+          sel.replaceChildren(new Option(t('selectSaveForFeat'), ''));
           from.forEach((opt) => {
             const o = document.createElement('option');
             o.value = opt;
@@ -173,7 +173,7 @@ export function renderProficiencyChoices(feat, wrapper, onChange = () => {}) {
       const opts = JSON.parse(sel.dataset.opts || '[]');
       const current = sel.value;
       if (current) taken.delete(current);
-      sel.innerHTML = `<option value=''>${t('selectSaveForFeat')}</option>`;
+      sel.replaceChildren(new Option(t('selectSaveForFeat'), ''));
       opts.forEach((ab) => {
         if (ab !== current && taken.has(ab)) return;
         const o = document.createElement('option');
@@ -195,7 +195,7 @@ export function renderProficiencyChoices(feat, wrapper, onChange = () => {}) {
     expertiseSelects.forEach((sel) => {
       const current = sel.value;
       if (current) taken.delete(current);
-      sel.innerHTML = `<option value=''>${t('selectSkillForFeat')}</option>`;
+      sel.replaceChildren(new Option(t('selectSkillForFeat'), ''));
       Array.from(known)
         .sort()
         .forEach((sk) => {
@@ -230,7 +230,7 @@ export async function renderWeaponChoices(feat, wrapper, onChange = () => {}) {
         const selects = [];
         for (let i = 0; i < count; i++) {
           const sel = document.createElement('select');
-          sel.innerHTML = `<option value=''>${t('selectWeaponForFeat')}</option>`;
+          sel.replaceChildren(new Option(t('selectWeaponForFeat'), ''));
           wrapper.appendChild(sel);
           weaponSelects.push(sel);
           selects.push(sel);
@@ -278,7 +278,7 @@ export async function renderWeaponChoices(feat, wrapper, onChange = () => {}) {
     const taken = new Set(selects.map((s) => s.value).filter(Boolean));
     selects.forEach((sel) => {
       const current = sel.value;
-      sel.innerHTML = `<option value=''>${t('selectWeaponForFeat')}</option>`;
+      sel.replaceChildren(new Option(t('selectWeaponForFeat'), ''));
       opts.forEach((o) => {
         if (o !== current && taken.has(o)) return;
         const opt = document.createElement('option');
@@ -324,7 +324,7 @@ export async function renderFeatChoices(featName, container, onChange = () => {}
       const selects = [];
       for (let i = 0; i < count; i++) {
         const sel = document.createElement('select');
-        sel.innerHTML = `<option value=''>${t('select')}</option>`;
+        sel.replaceChildren(new Option(t('select'), ''));
         wrapper.appendChild(sel);
         optionalFeatureSelects.push(sel);
         selects.push(sel);
@@ -341,7 +341,7 @@ export async function renderFeatChoices(featName, container, onChange = () => {}
     const taken = new Set(selects.map((s) => s.value).filter(Boolean));
     selects.forEach((sel) => {
       const current = sel.value;
-      sel.innerHTML = `<option value=''>${t('select')}</option>`;
+      sel.replaceChildren(new Option(t('select'), ''));
       opts.forEach((o) => {
         if (o !== current && taken.has(o)) return;
         const opt = document.createElement('option');
@@ -361,7 +361,7 @@ export async function renderFeatChoices(featName, container, onChange = () => {}
   if (Array.isArray(feat.additionalSpells) && feat.additionalSpells.length) {
     const spellWrapper = document.createElement('div');
     spellClassSelect = document.createElement('select');
-    spellClassSelect.innerHTML = `<option value=''>${t('select')}</option>`;
+    spellClassSelect.replaceChildren(new Option(t('select'), ''));
     feat.additionalSpells.forEach((opt, idx) => {
       const o = document.createElement('option');
       o.value = String(idx);
@@ -424,7 +424,7 @@ export async function renderFeatChoices(featName, container, onChange = () => {}
             const sel = document.createElement('select');
             sel.className = 'feat-spell-select';
             sel.dataset.opts = JSON.stringify(opts);
-            sel.innerHTML = `<option value=''>${t('select')}</option>`;
+            sel.replaceChildren(new Option(t('select'), ''));
             sel.addEventListener('change', () => {
               updateSpellSelects();
               onChange();
@@ -457,7 +457,7 @@ export async function renderFeatChoices(featName, container, onChange = () => {}
               const sel = document.createElement('select');
               sel.className = 'feat-spell-select';
               sel.dataset.opts = JSON.stringify(opts);
-              sel.innerHTML = `<option value=''>${t('select')}</option>`;
+              sel.replaceChildren(new Option(t('select'), ''));
               sel.addEventListener('change', () => {
                 updateSpellSelects();
                 onChange();
@@ -498,7 +498,7 @@ export async function renderFeatChoices(featName, container, onChange = () => {}
       const opts = JSON.parse(sel.dataset.opts || '[]');
       const current = sel.value;
       if (current) existing.delete(current);
-      sel.innerHTML = `<option value=''>${t('select')}</option>`;
+      sel.replaceChildren(new Option(t('select'), ''));
       opts.forEach((sp) => {
         if (sp !== current && existing.has(sp)) return;
         const o = document.createElement('option');

--- a/src/main.js
+++ b/src/main.js
@@ -295,73 +295,157 @@ function renderCharacterSheet() {
 
   const details = CharacterState.system?.details || {};
   const systemAbilities = CharacterState.system?.abilities || {};
-  const abilityBoxes = ["str", "dex", "con", "int", "wis", "cha"]
-    .map((ab) => {
+  const abilityBoxes = ["str", "dex", "con", "int", "wis", "cha"].map(
+    (ab) => {
       const score = systemAbilities[ab]?.value ?? "";
       const mod = score === "" ? "" : Math.floor((score - 10) / 2);
       const modText = mod === "" ? "" : mod >= 0 ? `+${mod}` : `${mod}`;
       const label = ab.toUpperCase();
-      return `<div class="ability-box" data-ab="${label}"><div class="label">${label}</div><div class="score">${score}</div><div class="mod">${modText}</div></div>`;
-    })
-    .join("");
+      const box = document.createElement("div");
+      box.className = "ability-box";
+      box.dataset.ab = label;
+      const lab = document.createElement("div");
+      lab.className = "label";
+      lab.textContent = label;
+      const scoreDiv = document.createElement("div");
+      scoreDiv.className = "score";
+      scoreDiv.textContent = score;
+      const modDiv = document.createElement("div");
+      modDiv.className = "mod";
+      modDiv.textContent = modText;
+      box.append(lab, scoreDiv, modDiv);
+      return box;
+    }
+  );
 
-  const languagesHtml = summary.languages
-    .map((l) => `<li>${l}</li>`)
-    .join("");
-  const toolsHtml = summary.tools.map((t) => `<li>${t}</li>`).join("");
-  const featuresHtml = summary.features.map((f) => `<li>${f}</li>`).join("");
-  const skillsHtml = summary.skills
-    .map(
-      ({ name, ability, prof, expert }) =>
-        `<li><input type="checkbox" disabled ${prof || expert ? "checked" : ""}/><input type="checkbox" disabled ${expert ? "checked" : ""}/> ${name} (${ability})</li>`
-    )
-    .join("");
-  const equipmentHtml = summary.equipment
-    .map((e) => `<li>${e}</li>`)
-    .join("");
-  const spellsHtml = summary.spells.map((s) => `<li>${s}</li>`).join("");
+  container.textContent = "";
 
-  container.innerHTML = `
-    <header class="char-header">
-      <div><strong>Character:</strong> ${summary.characterName || ""}</div>
-      <div><strong>Player:</strong> ${summary.playerName || ""}</div>
-      <div><strong>Class & Level:</strong> ${classText}</div>
-      <div><strong>Race:</strong> ${details.race || ""}</div>
-      <div><strong>Background:</strong> ${details.background || ""}</div>
-      <div><strong>Provenienza:</strong> ${details.origin || ""}</div>
-      <div><strong>Age:</strong> ${details.age || ""}</div>
-    </header>
-    <section class="abilities">
-      <h3>Abilities</h3>
-      <div class="ability-list">${abilityBoxes}</div>
-    </section>
-    <section class="skills">
-      ${summary.skills.length ? `<h3>Skills</h3><ul>${skillsHtml}</ul>` : ""}
-    </section>
-    <section class="features">
-      <h3>Features</h3>
-      <ul>${featuresHtml}</ul>
-    </section>
-    <section class="equipment">
-      ${summary.equipment.length ? `<h3>Equipment</h3><ul>${equipmentHtml}</ul>` : ""}
-    </section>
-    <section class="tools-languages">
-      ${summary.languages.length ? `<h3>Languages</h3><ul>${languagesHtml}</ul>` : ""}
-      ${summary.tools.length ? `<h3>Tools</h3><ul>${toolsHtml}</ul>` : ""}
-    </section>
-    <section class="spells">
-      <h3>Spells</h3>
-      <ul>${spellsHtml}</ul>
-    </section>
-    <section class="backstory">
-      <h3>Backstory</h3>
-      <textarea id="backstoryInput" class="form-control" rows="4">${
-        details.backstory || ""
-      }</textarea>
-    </section>
-  `;
+  const header = document.createElement("header");
+  header.className = "char-header";
+  const addHeaderRow = (label, value) => {
+    const div = document.createElement("div");
+    const strong = document.createElement("strong");
+    strong.textContent = label;
+    div.append(strong, ` ${value || ""}`);
+    header.appendChild(div);
+  };
+  addHeaderRow("Character:", summary.characterName || "");
+  addHeaderRow("Player:", summary.playerName || "");
+  addHeaderRow("Class & Level:", classText);
+  addHeaderRow("Race:", details.race || "");
+  addHeaderRow("Background:", details.background || "");
+  addHeaderRow("Provenienza:", details.origin || "");
+  addHeaderRow("Age:", details.age || "");
+  container.appendChild(header);
 
-  const backstoryEl = container.querySelector("#backstoryInput");
+  const abilitiesSection = document.createElement("section");
+  abilitiesSection.className = "abilities";
+  abilitiesSection.appendChild(document.createElement("h3")).textContent =
+    "Abilities";
+  const abilityList = document.createElement("div");
+  abilityList.className = "ability-list";
+  abilityList.append(...abilityBoxes);
+  abilitiesSection.appendChild(abilityList);
+  container.appendChild(abilitiesSection);
+
+  const skillsSection = document.createElement("section");
+  skillsSection.className = "skills";
+  if (summary.skills.length) {
+    skillsSection.appendChild(document.createElement("h3")).textContent =
+      "Skills";
+    const ul = document.createElement("ul");
+    summary.skills.forEach(({ name, ability, prof, expert }) => {
+      const li = document.createElement("li");
+      const profBox = document.createElement("input");
+      profBox.type = "checkbox";
+      profBox.disabled = true;
+      profBox.checked = prof || expert;
+      const expertBox = document.createElement("input");
+      expertBox.type = "checkbox";
+      expertBox.disabled = true;
+      expertBox.checked = expert;
+      li.append(
+        profBox,
+        expertBox,
+        document.createTextNode(` ${name} (${ability})`)
+      );
+      ul.appendChild(li);
+    });
+    skillsSection.appendChild(ul);
+  }
+  container.appendChild(skillsSection);
+
+  const featuresSection = document.createElement("section");
+  featuresSection.className = "features";
+  featuresSection.appendChild(document.createElement("h3")).textContent =
+    "Features";
+  const featuresList = document.createElement("ul");
+  summary.features.forEach(
+    (f) =>
+      (featuresList.appendChild(document.createElement("li")).textContent = f)
+  );
+  featuresSection.appendChild(featuresList);
+  container.appendChild(featuresSection);
+
+  const equipmentSection = document.createElement("section");
+  equipmentSection.className = "equipment";
+  if (summary.equipment.length) {
+    equipmentSection.appendChild(document.createElement("h3")).textContent =
+      "Equipment";
+    const equipmentList = document.createElement("ul");
+    summary.equipment.forEach(
+      (e) =>
+        (equipmentList.appendChild(document.createElement("li")).textContent = e)
+    );
+    equipmentSection.appendChild(equipmentList);
+  }
+  container.appendChild(equipmentSection);
+
+  const tlSection = document.createElement("section");
+  tlSection.className = "tools-languages";
+  if (summary.languages.length) {
+    tlSection.appendChild(document.createElement("h3")).textContent =
+      "Languages";
+    const langList = document.createElement("ul");
+    summary.languages.forEach(
+      (l) => (langList.appendChild(document.createElement("li")).textContent = l)
+    );
+    tlSection.appendChild(langList);
+  }
+  if (summary.tools.length) {
+    tlSection.appendChild(document.createElement("h3")).textContent = "Tools";
+    const toolsList = document.createElement("ul");
+    summary.tools.forEach(
+      (t) => (toolsList.appendChild(document.createElement("li")).textContent = t)
+    );
+    tlSection.appendChild(toolsList);
+  }
+  container.appendChild(tlSection);
+
+  const spellsSection = document.createElement("section");
+  spellsSection.className = "spells";
+  spellsSection.appendChild(document.createElement("h3")).textContent =
+    "Spells";
+  const spellsList = document.createElement("ul");
+  summary.spells.forEach(
+    (s) => (spellsList.appendChild(document.createElement("li")).textContent = s)
+  );
+  spellsSection.appendChild(spellsList);
+  container.appendChild(spellsSection);
+
+  const backstorySection = document.createElement("section");
+  backstorySection.className = "backstory";
+  backstorySection.appendChild(document.createElement("h3")).textContent =
+    "Backstory";
+  const backstoryInput = document.createElement("textarea");
+  backstoryInput.id = "backstoryInput";
+  backstoryInput.className = "form-control";
+  backstoryInput.rows = 4;
+  backstoryInput.value = details.backstory || "";
+  backstorySection.appendChild(backstoryInput);
+  container.appendChild(backstorySection);
+
+  const backstoryEl = backstoryInput;
   backstoryEl?.addEventListener("input", () => {
     CharacterState.system.details.backstory = backstoryEl.value;
   });

--- a/src/proficiency.js
+++ b/src/proficiency.js
@@ -134,7 +134,7 @@ export function addUniqueProficiency(
     type: t(type.slice(0, -1)),
   });
   const sel = document.createElement('select');
-  sel.innerHTML = `<option value=''>${t('select')}</option>`;
+  sel.replaceChildren(new Option(t('select'), ''));
   getAllOptions(type)
     .filter(opt => !list.includes(opt))
     .forEach(opt => {

--- a/src/spell-select.js
+++ b/src/spell-select.js
@@ -49,7 +49,7 @@ export function renderSpellChoices(cls) {
 
     for (let i = 0; i < count; i++) {
       const sel = document.createElement('select');
-      sel.innerHTML = `<option value=''>${t('selectSpell')}</option>`;
+      sel.replaceChildren(new Option(t('selectSpell'), ''));
       spells
         .filter(
           (s) =>

--- a/src/step2.js
+++ b/src/step2.js
@@ -153,7 +153,7 @@ function updateExpertiseSelectOptions(selects) {
   const profSkills = [...CharacterState.system.skills].sort();
   list.forEach(sel => {
     const current = sel.value;
-    sel.innerHTML = `<option value=''>${t('select')}</option>`;
+    sel.replaceChildren(new Option(t('select'), ''));
     profSkills.forEach(sk => {
       const o = document.createElement('option');
       o.value = sk;
@@ -293,7 +293,7 @@ function createAbilitySelect() {
     'Charisma',
   ];
   const sel = document.createElement('select');
-  sel.innerHTML = `<option value=''>${t('selectAbility')}</option>`;
+  sel.replaceChildren(new Option(t('selectAbility'), ''));
   abilities.forEach(ab => {
     const o = document.createElement('option');
     o.value = ab;
@@ -306,7 +306,7 @@ function createAbilitySelect() {
 
 function createFeatSelect(current = '') {
   const sel = document.createElement('select');
-  sel.innerHTML = `<option value=''>${t('selectFeat')}</option>`;
+  sel.replaceChildren(new Option(t('selectFeat'), ''));
   const taken = getExistingFeats();
   (DATA.feats || []).forEach(feat => {
     if (!taken.has(feat) || feat === current) {
@@ -506,7 +506,7 @@ function renderClassEditor(cls, index) {
       }
       for (let i = 0; i < clsDef.skill_proficiencies.choose; i++) {
         const sel = document.createElement('select');
-        sel.innerHTML = `<option value=''>${t('select')}</option>`;
+        sel.replaceChildren(new Option(t('select'), ''));
         clsDef.skill_proficiencies.options.forEach(opt => {
           const o = document.createElement('option');
           o.value = opt;
@@ -546,7 +546,7 @@ function renderClassEditor(cls, index) {
         subContainer.appendChild(desc);
       }
       const sel = document.createElement('select');
-      sel.innerHTML = `<option value=''>${t('select')}</option>`;
+      sel.replaceChildren(new Option(t('select'), ''));
       clsDef.subclasses.forEach(sc => {
         const o = document.createElement('option');
         o.value = sc.name;
@@ -623,7 +623,7 @@ function renderClassEditor(cls, index) {
         }
         for (let i = 0; i < count; i++) {
           const sel = document.createElement('select');
-          sel.innerHTML = `<option value=''>${t('select')}</option>`;
+          sel.replaceChildren(new Option(t('select'), ''));
           const choiceId = `${choice.name}-${lvl}-${i}`;
           sel.dataset.choiceId = choiceId;
           if (isExpertise) {

--- a/src/step3.js
+++ b/src/step3.js
@@ -275,7 +275,7 @@ async function renderSelectedRace() {
   ) {
     const sizeContent = document.createElement('div');
     const sel = document.createElement('select');
-    sel.innerHTML = `<option value=''>${t('select')}</option>`;
+    sel.replaceChildren(new Option(t('select'), ''));
     const sizeNames = {
       T: 'Tiny',
       S: 'Small',
@@ -334,7 +334,7 @@ async function renderSelectedRace() {
       const known = new Set([...CharacterState.system.skills, ...raceSkills]);
       for (let i = 0; i < pendingAny; i++) {
         const sel = document.createElement('select');
-        sel.innerHTML = `<option value=''>${t('select')}</option>`;
+        sel.replaceChildren(new Option(t('select'), ''));
         ALL_SKILLS.filter((sk) => !known.has(sk)).forEach((sk) => {
           const o = document.createElement('option');
           o.value = sk;
@@ -355,7 +355,7 @@ async function renderSelectedRace() {
         const count = grp.count || 1;
         for (let i = 0; i < count; i++) {
           const sel = document.createElement('select');
-          sel.innerHTML = `<option value=''>${t('select')}</option>`;
+          sel.replaceChildren(new Option(t('select'), ''));
           opts
             .filter((opt) => !known.has(opt))
             .forEach((opt) => {
@@ -412,7 +412,7 @@ async function renderSelectedRace() {
       ]);
       for (let i = 0; i < pendingAny; i++) {
         const sel = document.createElement('select');
-        sel.innerHTML = `<option value=''>${t('select')}</option>`;
+        sel.replaceChildren(new Option(t('select'), ''));
         ALL_TOOLS.filter((tl) => !known.has(tl)).forEach((tl) => {
           const o = document.createElement('option');
           o.value = tl;
@@ -433,7 +433,7 @@ async function renderSelectedRace() {
         const count = grp.count || 1;
         for (let i = 0; i < count; i++) {
           const sel = document.createElement('select');
-          sel.innerHTML = `<option value=''>${t('select')}</option>`;
+          sel.replaceChildren(new Option(t('select'), ''));
           opts
             .filter((opt) => !known.has(opt))
             .forEach((opt) => {
@@ -518,7 +518,7 @@ async function renderSelectedRace() {
         const count = grp.count || 1;
         for (let i = 0; i < count; i++) {
           const sel = document.createElement('select');
-          sel.innerHTML = `<option value=''>${t('select')}</option>`;
+          sel.replaceChildren(new Option(t('select'), ''));
           (opts || [])
             .filter((opt) => !known.has(opt))
             .forEach((opt) => {
@@ -584,7 +584,7 @@ async function renderSelectedRace() {
         ]);
         for (let i = 0; i < pendingLang; i++) {
           const sel = document.createElement('select');
-          sel.innerHTML = `<option value=''>${t('select')}</option>`;
+          sel.replaceChildren(new Option(t('select'), ''));
           (DATA.languages || [])
             .filter((l) => !known.has(l))
             .forEach((l) => {
@@ -634,7 +634,7 @@ async function renderSelectedRace() {
       }
       if (Array.isArray(chooseOpts) && chooseOpts.length) {
         const sel = document.createElement('select');
-        sel.innerHTML = `<option value=''>${t('select')}</option>`;
+        sel.replaceChildren(new Option(t('select'), ''));
         chooseOpts.forEach((opt) => {
           const o = document.createElement('option');
           o.value = opt;
@@ -664,7 +664,7 @@ async function renderSelectedRace() {
   ) {
     const alterContent = document.createElement('div');
     const comboSel = document.createElement('select');
-    comboSel.innerHTML = `<option value=''>${t('select')}</option>`;
+    comboSel.replaceChildren(new Option(t('select'), ''));
     const minorAllowed = currentRaceData.minorAlterations?.allowed || [];
     const majorAllowed = currentRaceData.majorAlterations?.allowed || [];
     const combos = [];
@@ -705,7 +705,7 @@ async function renderSelectedRace() {
 
         const rebuild = (sel, opts) => {
           const current = sel.value;
-          sel.innerHTML = `<option value=''>${t('select')}</option>`;
+          sel.replaceChildren(new Option(t('select'), ''));
           (opts || []).forEach((opt) => {
             const o = document.createElement('option');
             o.value = opt;
@@ -726,7 +726,7 @@ async function renderSelectedRace() {
 
       for (let i = 0; i < (combo.minor || 0); i++) {
         const sel = document.createElement('select');
-        sel.innerHTML = `<option value=''>${t('select')}</option>`;
+        sel.replaceChildren(new Option(t('select'), ''));
         sel.dataset.type = 'choice';
         sel.addEventListener('change', () => {
           updateAlterOptionLists();
@@ -737,7 +737,7 @@ async function renderSelectedRace() {
       }
       for (let i = 0; i < (combo.major || 0); i++) {
         const sel = document.createElement('select');
-        sel.innerHTML = `<option value=''>${t('select')}</option>`;
+        sel.replaceChildren(new Option(t('select'), ''));
         sel.dataset.type = 'choice';
         sel.addEventListener('change', () => {
           updateAlterOptionLists();
@@ -776,7 +776,7 @@ async function renderSelectedRace() {
         spellEntryUsed = true;
       }
       const sel = document.createElement('select');
-      sel.innerHTML = `<option value=''>${t('select')}</option>`;
+      sel.replaceChildren(new Option(t('select'), ''));
       abilityOpts.forEach((ab) => {
         const o = document.createElement('option');
         o.value = ab;
@@ -873,7 +873,7 @@ async function renderSelectedRace() {
             );
             validateRaceChoices();
           });
-          sel.innerHTML = `<option value=''>${t('select')}</option>`;
+          sel.replaceChildren(new Option(t('select'), ''));
           opts.forEach((sp) => {
             const o = document.createElement('option');
             o.value = sp;
@@ -917,7 +917,10 @@ function showRaceModal(race) {
   const details = document.getElementById('raceModalDetails');
   const closeBtn = document.getElementById('closeRaceModal');
   if (!modal || !details) return;
-  details.innerHTML = `<h2>${race.name}</h2>`;
+  details.textContent = '';
+  const header = document.createElement('h2');
+  header.textContent = race.name;
+  details.appendChild(header);
   (race.entries || []).forEach((entry) => {
     if (typeof entry === 'string') {
       const p = document.createElement('p');

--- a/src/step4.js
+++ b/src/step4.js
@@ -155,7 +155,7 @@ function selectBackground(bg) {
     appendFeatureDesc(wrapper, 'skill');
     for (let i = 0; i < currentBackgroundData.skillChoices.choose; i++) {
       const sel = document.createElement('select');
-      sel.innerHTML = `<option value=''>${t('selectSkill')}</option>`;
+      sel.replaceChildren(new Option(t('selectSkill'), ''));
       currentBackgroundData.skillChoices.options.forEach((opt) => {
         const o = document.createElement('option');
         o.value = opt;
@@ -186,7 +186,7 @@ function selectBackground(bg) {
     appendFeatureDesc(wrapper, 'tool');
     for (let i = 0; i < toolData.choose; i++) {
       const sel = document.createElement('select');
-      sel.innerHTML = `<option value=''>${t('selectTool')}</option>`;
+      sel.replaceChildren(new Option(t('selectTool'), ''));
       (toolData.options || []).forEach((opt) => {
         const o = document.createElement('option');
         o.value = opt;
@@ -219,7 +219,7 @@ function selectBackground(bg) {
       : DATA.languages || [];
     for (let i = 0; i < currentBackgroundData.languages.choose; i++) {
       const sel = document.createElement('select');
-      sel.innerHTML = `<option value=''>${t('selectLanguage')}</option>`;
+      sel.replaceChildren(new Option(t('selectLanguage'), ''));
       langOpts.forEach((l) => {
         const o = document.createElement('option');
         o.value = l;
@@ -244,7 +244,7 @@ function selectBackground(bg) {
     const wrapper = document.createElement('div');
     appendFeatureDesc(wrapper, 'feat');
     const sel = document.createElement('select');
-    sel.innerHTML = `<option value=''>${t('selectFeat')}</option>`;
+    sel.replaceChildren(new Option(t('selectFeat'), ''));
     currentBackgroundData.featOptions.forEach((f) => {
       const o = document.createElement('option');
       o.value = f;

--- a/src/step5.js
+++ b/src/step5.js
@@ -49,7 +49,7 @@ function buildSimpleWeaponSelect(count = 1) {
   const selects = [];
   for (let i = 0; i < count; i++) {
     const sel = document.createElement('select');
-    sel.innerHTML = `<option value="">${t('selectSimpleWeapon')}</option>`;
+    sel.replaceChildren(new Option(t('selectSimpleWeapon'), ''));
     getSimpleWeapons().forEach((w) => {
       const o = document.createElement('option');
       o.value = w;
@@ -129,7 +129,7 @@ function buildChoiceBlock(choice, idx) {
 
   if (choice.type === 'dropdown' || choice.type === 'select') {
     const sel = document.createElement('select');
-    sel.innerHTML = `<option value="">${t('select')}</option>`;
+    sel.replaceChildren(new Option(t('select'), ''));
     (choice.options || []).forEach((opt) => {
       const o = document.createElement('option');
       o.value = opt.value;

--- a/src/ui-helpers.js
+++ b/src/ui-helpers.js
@@ -31,28 +31,33 @@ export function parse5eLinks(str) {
   });
 }
 
+function appendHTML(el, html) {
+  const doc = new DOMParser().parseFromString(html, 'text/html');
+  el.append(...doc.body.childNodes);
+}
+
 export function appendEntries(container, entries) {
   (entries || []).forEach(e => {
     if (!e) return;
     if (typeof e === 'string') {
       const p = document.createElement('p');
-      p.innerHTML = parse5eLinks(e);
+      appendHTML(p, parse5eLinks(e));
       container.appendChild(p);
     } else if (typeof e === 'object') {
       if (e.description) {
         const p = document.createElement('p');
-        p.innerHTML = parse5eLinks(e.description);
+        appendHTML(p, parse5eLinks(e.description));
         container.appendChild(p);
       }
       if (typeof e.entry === 'string') {
         const p = document.createElement('p');
-        p.innerHTML = parse5eLinks(e.entry);
+        appendHTML(p, parse5eLinks(e.entry));
         container.appendChild(p);
       }
       if (Array.isArray(e.entries)) appendEntries(container, e.entries);
       else if (e.name && !e.entry && !e.entries && !e.description) {
         const p = document.createElement('p');
-        p.innerHTML = parse5eLinks(e.name);
+        appendHTML(p, parse5eLinks(e.name));
         container.appendChild(p);
       }
     }


### PR DESCRIPTION
## Summary
- build race modal header and details using DOM methods instead of innerHTML
- render character sheet and selectable inputs with safe DOM APIs
- safely parse 5e reference links via DOMParser

## Testing
- `npm test` *(fails: Race validation failed)*

------
https://chatgpt.com/codex/tasks/task_e_68b96e369cf4832eac051ce5181e5975