### PR TITLE
Add subclass feature selections and optional Barbarian Primal Knowledge

### DIFF
--- a/__tests__/step2.test.js
+++ b/__tests__/step2.test.js
@@ -203,3 +203,28 @@ describe('feature descriptions', () => {
     );
   });
 });
+
+describe('optional class choices', () => {
+  test('unselected optional choices do not block completion', () => {
+    const __dirname = path.dirname(fileURLToPath(import.meta.url));
+    const barbarianData = JSON.parse(
+      readFileSync(path.join(__dirname, '../data/classes/barbarian.json'), 'utf8')
+    );
+    const prevClasses = DATA.classes;
+    DATA.classes = [barbarianData];
+    CharacterState.classes = [
+      {
+        name: 'Barbarian',
+        level: 10,
+        skills: ['Athletics', 'Survival'],
+        choiceSelections: {},
+        expertise: [],
+        subclass: 'Berserker',
+      },
+    ];
+    const complete = Step2.isStepComplete();
+    expect(complete).toBe(true);
+    DATA.classes = prevClasses;
+    CharacterState.classes = [];
+  });
+});

--- a/data/classes/barbarian.json
+++ b/data/classes/barbarian.json
@@ -265,6 +265,7 @@
       "description": "Gain proficiency in one skill from the barbarian list",
       "count": 1,
       "type": "skills",
+      "optional": true,
       "selection": [
         "Animal Handling",
         "Athletics",
@@ -296,6 +297,22 @@
         "Increase one ability score by 2",
         "Increase two ability scores by 1",
         "Feat"
+      ]
+    },
+    {
+      "level": 10,
+      "name": "Primal Knowledge",
+      "description": "Gain proficiency in one skill from the barbarian list",
+      "count": 1,
+      "type": "skills",
+      "optional": true,
+      "selection": [
+        "Animal Handling",
+        "Athletics",
+        "Intimidation",
+        "Nature",
+        "Perception",
+        "Survival"
       ]
     },
     {

--- a/data/subclasses/armorer.json
+++ b/data/subclasses/armorer.json
@@ -39,4 +39,15 @@
       }
     ]
   }
+  ,
+  "choices": [
+    {
+      "level": 3,
+      "name": "Armor Model",
+      "description": "Choose a model for your Arcane Armor",
+      "count": 1,
+      "type": "Armor Model",
+      "selection": ["Guardian", "Infiltrator"]
+    }
+  ]
 }

--- a/data/subclasses/beast.json
+++ b/data/subclasses/beast.json
@@ -27,4 +27,16 @@
       }
     ]
   }
+  ,
+  "choices": [
+    {
+      "level": 6,
+      "name": "Bestial Soul",
+      "description": "Choose a Bestial Soul adaptation",
+      "count": 1,
+      "type": "Bestial Soul",
+      "selection": ["Swimming", "Climbing", "Jumping"],
+      "optional": true
+    }
+  ]
 }

--- a/data/subclasses/storm_herald.json
+++ b/data/subclasses/storm_herald.json
@@ -27,4 +27,15 @@
       }
     ]
   }
+  ,
+  "choices": [
+    {
+      "level": 3,
+      "name": "Storm Aura",
+      "description": "Choose an environment for your Storm Aura",
+      "count": 1,
+      "type": "Storm Aura",
+      "selection": ["Desert", "Sea", "Tundra"]
+    }
+  ]
 }

--- a/data/subclasses/zealot.json
+++ b/data/subclasses/zealot.json
@@ -31,4 +31,15 @@
       }
     ]
   }
+  ,
+  "choices": [
+    {
+      "level": 3,
+      "name": "Divine Fury",
+      "description": "Choose necrotic or radiant damage for Divine Fury",
+      "count": 1,
+      "type": "damage type",
+      "selection": ["Necrotic", "Radiant"]
+    }
+  ]
 }

--- a/src/step2.js
+++ b/src/step2.js
@@ -276,7 +276,9 @@ function compileClassFeatures(cls) {
   }
   if (cls.choiceSelections) {
     for (const [name, entries] of Object.entries(cls.choiceSelections)) {
-      const choiceDef = (data.choices || []).find(c => c.name === name);
+      const choiceDef =
+        (data.choices || []).find(c => c.name === name) ||
+        (cls.subclassData?.choices || []).find(c => c.name === name);
       entries.forEach(e => {
         if (choiceDef?.type === 'infusion') {
           cls.features.push({
@@ -921,9 +923,12 @@ function classHasPendingChoices(cls) {
     return true;
   }
 
-  const choices = (clsDef.choices || []).filter(c => c.level <= (cls.level || 1));
+  const choices = [
+    ...(clsDef.choices || []),
+    ...(cls.subclassData?.choices || []),
+  ].filter(c => c.level <= (cls.level || 1));
   for (const choice of choices) {
-    const needed = choice.count || 1;
+    const needed = choice.optional ? 0 : (choice.count || 1);
     const isExpertise = choice.name === 'Expertise' || choice.requiresProficiency;
     if (isExpertise) {
       const selections = (cls.expertise || []).filter(e => e.level === choice.level);


### PR DESCRIPTION
## Summary
- allow Barbarians to optionally choose Primal Knowledge at levels 3 and 10
- add Armor Model, Storm Aura, Bestial Soul, and Divine Fury choices for relevant subclasses
- support optional and subclass choices in step 2 with test coverage

## Testing
- `npm test` *(fails: Race validation failed)*
- `node --experimental-vm-modules ./node_modules/jest/bin/jest.js` *(fails: missing html2canvas module)*

------
https://chatgpt.com/codex/tasks/task_e_68c5c1652de4832ebd1fe241cfc8176b