### PR TITLE
refactor: centralize step count constants

### DIFF
--- a/__tests__/asiFeatIntegration.test.js
+++ b/__tests__/asiFeatIntegration.test.js
@@ -9,6 +9,7 @@ const setCurrentStepComplete = jest.fn();
 jest.unstable_mockModule('../src/main.js', () => ({
   setCurrentStepComplete,
   showStep: jest.fn(),
+  TOTAL_STEPS: 7,
 }));
 
 jest.unstable_mockModule('../src/i18n.js', () => ({ t: k => k }));

--- a/__tests__/step3.test.js
+++ b/__tests__/step3.test.js
@@ -65,6 +65,7 @@ jest.unstable_mockModule('../src/main.js', () => ({
   invalidateStep: jest.fn(),
   invalidateStepsFrom: jest.fn(),
   setCurrentStepComplete: jest.fn(),
+  TOTAL_STEPS: 7,
 }));
 jest.unstable_mockModule('../src/step5.js', () => ({
   loadEquipmentData: jest.fn().mockResolvedValue([]),

--- a/__tests__/step4.test.js
+++ b/__tests__/step4.test.js
@@ -33,7 +33,10 @@ jest.unstable_mockModule('../src/choice-select-helpers.js', () => ({
 }));
 
 jest.unstable_mockModule('../src/i18n.js', () => ({ t: (k) => k }));
-jest.unstable_mockModule('../src/main.js', () => ({ showStep: jest.fn() }));
+jest.unstable_mockModule('../src/main.js', () => ({
+  showStep: jest.fn(),
+  TOTAL_STEPS: 7,
+}));
 
 const { loadStep4 } = await import('../src/step4.js');
 const { DATA } = await import('../src/data.js');

--- a/__tests__/step5.test.js
+++ b/__tests__/step5.test.js
@@ -9,6 +9,7 @@ const showErrorBanner = jest.fn();
 let loadStep5;
 let CharacterState;
 let fetchJsonWithRetry;
+let TOTAL_STEPS;
 
 beforeEach(async () => {
   jest.resetModules();
@@ -22,10 +23,15 @@ beforeEach(async () => {
     fetchJsonWithRetry: jest.fn(),
   }));
   jest.unstable_mockModule('../src/i18n.js', () => ({ t: (k) => k }));
-  jest.unstable_mockModule('../src/main.js', () => ({ showStep, showErrorBanner }));
+  jest.unstable_mockModule('../src/main.js', () => ({
+    showStep,
+    showErrorBanner,
+    TOTAL_STEPS: 7,
+  }));
 
   ({ loadStep5 } = await import('../src/step5.js'));
   ({ CharacterState, fetchJsonWithRetry } = await import('../src/data.js'));
+  ({ TOTAL_STEPS } = await import('../src/main.js'));
 
   document.body.innerHTML =
     '<div id="equipmentSelections"></div><button id="confirmEquipment"></button>';
@@ -47,7 +53,7 @@ describe('step5 re-entry', () => {
     const btn = document.getElementById('confirmEquipment');
     btn.click();
     expect(showStep).toHaveBeenCalledTimes(1);
-    expect(showStep).toHaveBeenCalledWith(6);
+    expect(showStep).toHaveBeenCalledWith(TOTAL_STEPS - 1);
   });
 
   test('failed fetch surfaces error and allows retry', async () => {

--- a/__tests__/step6.test.js
+++ b/__tests__/step6.test.js
@@ -8,6 +8,7 @@ const setCurrentStepComplete = jest.fn();
 jest.unstable_mockModule('../src/main.js', () => ({
   setCurrentStepComplete,
   showStep: jest.fn(),
+  TOTAL_STEPS: 7,
 }));
 
 jest.unstable_mockModule('../src/i18n.js', () => ({ t: (k) => k }));

--- a/src/main.js
+++ b/src/main.js
@@ -28,6 +28,9 @@ import { exportFoundryActor } from "./export.js";
 import { t, initI18n, applyTranslations } from "./i18n.js";
 import { exportPdf } from "./export-pdf.js";
 
+const TOTAL_STEPS = 7;
+const LAST_STEP = TOTAL_STEPS;
+
 let currentStep = 1;
 let currentStepComplete = false;
 const visitedSteps = new Set();
@@ -56,7 +59,7 @@ function invalidateStep(stepNumber) {
 }
 
 function invalidateStepsFrom(stepNumber) {
-  for (let i = stepNumber; i <= 7; i++) {
+  for (let i = stepNumber; i <= TOTAL_STEPS; i++) {
     visitedSteps.delete(i);
     completedSteps.delete(i);
   }
@@ -64,7 +67,7 @@ function invalidateStepsFrom(stepNumber) {
 }
 
 function updateNavButtons() {
-  for (let i = 1; i <= 7; i++) {
+  for (let i = 1; i <= TOTAL_STEPS; i++) {
     const btn = document.getElementById(`btnStep${i}`);
     if (!btn) continue;
     if (i === 1) {
@@ -81,7 +84,7 @@ function updateNavButtons() {
 function setCurrentStepComplete(flag) {
   currentStepComplete = flag;
   const nextBtn = document.getElementById("nextStep");
-  if (nextBtn) nextBtn.disabled = !flag || currentStep >= 7;
+  if (nextBtn) nextBtn.disabled = !flag || currentStep >= LAST_STEP;
   if (flag) {
     completedSteps.add(currentStep);
   } else {
@@ -113,7 +116,7 @@ function showStep(step) {
     const force = invalidatedSteps.has(step);
     visitedSteps.add(step);
     invalidatedSteps.delete(step);
-    for (let i = 1; i <= 7; i++) {
+    for (let i = 1; i <= TOTAL_STEPS; i++) {
       const el = document.getElementById(`step${i}`);
       if (!el) continue;
       if (i === step) {
@@ -126,7 +129,7 @@ function showStep(step) {
     }
     const bar = document.getElementById("progressBar");
     if (bar) {
-      bar.style.width = `${((step - 1) / 6) * 100}%`;
+      bar.style.width = `${((step - 1) / (TOTAL_STEPS - 1)) * 100}%`;
     }
     currentStep = step;
     if (CharacterState.showHelp) {
@@ -137,8 +140,8 @@ function showStep(step) {
     if (step === 3) loadStep3(firstVisit || force);
     if (step === 4) loadStep4(firstVisit || force);
     if (step === 5) loadStep5(firstVisit || force);
-    if (step === 6) loadStep6(firstVisit || force);
-    if (step === 7) {
+    if (step === TOTAL_STEPS - 1) loadStep6(firstVisit || force);
+    if (step === LAST_STEP) {
       commitAbilities();
       CharacterState.playerName =
         document.getElementById("userName")?.value || CharacterState.playerName;
@@ -496,7 +499,7 @@ document.addEventListener("DOMContentLoaded", async () => {
       const obj = JSON.parse(stored);
       Object.assign(CharacterState, obj);
       startAtStep7 = true;
-      currentStep = 7;
+      currentStep = LAST_STEP;
       localStorage.removeItem('characterState');
     }
   } catch (e) {
@@ -505,7 +508,7 @@ document.addEventListener("DOMContentLoaded", async () => {
 
   await initI18n();
   applyTranslations();
-  for (let i = 1; i <= 7; i++) {
+  for (let i = 1; i <= TOTAL_STEPS; i++) {
     const btn = document.getElementById(`btnStep${i}`);
     if (btn) {
       btn.addEventListener("click", () => {
@@ -514,7 +517,7 @@ document.addEventListener("DOMContentLoaded", async () => {
         if (i === 3) loadStep3(true);
         if (i === 4) loadStep4(true);
         if (i === 5) loadStep5(true);
-        if (i === 6) loadStep6(true);
+        if (i === TOTAL_STEPS - 1) loadStep6(true);
       });
     }
   }
@@ -560,7 +563,7 @@ document.addEventListener("DOMContentLoaded", async () => {
       loadStep4();
       loadStep5();
       loadStep6();
-      if (startAtStep7) showStep(7);
+      if (startAtStep7) showStep(LAST_STEP);
     })
     .catch((err) => console.error(err));
 
@@ -645,4 +648,6 @@ export {
   showErrorBanner,
   invalidateStep,
   invalidateStepsFrom,
+  TOTAL_STEPS,
+  LAST_STEP,
 };

--- a/src/step2.js
+++ b/src/step2.js
@@ -132,7 +132,7 @@ function rebuildFromClasses() {
   main.invalidateStep(3);
   main.invalidateStep(4);
   main.invalidateStep(5);
-  main.invalidateStep(6);
+  main.invalidateStep(main.TOTAL_STEPS - 1);
   main.invalidateStepsFrom(3);
 }
 
@@ -911,7 +911,7 @@ export function updateStep2Completion() {
     btnStep4.disabled =
       !complete || !CharacterState.system.details.race;
   if (progressBar) {
-    const width = (complete ? 2 : 1) / 6 * 100;
+    const width = ((complete ? 2 : 1) / (main.TOTAL_STEPS - 1)) * 100;
     progressBar.style.width = `${width}%`;
   }
   (CharacterState.classes || []).forEach((cls) => {

--- a/src/step3.js
+++ b/src/step3.js
@@ -1299,7 +1299,7 @@ function confirmRaceSelection() {
   finalize();
   main.invalidateStep(4);
   main.invalidateStep(5);
-  main.invalidateStep(6);
+  main.invalidateStep(main.TOTAL_STEPS - 1);
   main.invalidateStepsFrom(4);
   return true;
 }
@@ -1342,7 +1342,7 @@ export async function loadStep3(force = false) {
         rebuildFromClasses();
         main.invalidateStep(4);
         main.invalidateStep(5);
-        main.invalidateStep(6);
+        main.invalidateStep(main.TOTAL_STEPS - 1);
         main.invalidateStepsFrom(4);
       }
       const traits = document.getElementById('raceTraits');

--- a/src/step4.js
+++ b/src/step4.js
@@ -423,7 +423,7 @@ async function confirmBackgroundSelection() {
 
   finalize();
   main.invalidateStep(5);
-  main.invalidateStep(6);
+  main.invalidateStep(main.TOTAL_STEPS - 1);
   main.invalidateStepsFrom(5);
   return true;
 }
@@ -467,7 +467,7 @@ export function loadStep4(force = false) {
       }
       renderBackgroundList(search?.value);
       main.invalidateStep(5);
-      main.invalidateStep(6);
+      main.invalidateStep(main.TOTAL_STEPS - 1);
       main.invalidateStepsFrom(5);
     });
   }

--- a/src/step5.js
+++ b/src/step5.js
@@ -274,7 +274,7 @@ function confirmEquipment() {
     });
   });
   CharacterState.equipment = selections;
-  main.showStep(6);
+  main.showStep(main.TOTAL_STEPS - 1);
 }
 
 export async function loadStep5(force = false) {

--- a/src/step6.js
+++ b/src/step6.js
@@ -117,7 +117,7 @@ export function commitAbilities() {
 
 function confirmAbilities() {
   commitAbilities();
-  main.showStep?.(7);
+  main.showStep?.(main.TOTAL_STEPS);
 }
 
 export function loadStep6(force = false) {


### PR DESCRIPTION
## Summary
- centralize total step count with `TOTAL_STEPS` and `LAST_STEP` constants
- replace magic numbers for navigation and progress calculations
- align tests with step count constants

## Testing
- `npm test` *(fails: Race validation failed)*

------
https://chatgpt.com/codex/tasks/task_e_68b98ad61f24832e943e4ee19c063d0d