### PR TITLE
Add Spelljammer race data and standardize size selection

### DIFF
--- a/data/races.json
+++ b/data/races.json
@@ -5,6 +5,8 @@
         "Aasimar (Protector)": "data/races/aasimarprotector.json",
         "Aasimar (Scourge)": "data/races/aasimarscourge.json",
         "Altered": "data/races/altered.json",
+        "Astral Elf": "data/races/astralelf.json",
+        "Autognome": "data/races/autognome.json",
         "Bugbear": "data/races/bugbear.json",
         "Centaur": "data/races/centaur.json",
         "Changeling": "data/races/changeling.json",
@@ -28,6 +30,7 @@
         "Genasi (Earth)": "data/races/genasiearth.json",
         "Genasi (Fire)": "data/races/genasifire.json",
         "Genasi (Water)": "data/races/genasiwater.json",
+        "Giff": "data/races/giff.json",
         "Githyanki": "data/races/githyanki.json",
         "Githzerai": "data/races/githzerai.json",
         "Gnome (Deep)": "data/races/gnomedeep.json",
@@ -35,6 +38,7 @@
         "Gnome (Rock)": "data/races/gnomerock.json",
         "Goblin": "data/races/goblin.json",
         "Goliath": "data/races/goliath.json",
+        "Hadozee": "data/races/hadozee.json",
         "Half-Elf (Acquatic)": "data/races/halfelfacquatic.json",
         "Half-Elf (Drow)": "data/races/halfelfdrow.json",
         "Half-Elf (Moon/Sun)": "data/races/halfelfmoonsun.json",
@@ -56,6 +60,8 @@
         "Leonin": "data/races/leonin.json",
         "Lizardfolk": "data/races/lizardfolk.json",
         "Locathah": "data/races/locathah.json",
-        "Loxodon": "data/races/loxodon.json"
+        "Loxodon": "data/races/loxodon.json",
+        "Plasmoid": "data/races/plasmoid.json",
+        "Thri-kreen": "data/races/thrikreen.json"
     }
 }

--- a/data/races/altered.json
+++ b/data/races/altered.json
@@ -1,118 +1,159 @@
 {
-  "name": "Altered",
-  "raceName": "Altered",
-  "source": "HB",
-  "size": ["S", "M"],
-  "speed": 30,
-  "ability": [
-    {
-      "choose": {
-        "weighted": {
-          "from": ["str", "dex", "con", "int", "wis", "cha"],
-          "weights": [2, 1]
-        }
-      }
-    },
-    {
-      "choose": {
-        "weighted": {
-          "from": ["str", "dex", "con", "int", "wis", "cha"],
-          "weights": [1, 1, 1]
-        }
-      }
-    }
-  ],
-  "skillProficiencies": [
-    { "any": 1 }
-  ],
-  "languageProficiencies": [
-    { "common": true, "anyStandard": 1 }
-  ],
-  "minorAlterations": {
-    "allowed": [3, 2],
-    "options": [
-      "Aquatic Adaptation",
-      "Altered Metabolism",
-      "Darkvision",
-      "Fleet of Foot",
-      "Glider",
-      "Natural Weapon",
-      "Nimble Climber",
-      "Mutated Eyes",
-      "Silent Speech",
-      "Skilled",
-      "Strong-Minded",
-      "Supernatural Resistance"
-    ]
-  },
-  "majorAlterations": {
-    "allowed": [0, 1],
-    "options": [
-      "Amorphous",
-      "Augmented Toughness",
-      "Blind Sense",
-      "Magical Affinity",
-      "Massive Build",
-      "Painful Regeneration",
-      "Secondary Arms",
-      "Shapechanger",
-      "Unnatural Armor"
-    ]
-  },
-  "entries": [
-    {
-      "name": "Size",
-      "type": "entries",
-      "entries": [
-        "You are Medium or Small. You choose the size when you select this race."
-      ]
-    },
-    {
-      "name": "Alterations",
-      "type": "entries",
-      "entries": [
-        "You gain three Minor Alterations or two Minor and one Major Alteration.",
-        "{@bold Minor Alterations}",
-        {
-          "type": "list",
-          "items": [
-            "Aquatic Adaptation. You can breathe air and water, and you gain a swim speed equal to your walking speed.",
-            "Altered Metabolism. You don’t need to eat, drink, or breathe. You have advantage on saving throws against diseases and being poisoned, and you have resistance to poison damage. When you take a long rest, you must remain motionless for at least six hours but stay conscious.",
-            "Darkvision. You can see in dim light within 60 feet of you as if it were bright light and in darkness as if it were dim light.",
-            "Fleet of Foot. Your base walking speed increases to 35 feet.",
-            "Glider. When you fall and are not incapacitated, reduce any fall distance by up to 100 feet and move horizontally 2 feet for every foot you fall.",
-            "Natural Weapon. You have a natural weapon for unarmed strikes dealing 1d6 bludgeoning, piercing, or slashing damage (chosen when you select this race) and you may use Dexterity for attack and damage rolls.",
-            "Nimble Climber. You have a climb speed equal to your walking speed.",
-            "Mutated Eyes. You have advantage on Wisdom (Perception) checks that rely on sight.",
-            "Silent Speech. You can speak telepathically to a creature within 30 feet that shares a language with you.",
-            "Skilled. You gain proficiency in one skill of your choice.",
-            "Strong-Minded. You have advantage on saving throws against being charmed or frightened.",
-            "Supernatural Resistance. You gain resistance to one damage type of your choice: acid, cold, fire, force, lightning, necrotic, psychic, radiant, or thunder."
-          ]
-        },
-        "{@bold Major Alterations}",
-        {
-          "type": "list",
-          "items": [
-            "Amorphous. You can squeeze through a space as narrow as 1 inch if you are carrying or wearing nothing, and you have advantage on checks and saves to escape a grapple or restraint.",
-            "Augmented Toughness. Your hit point maximum increases by 1, and it increases by 1 again whenever you gain a level.",
-            "Blind Sense. You have blindsight out to 30 feet and are blind beyond that distance; you have advantage on Perception checks that rely on hearing or smell.",
-            "Magical Affinity. You know one cantrip of your choice from any class spell list. Intelligence, Wisdom, or Charisma (chosen when you select this race) is your spellcasting ability.",
-            "Massive Build. You have advantage on Strength checks and saving throws and count as one size larger for carrying capacity and the weight you can push, drag, or lift.",
-            "Painful Regeneration. When you start your turn at half hit points or fewer, you may roll a d3 to regain that many hit points and take a penalty equal to the roll on attack rolls, ability checks, and saving throws until the start of your next turn.",
-            "Secondary Arms. You have two smaller secondary arms that can manipulate objects or wield a light weapon.",
-            "Shapechanger. As an action, you can change your appearance and voice as described in the trait, remaining in the new form until you revert or die.",
-            "Unnatural Armor. While not wearing heavy armor, you gain a +1 bonus to AC."
-          ]
-        }
-      ]
-    },
-    {
-      "name": "Languages",
-      "type": "entries",
-      "entries": [
-        "You can speak, read, and write Common and one extra language of your choice."
-      ]
-    }
-  ]
+	"name": "Altered",
+	"raceName": "Altered",
+	"source": "HB",
+	"size": [
+		{
+			"choose": {
+				"from": [
+					"S",
+					"M"
+				]
+			}
+		}
+	],
+	"speed": 30,
+	"ability": [
+		{
+			"choose": {
+				"weighted": {
+					"from": [
+						"str",
+						"dex",
+						"con",
+						"int",
+						"wis",
+						"cha"
+					],
+					"weights": [
+						2,
+						1
+					]
+				}
+			}
+		},
+		{
+			"choose": {
+				"weighted": {
+					"from": [
+						"str",
+						"dex",
+						"con",
+						"int",
+						"wis",
+						"cha"
+					],
+					"weights": [
+						1,
+						1,
+						1
+					]
+				}
+			}
+		}
+	],
+	"skillProficiencies": [
+		{
+			"any": 1
+		}
+	],
+	"languageProficiencies": [
+		{
+			"common": true,
+			"anyStandard": 1
+		}
+	],
+	"minorAlterations": {
+		"allowed": [
+			3,
+			2
+		],
+		"options": [
+			"Aquatic Adaptation",
+			"Altered Metabolism",
+			"Darkvision",
+			"Fleet of Foot",
+			"Glider",
+			"Natural Weapon",
+			"Nimble Climber",
+			"Mutated Eyes",
+			"Silent Speech",
+			"Skilled",
+			"Strong-Minded",
+			"Supernatural Resistance"
+		]
+	},
+	"majorAlterations": {
+		"allowed": [
+			0,
+			1
+		],
+		"options": [
+			"Amorphous",
+			"Augmented Toughness",
+			"Blind Sense",
+			"Magical Affinity",
+			"Massive Build",
+			"Painful Regeneration",
+			"Secondary Arms",
+			"Shapechanger",
+			"Unnatural Armor"
+		]
+	},
+	"entries": [
+		{
+			"name": "Size",
+			"type": "entries",
+			"entries": [
+				"You are Medium or Small. You choose the size when you select this race."
+			]
+		},
+		{
+			"name": "Alterations",
+			"type": "entries",
+			"entries": [
+				"You gain three Minor Alterations or two Minor and one Major Alteration.",
+				"{@bold Minor Alterations}",
+				{
+					"type": "list",
+					"items": [
+						"Aquatic Adaptation. You can breathe air and water, and you gain a swim speed equal to your walking speed.",
+						"Altered Metabolism. You don’t need to eat, drink, or breathe. You have advantage on saving throws against diseases and being poisoned, and you have resistance to poison damage. When you take a long rest, you must remain motionless for at least six hours but stay conscious.",
+						"Darkvision. You can see in dim light within 60 feet of you as if it were bright light and in darkness as if it were dim light.",
+						"Fleet of Foot. Your base walking speed increases to 35 feet.",
+						"Glider. When you fall and are not incapacitated, reduce any fall distance by up to 100 feet and move horizontally 2 feet for every foot you fall.",
+						"Natural Weapon. You have a natural weapon for unarmed strikes dealing 1d6 bludgeoning, piercing, or slashing damage (chosen when you select this race) and you may use Dexterity for attack and damage rolls.",
+						"Nimble Climber. You have a climb speed equal to your walking speed.",
+						"Mutated Eyes. You have advantage on Wisdom (Perception) checks that rely on sight.",
+						"Silent Speech. You can speak telepathically to a creature within 30 feet that shares a language with you.",
+						"Skilled. You gain proficiency in one skill of your choice.",
+						"Strong-Minded. You have advantage on saving throws against being charmed or frightened.",
+						"Supernatural Resistance. You gain resistance to one damage type of your choice: acid, cold, fire, force, lightning, necrotic, psychic, radiant, or thunder."
+					]
+				},
+				"{@bold Major Alterations}",
+				{
+					"type": "list",
+					"items": [
+						"Amorphous. You can squeeze through a space as narrow as 1 inch if you are carrying or wearing nothing, and you have advantage on checks and saves to escape a grapple or restraint.",
+						"Augmented Toughness. Your hit point maximum increases by 1, and it increases by 1 again whenever you gain a level.",
+						"Blind Sense. You have blindsight out to 30 feet and are blind beyond that distance; you have advantage on Perception checks that rely on hearing or smell.",
+						"Magical Affinity. You know one cantrip of your choice from any class spell list. Intelligence, Wisdom, or Charisma (chosen when you select this race) is your spellcasting ability.",
+						"Massive Build. You have advantage on Strength checks and saving throws and count as one size larger for carrying capacity and the weight you can push, drag, or lift.",
+						"Painful Regeneration. When you start your turn at half hit points or fewer, you may roll a d3 to regain that many hit points and take a penalty equal to the roll on attack rolls, ability checks, and saving throws until the start of your next turn.",
+						"Secondary Arms. You have two smaller secondary arms that can manipulate objects or wield a light weapon.",
+						"Shapechanger. As an action, you can change your appearance and voice as described in the trait, remaining in the new form until you revert or die.",
+						"Unnatural Armor. While not wearing heavy armor, you gain a +1 bonus to AC."
+					]
+				}
+			]
+		},
+		{
+			"name": "Languages",
+			"type": "entries",
+			"entries": [
+				"You can speak, read, and write Common and one extra language of your choice."
+			]
+		}
+	]
 }

--- a/data/races/astralelf.json
+++ b/data/races/astralelf.json
@@ -1,0 +1,128 @@
+{
+	"name": "Astral Elf",
+	"source": "AAG",
+	"page": 10,
+	"lineage": "VRGR",
+	"creatureTypes": [
+		"humanoid"
+	],
+	"creatureTypeTags": [
+		"elf"
+	],
+	"size": [
+		"M"
+	],
+	"speed": 30,
+	"age": {
+		"max": 750
+	},
+	"darkvision": 60,
+	"traitTags": [
+		"Improved Resting",
+		"Tool Proficiency",
+		"Weapon Proficiency"
+	],
+	"skillProficiencies": [
+		{
+			"perception": true
+		}
+	],
+	"additionalSpells": [
+		{
+			"known": {
+				"1": [
+					"dancing lights#c"
+				]
+			},
+			"ability": {
+				"choose": [
+					"int",
+					"wis",
+					"cha"
+				]
+			}
+		},
+		{
+			"known": {
+				"1": [
+					"light#c"
+				]
+			},
+			"ability": {
+				"choose": [
+					"int",
+					"wis",
+					"cha"
+				]
+			}
+		},
+		{
+			"known": {
+				"1": [
+					"sacred flame#c"
+				]
+			},
+			"ability": {
+				"choose": [
+					"int",
+					"wis",
+					"cha"
+				]
+			}
+		}
+	],
+	"entries": [
+		{
+			"type": "entries",
+			"name": "Creature Type",
+			"entries": [
+				"You are a Humanoid. You are also considered an elf for any prerequisite or effect that requires you to be an elf."
+			]
+		},
+		{
+			"type": "entries",
+			"name": "Astral Fire",
+			"entries": [
+				"You know one of the following cantrips of your choice: {@spell dancing lights}, {@spell light}, or {@spell sacred flame}. Intelligence, Wisdom, or Charisma is your spellcasting ability for it (choose when you select this race)."
+			]
+		},
+		{
+			"type": "entries",
+			"name": "Darkvision",
+			"entries": [
+				"You can see in dim light within 60 feet of yourself as if it were bright light, and in darkness as if it were dim light. You discern colors in that darkness only as shades of gray."
+			]
+		},
+		{
+			"type": "entries",
+			"name": "Fey Ancestry",
+			"entries": [
+				"You have advantage on saving throws you make to avoid or end the {@condition charmed} condition on yourself."
+			]
+		},
+		{
+			"type": "entries",
+			"name": "Keen Senses",
+			"entries": [
+				"You have proficiency in the {@skill Perception} skill."
+			]
+		},
+		{
+			"type": "entries",
+			"name": "Starlight Step",
+			"entries": [
+				"As a bonus action, you can magically teleport up to 30 feet to an unoccupied space you can see. You can use this trait a number of times equal to your proficiency bonus, and you regain all expended uses when you finish a long rest."
+			]
+		},
+		{
+			"type": "entries",
+			"name": "Astral Trance",
+			"entries": [
+				"You don't need to sleep, and magic can't put you to sleep. You can finish a long rest in 4 hours if you spend those hours in a trancelike meditation, during which you remain conscious.",
+				"Whenever you finish this trance, you gain proficiency in one skill of your choice and with one weapon or tool of your choice, selected from the {@book Player's Handbook|PHB}. You mystically acquire these proficiencies by drawing them from shared elven memory and the experiences of entities on the Astral Plane, and you retain them until you finish your next long rest."
+			]
+		}
+	],
+	"hasFluff": true,
+	"hasFluffImages": true
+}

--- a/data/races/autognome.json
+++ b/data/races/autognome.json
@@ -1,0 +1,82 @@
+{
+	"name": "Autognome",
+	"source": "AAG",
+	"page": 11,
+	"lineage": "VRGR",
+	"creatureTypes": [
+		"construct"
+	],
+	"size": [
+		"S"
+	],
+	"speed": 30,
+	"traitTags": [
+		"Improved Resting",
+		"Natural Armor"
+	],
+	"toolProficiencies": [
+		{
+			"any": 2
+		}
+	],
+	"resist": [
+		"poison"
+	],
+	"conditionImmune": [
+		"disease"
+	],
+	"entries": [
+		{
+			"type": "entries",
+			"name": "Creature Type",
+			"entries": [
+				"You are a Construct."
+			]
+		},
+		{
+			"type": "entries",
+			"name": "Armored Casing",
+			"entries": [
+				"You are encased in thin metal or some other durable material. While you aren't wearing armor, your base Armor Class is 13 + your Dexterity modifier."
+			]
+		},
+		{
+			"type": "entries",
+			"name": "Built for Success",
+			"entries": [
+				"You can add a {@dice d4} to one attack roll, ability check, or saving throw you make, and you can do so after seeing the {@dice d20} roll but before the effects of the roll are resolved. You can use this trait a number of times equal to your proficiency bonus, and you regain all expended uses when you finish a long rest."
+			]
+		},
+		{
+			"type": "entries",
+			"name": "Healing Machine",
+			"entries": [
+				"If the {@spell mending} spell is cast on you, you can spend a Hit Die, roll it, and regain a number of hit points equal to the roll plus your Constitution modifier (minimum of 1 hit point).",
+				"In addition, your creator designed you to benefit from several spells that preserve life but that normally don't affect Constructs: {@spell cure wounds}, {@spell healing word}, {@spell mass cure wounds}, {@spell mass healing word}, and {@spell spare the dying}."
+			]
+		},
+		{
+			"type": "entries",
+			"name": "Mechanical Nature",
+			"entries": [
+				"You have resistance to poison damage and immunity to disease, and you have advantage on saving throws against being {@condition paralyzed} or {@condition poisoned}. You don't need to eat, drink, or breathe."
+			]
+		},
+		{
+			"type": "entries",
+			"name": "Sentry's Rest",
+			"entries": [
+				"When you take a long rest, you spend at least 6 hours in an inactive, motionless state, instead of sleeping. In this state, you appear inert, but you remain conscious."
+			]
+		},
+		{
+			"type": "entries",
+			"name": "Specialized Design",
+			"entries": [
+				"You gain two tool proficiencies of your choice, selected from the {@book Player's Handbook|PHB}."
+			]
+		}
+	],
+	"hasFluff": true,
+	"hasFluffImages": true
+}

--- a/data/races/changeling.json
+++ b/data/races/changeling.json
@@ -1,15 +1,21 @@
 {
-        "name": "Changeling",
-        "raceName": "Changeling",
-        "source": "MPMM",
+	"name": "Changeling",
+	"raceName": "Changeling",
+	"source": "MPMM",
 	"page": 10,
 	"lineage": "VRGR",
 	"creatureTypes": [
 		"fey"
 	],
 	"size": [
-		"S",
-		"M"
+		{
+			"choose": {
+				"from": [
+					"S",
+					"M"
+				]
+			}
+		}
 	],
 	"speed": 30,
 	"skillProficiencies": [

--- a/data/races/dhampir.json
+++ b/data/races/dhampir.json
@@ -1,27 +1,33 @@
 {
-        "name": "Dhampir",
-        "raceName": "Dhampir",
-        "source": "VRGR",
+	"name": "Dhampir",
+	"raceName": "Dhampir",
+	"source": "VRGR",
 	"page": 16,
 	"lineage": "VRGR",
 	"size": [
-		"S",
-		"M"
+		{
+			"choose": {
+				"from": [
+					"S",
+					"M"
+				]
+			}
+		}
 	],
 	"speed": {
 		"walk": 35,
 		"climb": 35
 	},
-"darkvision": 60,
-"traitTags": [
-"Natural Weapon"
-],
+	"darkvision": 60,
+	"traitTags": [
+		"Natural Weapon"
+	],
 	"skillProficiencies": [
 		{
 			"any": 2
 		}
 	],
-"entries": [
+	"entries": [
 		{
 			"type": "entries",
 			"name": "Size",

--- a/data/races/elfsea.json
+++ b/data/races/elfsea.json
@@ -32,10 +32,6 @@
 	"languageProficiencies": [
 		{
 			"common": true,
-			"elvish": true
-		},
-		{
-			"common": true,
 			"elvish": true,
 			"aquan": true
 		}

--- a/data/races/genasiair.json
+++ b/data/races/genasiair.json
@@ -4,8 +4,14 @@
 	"page": 16,
 	"lineage": "VRGR",
 	"size": [
-		"S",
-		"M"
+		{
+			"choose": {
+				"from": [
+					"S",
+					"M"
+				]
+			}
+		}
 	],
 	"speed": 35,
 	"age": {

--- a/data/races/genasiearth.json
+++ b/data/races/genasiearth.json
@@ -4,8 +4,14 @@
 	"page": 17,
 	"lineage": "VRGR",
 	"size": [
-		"S",
-		"M"
+		{
+			"choose": {
+				"from": [
+					"S",
+					"M"
+				]
+			}
+		}
 	],
 	"speed": 30,
 	"age": {

--- a/data/races/genasifire.json
+++ b/data/races/genasifire.json
@@ -4,8 +4,14 @@
 	"page": 17,
 	"lineage": "VRGR",
 	"size": [
-		"S",
-		"M"
+		{
+			"choose": {
+				"from": [
+					"S",
+					"M"
+				]
+			}
+		}
 	],
 	"speed": 30,
 	"age": {

--- a/data/races/genasiwater.json
+++ b/data/races/genasiwater.json
@@ -4,8 +4,14 @@
 	"page": 17,
 	"lineage": "VRGR",
 	"size": [
-		"S",
-		"M"
+		{
+			"choose": {
+				"from": [
+					"S",
+					"M"
+				]
+			}
+		}
 	],
 	"speed": {
 		"walk": 30,

--- a/data/races/giff.json
+++ b/data/races/giff.json
@@ -1,0 +1,51 @@
+{
+	"name": "Giff",
+	"source": "AAG",
+	"page": 12,
+	"lineage": "VRGR",
+	"size": [
+		"M"
+	],
+	"speed": {
+		"walk": 30,
+		"swim": true
+	},
+	"traitTags": [
+		"Powerful Build"
+	],
+	"weaponProficiencies": [
+		{
+			"firearms": true
+		}
+	],
+	"soundClip": {
+		"type": "internal",
+		"path": "races/giff.mp3"
+	},
+	"entries": [
+		{
+			"type": "entries",
+			"name": "Astral Spark",
+			"entries": [
+				"Your psychic connection to the Astral Plane enables you to mystically access a spark of divine power, which you can channel through your weapons. When you hit a target with a {@filter simple or martial weapon|items|source=phb|category=basic|type=martial weapon;simple weapon}, you can cause the target to take extra force damage equal to your proficiency bonus.",
+				"You can use this trait a number of times equal to your proficiency bonus, but you can use it no more than once per turn. You regain all expended uses when you finish a long rest."
+			]
+		},
+		{
+			"type": "entries",
+			"name": "Firearms Mastery",
+			"entries": [
+				"You have a mystical connection to firearms that traces back to the gods of the giff, who delighted in such weapons. You have proficiency with all firearms and ignore the loading property of any firearm. In addition, attacking at long range with a firearm doesn't impose disadvantage on your attack roll."
+			]
+		},
+		{
+			"type": "entries",
+			"name": "Hippo Build",
+			"entries": [
+				"You have advantage on Strength-based ability checks and Strength saving throws. In addition, you count as one size larger when determining your carrying capacity and the weight you can push, drag, or lift."
+			]
+		}
+	],
+	"hasFluff": true,
+	"hasFluffImages": true
+}

--- a/data/races/hadozee.json
+++ b/data/races/hadozee.json
@@ -1,0 +1,53 @@
+{
+	"name": "Hadozee",
+	"source": "AAG",
+	"page": 13,
+	"lineage": "VRGR",
+	"size": [
+		{
+			"choose": {
+				"from": [
+					"S",
+					"M"
+				]
+			}
+		}
+	],
+	"speed": {
+		"walk": 30,
+		"climb": true
+	},
+	"entries": [
+		{
+			"type": "entries",
+			"name": "Size",
+			"entries": [
+				"You are Medium or Small. You choose the size when you select this race."
+			]
+		},
+		{
+			"type": "entries",
+			"name": "Dexterous Feet",
+			"entries": [
+				"As a bonus action, you can use your feet to manipulate an object, open or close a door or container, or pick up or set down a Tiny object."
+			]
+		},
+		{
+			"type": "entries",
+			"name": "Glide",
+			"entries": [
+				"When you fall at least 10 feet above the ground, you can use your reaction to extend your skin membranes to glide horizontally a number of feet equal to your walking speed, and you take 0 damage from the fall. You determine the direction of the glide."
+			]
+		},
+		{
+			"type": "entries",
+			"name": "Hadozee Dodge",
+			"entries": [
+				"The magic that runs in your veins heightens your natural defenses. When you take damage, you can use your reaction to roll a {@dice d6}. Add your proficiency bonus to the number rolled, and reduce the damage you take by an amount equal to that total (minimum of 0 damage).",
+				"You can use this trait a number of times equal to your proficiency bonus. You regain all expended uses when you finish a long rest."
+			]
+		}
+	],
+	"hasFluff": true,
+	"hasFluffImages": true
+}

--- a/data/races/harengon.json
+++ b/data/races/harengon.json
@@ -1,12 +1,18 @@
 {
-        "name": "Harengon",
-        "raceName": "Harengon",
-        "source": "MPMM",
+	"name": "Harengon",
+	"raceName": "Harengon",
+	"source": "MPMM",
 	"page": 22,
 	"lineage": "VRGR",
 	"size": [
-		"S",
-		"M"
+		{
+			"choose": {
+				"from": [
+					"S",
+					"M"
+				]
+			}
+		}
 	],
 	"speed": 30,
 	"skillProficiencies": [

--- a/data/races/hexblood.json
+++ b/data/races/hexblood.json
@@ -1,15 +1,21 @@
 {
-        "name": "Hexblood",
-        "raceName": "Hexblood",
-        "source": "VRGR",
+	"name": "Hexblood",
+	"raceName": "Hexblood",
+	"source": "VRGR",
 	"page": 18,
 	"lineage": "VRGR",
 	"creatureTypes": [
 		"fey"
 	],
 	"size": [
-		"S",
-		"M"
+		{
+			"choose": {
+				"from": [
+					"S",
+					"M"
+				]
+			}
+		}
 	],
 	"speed": 30,
 	"darkvision": 60,

--- a/data/races/plasmoid.json
+++ b/data/races/plasmoid.json
@@ -1,0 +1,79 @@
+{
+	"name": "Plasmoid",
+	"source": "AAG",
+	"page": 14,
+	"lineage": "VRGR",
+	"creatureTypes": [
+		"ooze"
+	],
+	"size": [
+		{
+			"choose": {
+				"from": [
+					"S",
+					"M"
+				]
+			}
+		}
+	],
+	"speed": 30,
+	"darkvision": 60,
+	"resist": [
+		"acid",
+		"poison"
+	],
+	"entries": [
+		{
+			"type": "entries",
+			"name": "Creature Type",
+			"entries": [
+				"You are an Ooze."
+			]
+		},
+		{
+			"type": "entries",
+			"name": "Size",
+			"entries": [
+				"You are Medium or Small. You choose the size when you select this race."
+			]
+		},
+		{
+			"type": "entries",
+			"name": "Amorphous",
+			"entries": [
+				"You can squeeze through a space as narrow as 1 inch wide, provided you are wearing and carrying nothing. You have advantage on ability checks you make to initiate or escape a grapple."
+			]
+		},
+		{
+			"type": "entries",
+			"name": "Darkvision",
+			"entries": [
+				"You can see in dim light within 60 feet of yourself as if it were bright light, and in darkness as if it were dim light. You discern colors in that darkness only as shades of gray."
+			]
+		},
+		{
+			"type": "entries",
+			"name": "Hold Breath",
+			"entries": [
+				"You can hold your breath for 1 hour."
+			]
+		},
+		{
+			"type": "entries",
+			"name": "Natural Resilience",
+			"entries": [
+				"You have resistance to acid and poison damage, and you have advantage on saving throws against being {@condition poisoned}."
+			]
+		},
+		{
+			"type": "entries",
+			"name": "Shape Self",
+			"entries": [
+				"As an action, you can reshape your body to give yourself a head, one or two arms, one or two legs, and makeshift hands and feet, or you can revert to a limbless blob. While you have a humanlike shape, you can wear clothing and armor made for a Humanoid of your size.",
+				"As a bonus action, you can extrude a pseudopod that is up to 6 inches wide and 10 feet long or reabsorb it into your body. As part of the same bonus action, you can use this pseudopod to manipulate an object, open or close a door or container, or pick up or set down a Tiny object. The pseudopod contains no sensory organs and can't attack, activate magic items, or lift more than 10 pounds."
+			]
+		}
+	],
+	"hasFluff": true,
+	"hasFluffImages": true
+}

--- a/data/races/thrikreen.json
+++ b/data/races/thrikreen.json
@@ -1,0 +1,83 @@
+{
+	"name": "Thri-kreen",
+	"source": "AAG",
+	"page": 15,
+	"lineage": "VRGR",
+	"creatureTypes": [
+		"monstrosity"
+	],
+	"size": [
+		{
+			"choose": {
+				"from": [
+					"S",
+					"M"
+				]
+			}
+		}
+	],
+	"speed": 30,
+	"darkvision": 60,
+	"traitTags": [
+		"Improved Resting",
+		"Natural Armor"
+	],
+	"soundClip": {
+		"type": "internal",
+		"path": "races/thri-kreen.mp3"
+	},
+	"entries": [
+		{
+			"type": "entries",
+			"name": "Creature Type",
+			"entries": [
+				"You are a Monstrosity."
+			]
+		},
+		{
+			"type": "entries",
+			"name": "Size",
+			"entries": [
+				"You are Medium or Small. You choose the size when you select this race."
+			]
+		},
+		{
+			"type": "entries",
+			"name": "Chameleon Carapace",
+			"entries": [
+				"While you aren't wearing armor, your carapace gives you a base Armor Class of 13 + your Dexterity modifier.",
+				"As an action, you can change the color of your carapace to match the color and texture of your surroundings, giving you advantage on Dexterity ({@skill Stealth}) checks made to {@action hide} in those surroundings."
+			]
+		},
+		{
+			"type": "entries",
+			"name": "Darkvision",
+			"entries": [
+				"You can see in dim light within 60 feet of yourself as if it were bright light, and in darkness as if it were dim light. You discern colors in that darkness only as shades of gray."
+			]
+		},
+		{
+			"type": "entries",
+			"name": "Secondary Arms",
+			"entries": [
+				"You have two slightly smaller secondary arms below your primary pair of arms. The secondary arms can manipulate an object, open or close a door or container, pick up or set down a Tiny object, or wield a weapon that has the light property."
+			]
+		},
+		{
+			"type": "entries",
+			"name": "Sleepless",
+			"entries": [
+				"You do not require sleep and can remain conscious during a long rest, though you must still refrain from strenuous activity to gain the benefit of the rest."
+			]
+		},
+		{
+			"type": "entries",
+			"name": "Thri-kreen Telepathy",
+			"entries": [
+				"Without the assistance of magic, you can't speak the non-thri-kreen languages you know. Instead you use telepathy to convey your thoughts. You have the magical ability to transmit your thoughts mentally to willing creatures within 120 feet of yourself. A contacted creature doesn't need to share a language with you to understand your thoughts, but it must be able to understand at least one language. Your telepathic link to a creature is broken if you and the creature move more than 120 feet apart, if either of you is {@condition incapacitated}, or if either of you mentally breaks the contact (no action required)."
+			]
+		}
+	],
+	"hasFluff": true,
+	"hasFluffImages": true
+}

--- a/scripts/import-spelljammer-races.js
+++ b/scripts/import-spelljammer-races.js
@@ -1,0 +1,59 @@
+#!/usr/bin/env node
+import { existsSync, readFileSync, writeFileSync } from 'fs';
+import path from 'path';
+
+const INDEX_FILE = path.resolve('data', 'races.json');
+const DATA_FILE = path.resolve('data', 'races', 'races-new.json');
+const OUTPUT_DIR = path.resolve('data', 'races');
+const SPELLJAMMER_SOURCE = 'AAG';
+
+function slugify(name) {
+  return name
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '')
+    .replace(/(^-|-$)/g, '');
+}
+
+function loadJson(file) {
+  return JSON.parse(readFileSync(file, 'utf8'));
+}
+
+function saveJson(file, data) {
+  writeFileSync(file, `${JSON.stringify(data, null, '\t')}\n`, 'utf8');
+}
+
+const index = loadJson(INDEX_FILE);
+index.items = index.items || {};
+const existingNames = new Set(Object.keys(index.items));
+const racesData = loadJson(DATA_FILE);
+const additions = [];
+
+for (const race of racesData.race || []) {
+  if (race.source !== SPELLJAMMER_SOURCE) continue;
+  if (!race.name) continue;
+  if (existingNames.has(race.name)) continue;
+  const slug = slugify(race.name);
+  const fileName = `${slug}.json`;
+  const outputPath = path.join(OUTPUT_DIR, fileName);
+  if (existsSync(outputPath)) continue;
+  saveJson(outputPath, race);
+  index.items[race.name] = `data/races/${fileName}`;
+  additions.push(race.name);
+}
+
+if (!additions.length) {
+  console.log('No new Spelljammer races were added.');
+  process.exit(0);
+}
+
+const sortedItems = Object.keys(index.items)
+  .sort((a, b) => a.localeCompare(b))
+  .reduce((acc, key) => {
+    acc[key] = index.items[key];
+    return acc;
+  }, {});
+
+index.items = sortedItems;
+
+saveJson(INDEX_FILE, index);
+console.log(`Added ${additions.length} Spelljammer races: ${additions.join(', ')}`);


### PR DESCRIPTION
## Summary
- add automated importer for Spelljammer (AAG) races and populate new Astral Elf, Autognome, Giff, Hadozee, Plasmoid, and Thri-kreen files
- normalize multi-size race definitions to use choose metadata across existing races
- clean up Sea Elf language proficiency list to avoid duplicate entries

## Testing
- npm run validate:races

------
https://chatgpt.com/codex/tasks/task_e_68d1863022ec832e81890f0a180f379e