### PR TITLE
Add infusion support and export handling

### DIFF
--- a/__tests__/export.test.js
+++ b/__tests__/export.test.js
@@ -108,4 +108,33 @@ describe("exportFoundryActor", () => {
     expect(exported.flags.fcc.skills).toEqual(["Stealth"]);
     expect(exported.flags.fcc.feats).toEqual(["Alert", "Lucky"]);
   });
+
+  test("exports infusions in flags and items", () => {
+    const state = {
+      playerName: "Bob",
+      name: "Tester",
+      type: "character",
+      infusions: ["Enhanced Defense"],
+      system: {
+        abilities: {},
+        tools: [],
+        skills: [],
+        attributes: {},
+        spells: {},
+        traits: { languages: { value: [] } },
+        details: {},
+      },
+      baseAbilities: {},
+      bonusAbilities: {},
+      prototypeToken: {},
+    };
+
+    const exported = exportFoundryActor(state);
+    expect(exported.flags.fcc.infusions).toEqual(["Enhanced Defense"]);
+    expect(
+      exported.items.find(
+        (i) => i.name === "Enhanced Defense" && i.type === "feat"
+      )
+    ).toBeTruthy();
+  });
 });

--- a/data/infusions/enhanceddefense.json
+++ b/data/infusions/enhanceddefense.json
@@ -1,0 +1,4 @@
+{
+  "name": "Enhanced Defense",
+  "description": "+1 bonus to AC."
+}

--- a/data/infusions/enhancedweapon.json
+++ b/data/infusions/enhancedweapon.json
@@ -1,0 +1,4 @@
+{
+  "name": "Enhanced Weapon",
+  "description": "+1 bonus to attack and damage rolls."
+}

--- a/src/data.js
+++ b/src/data.js
@@ -87,11 +87,10 @@ export async function loadFeats() {
 }
 
 /**
- * Fetches artificer infusions if not already loaded.
+ * Fetches artificer infusion names if not already loaded.
  */
 export async function loadInfusions() {
-  if (Array.isArray(DATA.infusions) && DATA.infusions.length)
-    return DATA.infusions;
+  if (Array.isArray(DATA.infusions) && DATA.infusions.length) return;
   const json = await fetchJsonWithRetry('data/infusions.json', 'infusions');
   DATA.infusions = json.infusions || [];
   return DATA.infusions;
@@ -99,6 +98,8 @@ export async function loadInfusions() {
 
 // Cache for individual feat details keyed by feat name
 DATA.featDetails = DATA.featDetails || {};
+// Cache for individual infusion details keyed by infusion name
+DATA.infusionDetails = DATA.infusionDetails || {};
 
 /**
  * Fetches detailed data for a single feat by name and caches the result.
@@ -114,6 +115,22 @@ export async function loadFeatDetails(name) {
   const feat = await fetchJsonWithRetry(path, `feat ${name}`);
   DATA.featDetails[name] = feat;
   return feat;
+}
+
+/**
+ * Fetches detailed data for a single infusion by name and caches the result.
+ * The infusion JSON files are stored under `data/infusions/<slug>.json` where
+ * the slug is the lowercase name stripped of non-alphanumeric characters.
+ * @param {string} name - The infusion name
+ * @returns {Promise<Object>} The infusion detail object
+ */
+export async function loadInfusionDetails(name) {
+  if (DATA.infusionDetails[name]) return DATA.infusionDetails[name];
+  const slug = name.toLowerCase().replace(/[^a-z0-9]+/g, '');
+  const path = `data/infusions/${slug}.json`;
+  const infusion = await fetchJsonWithRetry(path, `infusion ${name}`);
+  DATA.infusionDetails[name] = infusion;
+  return infusion;
 }
 
 /**
@@ -194,6 +211,7 @@ export const CharacterState = {
   type: "character",
   classes: [],
   feats: [],
+  infusions: [],
   equipment: [],
   knownSpells: {},
   showHelp: false,

--- a/src/export.js
+++ b/src/export.js
@@ -159,6 +159,9 @@ export function exportFoundryActor(state) {
         tools: clone(state.system.tools || []),
         skills: clone(state.system.skills || []),
         feats: clone((state.feats || []).map((f) => f.name || f)),
+        ...(state.infusions && state.infusions.length
+          ? { infusions: clone((state.infusions || []).map((i) => i.name || i)) }
+          : {}),
       },
     },
   };
@@ -193,6 +196,12 @@ export function exportFoundryActor(state) {
   (state.feats || []).forEach((feat) => {
     const name = typeof feat === "string" ? feat : feat.name;
     const system = typeof feat === "string" ? {} : feat.system || {};
+    actor.items.push({ name, type: "feat", system });
+  });
+
+  (state.infusions || []).forEach((inf) => {
+    const name = typeof inf === "string" ? inf : inf.name;
+    const system = typeof inf === "string" ? {} : inf.system || {};
     actor.items.push({ name, type: "feat", system });
   });
 

--- a/src/main.js
+++ b/src/main.js
@@ -272,6 +272,7 @@ function renderCharacterSheet() {
       toolSources[t] ? `${t} (${toolSources[t]})` : t
     ),
     equipment: (CharacterState.equipment || []).map((e) => e.name),
+    infusions: (CharacterState.infusions || []).slice(),
     features: (() => {
       const classFeatures = (CharacterState.classes || []).flatMap(
         (c) =>
@@ -389,6 +390,20 @@ function renderCharacterSheet() {
   );
   featuresSection.appendChild(featuresList);
   container.appendChild(featuresSection);
+
+  const infusionsSection = document.createElement("section");
+  infusionsSection.className = "infusions";
+  if (summary.infusions.length) {
+    infusionsSection.appendChild(document.createElement("h3")).textContent =
+      "Infusions";
+    const infList = document.createElement("ul");
+    summary.infusions.forEach(
+      (i) =>
+        (infList.appendChild(document.createElement("li")).textContent = i)
+    );
+    infusionsSection.appendChild(infList);
+  }
+  container.appendChild(infusionsSection);
 
   const equipmentSection = document.createElement("section");
   equipmentSection.className = "equipment";

--- a/src/step2.js
+++ b/src/step2.js
@@ -47,6 +47,7 @@ const baseState = {
   languages: [],
   cantrips: [],
   feats: [],
+  infusions: [],
   abilities: {},
   expertise: [],
 };
@@ -60,6 +61,9 @@ function refreshBaseState() {
     : [];
   baseState.feats = Array.isArray(CharacterState.feats)
     ? CharacterState.feats.map(f => ({ ...f }))
+    : [];
+  baseState.infusions = Array.isArray(CharacterState.infusions)
+    ? [...CharacterState.infusions]
     : [];
   baseState.expertise = Array.isArray(CharacterState.system.expertise)
     ? [...CharacterState.system.expertise]
@@ -76,6 +80,7 @@ function rebuildFromClasses() {
   const languages = new Set(baseState.languages);
   const cantrips = new Set(baseState.cantrips);
   const feats = new Map();
+  const infusions = new Set(baseState.infusions);
   const expertise = new Set(baseState.expertise);
   baseState.feats.forEach(f => feats.set(f.name, { ...f }));
   CharacterState.bonusAbilities = {};
@@ -96,6 +101,7 @@ function rebuildFromClasses() {
           else if (e.type === 'tools') tools.add(e.option);
           else if (e.type === 'languages') languages.add(e.option);
           else if (e.type === 'cantrips') cantrips.add(e.option);
+          else if (e.type === 'infusion') infusions.add(e.option);
           if (e.feat) {
             if (!feats.has(e.feat)) feats.set(e.feat, { name: e.feat });
           }
@@ -124,6 +130,7 @@ function rebuildFromClasses() {
   CharacterState.system.spells.cantrips = Array.from(cantrips);
   CharacterState.system.expertise = Array.from(expertise);
   CharacterState.feats = Array.from(feats.values());
+  CharacterState.infusions = Array.from(infusions);
   for (const [ab, base] of Object.entries(baseState.abilities)) {
     CharacterState.system.abilities[ab].value =
       base + (CharacterState.bonusAbilities[ab] || 0);


### PR DESCRIPTION
## Summary
- Add `infusions` to character state and data loaders
- Include infusions in rebuild logic, character sheet rendering, and exports
- Provide infusion metadata and tests for export handling

## Testing
- `npm test` *(fails: altered.json missing selection metadata; Race validation failed)*
- `node --experimental-vm-modules ./node_modules/jest/bin/jest.js __tests__/export.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68c5b60a3ca4832e8316391833820959