### PR TITLE
Always show background descriptions

### DIFF
--- a/__tests__/step4.test.js
+++ b/__tests__/step4.test.js
@@ -36,10 +36,12 @@ jest.unstable_mockModule('../src/i18n.js', () => ({ t: (k) => k }));
 jest.unstable_mockModule('../src/main.js', () => ({
   showStep: jest.fn(),
   TOTAL_STEPS: 7,
+  invalidateStep: jest.fn(),
+  invalidateStepsFrom: jest.fn(),
 }));
 
 const { loadStep4 } = await import('../src/step4.js');
-const { DATA } = await import('../src/data.js');
+const { DATA, CharacterState } = await import('../src/data.js');
 
 describe('change background button', () => {
   beforeEach(() => {
@@ -90,7 +92,8 @@ describe('renderBackgroundList description and details', () => {
     };
   });
 
-  test('shows description and toggles details', () => {
+  test('shows description and details even when help is hidden', () => {
+    CharacterState.showHelp = false;
     loadStep4();
     const card = document.querySelector('#backgroundList .class-card');
     const desc = card.querySelector('p');
@@ -100,6 +103,43 @@ describe('renderBackgroundList description and details', () => {
     detailsBtn.click();
     const detailsDiv = card.querySelector('.race-details');
     expect(detailsDiv.classList.contains('hidden')).toBe(false);
+    expect(detailsDiv.textContent).toContain('skills: Insight');
+  });
+});
+
+describe('selectBackground feature descriptions', () => {
+  beforeEach(() => {
+    document.body.innerHTML = `
+      <input id="backgroundSearch" />
+      <div id="backgroundList"></div>
+      <button id="confirmBackgroundSelection"></button>
+      <button id="changeBackground" class="hidden"></button>
+    `;
+    DATA.backgrounds = {
+      Acolyte: {
+        name: 'Acolyte',
+        description: 'Devout servant',
+        skills: ['Insight'],
+        languages: [],
+        featOptions: [],
+        skillChoices: { choose: 1, options: ['Arcana'] },
+        entries: [
+          { name: 'Skill Proficiencies', description: 'Choose a skill description', entries: [] }
+        ]
+      },
+    };
+  });
+
+  test('shows details and feature descriptions without help', () => {
+    CharacterState.showHelp = false;
+    loadStep4();
+    const card = document.querySelector('#backgroundList .class-card');
+    card.click();
+    const detailsAcc = document.querySelector('#backgroundFeatures .accordion-item .accordion-content');
+    expect(detailsAcc.textContent).toContain('skills: Insight');
+    const skillAcc = document.querySelectorAll('#backgroundFeatures .accordion-item')[1];
+    const skillDesc = skillAcc.querySelector('p');
+    expect(skillDesc.textContent).toBe('Choose a skill description');
   });
 });
 

--- a/src/step4.js
+++ b/src/step4.js
@@ -52,29 +52,25 @@ export function renderBackgroundList(query = '') {
   for (const [name, bg] of Object.entries(entries)) {
     if (!name.toLowerCase().includes(term)) continue;
     const details = [];
-    if (CharacterState.showHelp) {
-      if (bg.skills && bg.skills.length)
-        details.push(createElement('p', `${t('skills')}: ${bg.skills.join(', ')}`));
-      if (Array.isArray(bg.tools) && bg.tools.length)
-        details.push(createElement('p', `${t('tools')}: ${bg.tools.join(', ')}`));
-      if (Array.isArray(bg.languages) && bg.languages.length)
-        details.push(
-          createElement('p', `${t('languages')}: ${bg.languages.join(', ')}`)
-        );
-      if (bg.featOptions && bg.featOptions.length)
-        details.push(
-          createElement(
-            'p',
-            `${t('featOptions')}: ${bg.featOptions.join(', ')}`
-          )
-        );
-    }
+    if (bg.skills && bg.skills.length)
+      details.push(createElement('p', `${t('skills')}: ${bg.skills.join(', ')}`));
+    if (Array.isArray(bg.tools) && bg.tools.length)
+      details.push(createElement('p', `${t('tools')}: ${bg.tools.join(', ')}`));
+    if (Array.isArray(bg.languages) && bg.languages.length)
+      details.push(
+        createElement('p', `${t('languages')}: ${bg.languages.join(', ')}`)
+      );
+    if (bg.featOptions && bg.featOptions.length)
+      details.push(
+        createElement(
+          'p',
+          `${t('featOptions')}: ${bg.featOptions.join(', ')}`
+        )
+      );
     const card = createSelectableCard(
       name,
-      CharacterState.showHelp
-        ? bg.short || bg.description || bg.summary || bg.desc || ''
-        : '',
-      CharacterState.showHelp ? details : [],
+      bg.short || bg.description || bg.summary || bg.desc || '',
+      details,
       () => selectBackground(bg),
       t('details')
     );
@@ -106,36 +102,34 @@ function selectBackground(bg) {
 
   // Details summary
   const details = document.createElement('div');
-  if (CharacterState.showHelp) {
-    if (currentBackgroundData.skills && currentBackgroundData.skills.length)
-      details.appendChild(
-        createElement(
-          'p',
-          `${t('skills')}: ${currentBackgroundData.skills.join(', ')}`
-        )
-      );
-    if (Array.isArray(currentBackgroundData.tools) && currentBackgroundData.tools.length)
-      details.appendChild(
-        createElement(
-          'p',
-          `${t('tools')}: ${currentBackgroundData.tools.join(', ')}`
-        )
-      );
-    if (Array.isArray(currentBackgroundData.languages) && currentBackgroundData.languages.length)
-      details.appendChild(
-        createElement(
-          'p',
-          `${t('languages')}: ${currentBackgroundData.languages.join(', ')}`
-        )
-      );
-    if (currentBackgroundData.featOptions && currentBackgroundData.featOptions.length)
-      details.appendChild(
-        createElement(
-          'p',
-          `${t('featOptions')}: ${currentBackgroundData.featOptions.join(', ')}`
-        )
-      );
-  }
+  if (currentBackgroundData.skills && currentBackgroundData.skills.length)
+    details.appendChild(
+      createElement(
+        'p',
+        `${t('skills')}: ${currentBackgroundData.skills.join(', ')}`
+      )
+    );
+  if (Array.isArray(currentBackgroundData.tools) && currentBackgroundData.tools.length)
+    details.appendChild(
+      createElement(
+        'p',
+        `${t('tools')}: ${currentBackgroundData.tools.join(', ')}`
+      )
+    );
+  if (Array.isArray(currentBackgroundData.languages) && currentBackgroundData.languages.length)
+    details.appendChild(
+      createElement(
+        'p',
+        `${t('languages')}: ${currentBackgroundData.languages.join(', ')}`
+      )
+    );
+  if (currentBackgroundData.featOptions && currentBackgroundData.featOptions.length)
+    details.appendChild(
+      createElement(
+        'p',
+        `${t('featOptions')}: ${currentBackgroundData.featOptions.join(', ')}`
+      )
+    );
   features.appendChild(createAccordionItem(t('details'), details));
 
   // Choices --------------------------------------------------
@@ -144,7 +138,7 @@ function selectBackground(bg) {
       e => e.name && e.name.toLowerCase().includes(key)
     );
     if (entry) {
-      if (CharacterState.showHelp && entry.description)
+      if (entry.description)
         wrapper.appendChild(createElement('p', entry.description));
       appendEntries(wrapper, entry.entries);
     }


### PR DESCRIPTION
## Summary
- Always display background card descriptions and details regardless of the showHelp flag
- Include feature details in background selection summaries and choice descriptions
- Add tests to ensure descriptions render even when help is disabled

## Testing
- `npm test -- __tests__/step4.test.js` *(fails: Race validation failed)*
- `node --experimental-vm-modules ./node_modules/jest/bin/jest.js __tests__/step4.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68c5a5798358832eb61ec09bb6667f65