### PR TITLE
feat: support infusion details in character creation

### DIFF
--- a/src/export.js
+++ b/src/export.js
@@ -200,9 +200,13 @@ export function exportFoundryActor(state) {
   });
 
   (state.infusions || []).forEach((inf) => {
-    const name = typeof inf === "string" ? inf : inf.name;
-    const system = typeof inf === "string" ? {} : inf.system || {};
-    actor.items.push({ name, type: "feat", system });
+    const name = typeof inf === 'string' ? inf : inf.name;
+    const description = typeof inf === 'string' ? '' : inf.description || '';
+    const system = typeof inf === 'string' ? {} : clone(inf.system || {});
+    if (description && !system.description) {
+      system.description = { value: description };
+    }
+    actor.items.push({ name, type: 'feat', system });
   });
 
   (state.equipment || []).forEach((item) => {

--- a/src/infusion.js
+++ b/src/infusion.js
@@ -1,0 +1,76 @@
+import { CharacterState, loadInfusionDetails } from './data.js';
+import { t } from './i18n.js';
+import { createElement, appendEntries } from './ui-helpers.js';
+
+export function renderInfusion(name, existing = {}) {
+  const container = document.createElement('div');
+  container.className = 'infusion-card';
+
+  const state = {
+    name,
+    description: existing.description || '',
+    options: { ...(existing.options || {}) },
+  };
+
+  const optionSelects = [];
+
+  loadInfusionDetails(name)
+    .then(inf => {
+      state.description = inf.description || '';
+      if (inf.description) {
+        container.appendChild(createElement('p', inf.description));
+      }
+      appendEntries(container, inf.entries);
+      if (inf.prerequisites) {
+        const prereq = Array.isArray(inf.prerequisites)
+          ? inf.prerequisites.join(', ')
+          : inf.prerequisites;
+        container.appendChild(
+          createElement('p', `${t('prerequisite') || 'Prerequisite'}: ${prereq}`)
+        );
+      }
+      if (inf.options) {
+        Object.entries(inf.options).forEach(([key, opts]) => {
+          const sel = document.createElement('select');
+          sel.dataset.option = key;
+          sel.replaceChildren(new Option(t('select'), ''));
+          opts.forEach(opt => {
+            const o = document.createElement('option');
+            o.value = opt;
+            o.textContent = opt;
+            sel.appendChild(o);
+          });
+          if (state.options[key]) sel.value = state.options[key];
+          sel.addEventListener('change', () => {
+            state.options[key] = sel.value;
+            updateState();
+          });
+          container.appendChild(sel);
+          optionSelects.push(sel);
+        });
+      }
+      updateState();
+      renderer.isComplete = () => optionSelects.every(sel => !sel.options.length || sel.value);
+    })
+    .catch(err => {
+      console.error('Failed to load infusion', name, err);
+    });
+
+  function updateState() {
+    CharacterState.infusions = CharacterState.infusions || [];
+    const idx = CharacterState.infusions.findIndex(i => i.name === state.name);
+    const obj = {
+      name: state.name,
+      description: state.description,
+      options: { ...state.options },
+    };
+    if (idx >= 0) CharacterState.infusions[idx] = obj;
+    else CharacterState.infusions.push(obj);
+  }
+
+  const renderer = {
+    element: container,
+    isComplete: () => optionSelects.every(sel => !sel.options.length || sel.value),
+  };
+  return renderer;
+}

--- a/src/main.js
+++ b/src/main.js
@@ -272,7 +272,9 @@ function renderCharacterSheet() {
       toolSources[t] ? `${t} (${toolSources[t]})` : t
     ),
     equipment: (CharacterState.equipment || []).map((e) => e.name),
-    infusions: (CharacterState.infusions || []).slice(),
+    infusions: (CharacterState.infusions || []).map((i) =>
+      typeof i === 'string' ? { name: i, description: '' } : i
+    ),
     features: (() => {
       const classFeatures = (CharacterState.classes || []).flatMap(
         (c) =>
@@ -397,10 +399,14 @@ function renderCharacterSheet() {
     infusionsSection.appendChild(document.createElement("h3")).textContent =
       "Infusions";
     const infList = document.createElement("ul");
-    summary.infusions.forEach(
-      (i) =>
-        (infList.appendChild(document.createElement("li")).textContent = i)
-    );
+    summary.infusions.forEach((i) => {
+      const li = document.createElement('li');
+      const strong = document.createElement('strong');
+      strong.textContent = i.name;
+      li.appendChild(strong);
+      if (i.description) li.append(`: ${i.description}`);
+      infList.appendChild(li);
+    });
     infusionsSection.appendChild(infList);
   }
   container.appendChild(infusionsSection);


### PR DESCRIPTION
## Summary
- render artificer infusions with descriptions and selectable options
- track infusion selections during class building and show them in summary/export
- include infusion descriptions when exporting a Foundry actor

## Testing
- `npm test` *(fails: altered.json missing selection metadata for: size)*

------
https://chatgpt.com/codex/tasks/task_e_68c5ba569db4832e87f1fea58a480d3f