### PR TITLE
Warn on incomplete race selections

### DIFF
--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -85,6 +85,7 @@
   "selectClassToProceed": "Select a class to proceed.",
   "completeClassChoicesToProceed": "Complete class choices to proceed.",
   "selectRaceToProceed": "Select a race to proceed.",
+  "completeRaceSelectionsToProceed": "Complete all race selections to proceed.",
   "selectBackgroundToProceed": "Select a background to proceed.",
   "chooseEquipmentToProceed": "Choose your equipment to proceed.",
   "assignAbilityPointsToProceed": "Assign all ability points to proceed."

--- a/src/i18n/it.json
+++ b/src/i18n/it.json
@@ -85,6 +85,7 @@
   "selectClassToProceed": "Seleziona una classe per procedere.",
   "completeClassChoicesToProceed": "Completa le scelte della classe per procedere.",
   "selectRaceToProceed": "Seleziona una razza per procedere.",
+  "completeRaceSelectionsToProceed": "Completa tutte le scelte della razza per procedere.",
   "selectBackgroundToProceed": "Seleziona un background per procedere.",
   "chooseEquipmentToProceed": "Scegli il tuo equipaggiamento per procedere.",
   "assignAbilityPointsToProceed": "Assegna tutti i punti caratteristica per procedere."

--- a/src/ui-helpers.js
+++ b/src/ui-helpers.js
@@ -238,7 +238,6 @@ export function initNextStepWarning() {
   }
 
   const messages = {
-    step3: t('selectRaceToProceed'),
     step4: t('selectBackgroundToProceed'),
     step5: t('chooseEquipmentToProceed'),
     step6: t('assignAbilityPointsToProceed'),
@@ -254,6 +253,15 @@ export function initNextStepWarning() {
         msg = t('selectClassToProceed');
       } else if (document.querySelector('#step2 .needs-selection.incomplete')) {
         msg = t('completeClassChoicesToProceed');
+      }
+    }
+
+    if (active?.id === 'step3' && nextBtn.disabled) {
+      const hasRace = !!globalThis.CharacterState?.system?.details?.race;
+      if (hasRace && document.querySelector('#step3 .needs-selection.incomplete')) {
+        msg = t('completeRaceSelectionsToProceed');
+      } else if (!hasRace) {
+        msg = t('selectRaceToProceed');
       }
     }
 


### PR DESCRIPTION
## Summary
- show specific warning when race selections are incomplete
- add translation strings for new warning in English and Italian

## Testing
- `npm test` *(fails: Race validation failed)*
- `node --experimental-vm-modules ./node_modules/jest/bin/jest.js` *(fails: missing modules and DOM APIs)*

------
https://chatgpt.com/codex/tasks/task_e_68b970c51cc4832eb26d026df22d7f8b