### PR TITLE
Ensure class removal reopens selection list

### DIFF
--- a/src/step2.js
+++ b/src/step2.js
@@ -830,6 +830,10 @@ function removeClass(index) {
     delete (CharacterState.knownSpells || {})[removed.name];
   }
   rebuildFromClasses();
+  if (!classes.length) {
+    loadStep2(false);
+    return;
+  }
   renderSelectedClasses();
   updateStep2Completion();
 }


### PR DESCRIPTION
## Summary
- trigger the existing step-2 rendering flow after a class removal when none remain so the selection UI is restored

## Testing
- npm test -- --watch=false *(fails: Race validation failed — missing selection metadata for several races)*

------
https://chatgpt.com/codex/tasks/task_e_68cb039930fc832e8dea4ba5a91b93f9